### PR TITLE
Allow model name to be used with xml string interface 

### DIFF
--- a/src/neml_interface.h
+++ b/src/neml_interface.h
@@ -8,7 +8,7 @@
 
 namespace neml {
 std::unique_ptr<NEMLModel> parse_xml_unique(std::string fname, std::string mname);
-std::unique_ptr<NEMLModel> parse_string_unique(std::string input);
+std::unique_ptr<NEMLModel> parse_string_unique(std::string input, std::string mname);
 }
 
 #endif // NEML_INTERFACE_H

--- a/src/parse.cxx
+++ b/src/parse.cxx
@@ -24,20 +24,23 @@ std::shared_ptr<NEMLModel> parse_string(std::string input)
   }
 }
 
-std::unique_ptr<NEMLModel> parse_string_unique(std::string input)
+std::unique_ptr<NEMLModel> parse_string_unique(std::string input, std::string mname)
 {
   // Parse the string to the rapidxml representation
   rapidxml::xml_document<> doc;
   doc.parse<0>(&input[0]);
 
-  // The model is the root node
-  const rapidxml::xml_node<> * found = doc.first_node();
+  // Grab the root node
+  const rapidxml::xml_node<> * root = doc.first_node();
+
+  // Find the node with the right name
+  const rapidxml::xml_node<> * found = root->first_node(mname.c_str());
 
   // Get the NEMLObject
   std::unique_ptr<NEMLObject> obj = get_object_unique(found);
 
   // Do a dangerous cast
-  auto res = std::unique_ptr<NEMLModel>(dynamic_cast<NEMLModel*>(obj.release()));
+  auto res = std::unique_ptr<NEMLModel>(dynamic_cast<NEMLModel *>(obj.release()));
   if (res == nullptr) {
     throw InvalidType(found->name(), get_type_of_node(found), "NEMLModel");
   }

--- a/src/parse.h
+++ b/src/parse.h
@@ -23,7 +23,7 @@ namespace neml {
 std::shared_ptr<NEMLModel> parse_string(std::string input);
 
 /// Parse from a string to a unique_ptr
-std::unique_ptr<NEMLModel> parse_string_unique(std::string input);
+std::unique_ptr<NEMLModel> parse_string_unique(std::string input, std::string mname);
 
 /// Parse from file to a shared_ptr
 NEML_EXPORT std::shared_ptr<NEMLModel> parse_xml(std::string fname, std::string mname);

--- a/util/string_interface/cxxstring.cxx
+++ b/util/string_interface/cxxstring.cxx
@@ -5,7 +5,7 @@
 
 int main(int argc, char** argv)
 {
-  std::string thing_you_need_to_make = R"(<test_j2iso type="SmallStrainRateIndependentPlasticity"><elastic type="IsotropicLinearElasticModel"><m1>103561.64383561644</m1><m1_type>youngs</m1_type><m2>0.2945205479452055</m2><m2_type>poissons</m2_type></elastic><flow type="RateIndependentAssociativeFlow"><surface type="IsoJ2"/><hardening type="LinearIsotropicHardeningRule"><s0>100.0</s0><K>1000.0</K></hardening></flow></test_j2iso>)";
+  std::string thing_you_need_to_make = R"(<materials><test_j2iso type="SmallStrainRateIndependentPlasticity"><elastic type="IsotropicLinearElasticModel"><m1>103561.64383561644</m1><m1_type>youngs</m1_type><m2>0.2945205479452055</m2><m2_type>poissons</m2_type></elastic><flow type="RateIndependentAssociativeFlow"><surface type="IsoJ2"/><hardening type="LinearIsotropicHardeningRule"><s0>100.0</s0><K>1000.0</K></hardening></flow></test_j2iso></materials>)";
 
   if (argc != 5) {
         printf("Expected 4 arguments:\n");
@@ -17,8 +17,9 @@ int main(int argc, char** argv)
   double t = std::atof(argv[2]);
   int n = std::atoi(argv[3]);
   double T = std::atof(argv[4]);
-  
-  auto model = parse_string_unique(thing_you_need_to_make);
+  std::string model_name("test_j2iso");
+
+  auto model = parse_string_unique(thing_you_need_to_make,model_name);
 
   double * h_n = new double [model->nstore()];
   double * h_np1 = new double [model->nstore()];


### PR DESCRIPTION
This commit will allow the model name to be passed in along with the string containing the xml data.  This makes the string interface consistent with the xml interface. 
