### PR TITLE
Explicitly use int hash 

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -33,7 +33,7 @@ template <> constexpr StorageType GetStorageType<double>() {return TYPE_SCALAR;}
 template <> constexpr StorageType GetStorageType<SymSymR4>() {return TYPE_SYMSYM;}
 
 /// Storage size
-const std::unordered_map<StorageType,size_t> storage_size =
+const std::unordered_map<StorageType,size_t,std::hash<int>> storage_size =
   { {TYPE_VECTOR,    3},
     {TYPE_SCALAR,    1},
     {TYPE_RANKTWO,   9},
@@ -46,7 +46,7 @@ const std::unordered_map<StorageType,size_t> storage_size =
 template <class T> size_t GetStorageSize() {return storage_size.at(GetStorageType<T>());}
 
 /// Map between a type and its derivative
-const std::unordered_map<StorageType,const std::unordered_map<StorageType,StorageType>> derivative_type =
+const std::unordered_map<StorageType,const std::unordered_map<StorageType,StorageType,std::hash<int>>,std::hash<int>> derivative_type =
   { {TYPE_SCALAR,
       {{TYPE_SCALAR,    TYPE_SCALAR},
        {TYPE_VECTOR,    TYPE_VECTOR},
@@ -178,7 +178,7 @@ class NEML_EXPORT History {
       StorageType ntype = derivative_type.at(ctype).at(dtype);
       nsize += storage_size.at(ntype);
     }
-    
+
     // Cost of moving memory was actually quite high...
     History deriv;
     deriv.increase_store(nsize);


### PR DESCRIPTION
This fix allows neml to be build in the standard Conda-based MOOSE macOS development environment (Clang 9.0.1 , `-std=c++14` option set).

```
 cmake -DUSE_OPENMP=OFF . && make -j 8
```

(OpenMP configuration options are still not right on this platform so it needs to be disabled)

Closes #66