### PR TITLE
Clarify and test creep damage definition

### DIFF
--- a/doc/sphinx/damage/scalar.rst
+++ b/doc/sphinx/damage/scalar.rst
@@ -14,7 +14,7 @@ It implements the stress update function
       \bm{\varepsilon}_{n+1}, \bm{\varepsilon}_{n},
       T_{n+1}, T_{n},
       t_{n+1}, t_{n},
-      \bm{\sigma}_{n},
+      \bm{\sigma}_{n} / (1 - \omega_{n+1},
       \bm{\alpha}_{n},
       \bm{\alpha}_{n},
       u_n, p_n
@@ -26,6 +26,12 @@ This object defers damage evolution to another interface.
 
 The damage model maintains the set of history variables from the base 
 material plus one additional history variable for the damage.
+
+.. note::
+   The scalar damage model passes in the modified stress :math:`\bm{\sigma} / (1 - \omega)` to the base stress update model in addition to modifying the stress update formula as shown in the above equation.
+
+.. warning::
+   The model also passes the modified stress :math:`\bm{\sigma} / (1-\omega)` to the damage update equation.  That is, the stress passed into these functions is the modified effective stress, not the actual external stress.  This means that the damage equations implemented in NEML vary slightly from the correpsonding literature equations working with the unmodified stress directly.
 
 Implementations
 ---------------

--- a/examples/damage.py
+++ b/examples/damage.py
@@ -96,9 +96,11 @@ def unload_ex():
     driver.stress_int[-1], driver.T_int[-1], driver.stored[-1])[0])
 
   Ep = (driver.stress[-2,0]-driver.stress[-1,0])/(driver.strain[-2,0]-driver.strain[-1,0])
+  wf = driver.stored_int[-1][0]
   
   print("Initial Young's modulus: %f" % E)
   print("Final Young's modulus: %f" % Ep)
+  print("E (1-w): %f" % (E * (1-wf)))
 
   plt.plot(driver.strain[:,0], driver.stress[:,0])
   plt.show()

--- a/examples/damage.py
+++ b/examples/damage.py
@@ -95,6 +95,11 @@ def unload_ex():
   print("Calculated final elastic strain: %f" % model.elastic_strains(
     driver.stress_int[-1], driver.T_int[-1], driver.stored[-1])[0])
 
+  Ep = (driver.stress[-2,0]-driver.stress[-1,0])/(driver.strain[-2,0]-driver.strain[-1,0])
+  
+  print("Initial Young's modulus: %f" % E)
+  print("Final Young's modulus: %f" % Ep)
+
   plt.plot(driver.strain[:,0], driver.stress[:,0])
   plt.show()
 

--- a/verification/verify_classical_creep_strains.py
+++ b/verification/verify_classical_creep_strains.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.append('..')
+
+from neml import models, elasticity, drivers, damage, creep
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+if __name__ == "__main__":
+  s = 150.0
+
+  # We'll do it in terms of Hayhurst-Leckie
+  nu = 1.8
+  eta = 2.1
+  s0 = 7000.0
+  w0 = 3.25e-2
+  n = 4.0
+  e0 = 1.0 # This is key
+
+  # My parameters
+  xi = nu
+  phi = eta
+  A = s0 / (w0**(1.0/nu))
+
+  tf = 10000
+
+  # Hayhurst solution
+  times = np.linspace(0,tf,100)
+  dmg = (1-(eta+1)*w0*(s/s0)**nu*times)**(1.0/(eta+1.0))
+  strain = -e0 * (s/s0)**(-nu) * dmg**(eta+1) / ((1 + eta - n) * w0) * (s / (s0*dmg)
+      )**n + e0 * (s/s0)**(n-nu)/((1+eta-n)*w0)
+
+  
+  E = 10000000.0
+  nu = 0.3
+
+  srate = 100.0
+
+  emodel = elasticity.IsotropicLinearElasticModel(E, "youngs", nu, "poissons")
+  bmodel = models.SmallStrainElasticity(emodel)
+  scmodel = creep.NormalizedPowerLawCreep(s0, n)
+  cfmodel = creep.J2CreepModel(scmodel)
+  cmodel = models.SmallStrainCreepPlasticity(emodel, bmodel, cfmodel)
+  model = damage.ModularCreepDamageModel_sd(emodel, A, xi, phi,
+      damage.VonMisesEffectiveStress(), cmodel)
+
+  res = drivers.creep(model, s, srate, tf, nsteps = 1000)
+
+  plt.plot(times, strain)
+  plt.plot(res['rtime'], res['rstrain'])
+  plt.show()


### PR DESCRIPTION
This adds a verification example showing that for negligible elasticity the Hayhurst-Leckie damage model implemented in NEML agrees exactly with the results in the paper for both strain and failure time.

It adds an explicit calculation of the damaged elastic slope to the "damage.py" example.

It clarifies in the documentation that the damage model rate form receives the effective stress (sigma/(1-omega)) and not the stress itself.

This is all connected to the difference between the "rate form" and "algebraic form" damage implementations that Aritra and I were working on.  For the record, NEML uses the "algebraic form", as described in the docs for the ScalarDamageModel class.