### PR TITLE
Use custom variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,8 @@ matrix:
 
 before_install:
       - eval "$(MATRIX_EVAL)"
-      - if [ "$TO_TEST" = "BINDINGS" ]; then sudo apt-get install -y build-essential cmake libboost-dev libblas-dev liblapack-dev python3-dev python3-networkx python3-numpy python3-scipy python3-matplotlib python3-nose; fi
-      - if [ "$TO_TEST" = "NOBINDINGS" ]; then sudo apt-get install -y build-essential cmake libboost-dev libblas-dev liblapack-dev; fi
+      - if [ "$TO_TEST" = "BINDINGS" ]; then sudo apt-get install -y build-essential cmake libblas-dev liblapack-dev python3-dev python3-networkx python3-numpy python3-scipy python3-matplotlib python3-nose; fi
+      - if [ "$TO_TEST" = "NOBINDINGS" ]; then sudo apt-get install -y build-essential cmake libblas-dev liblapack-dev; fi
 install:
       - eval "$(MATRIX_EVAL)"
       - if [ "$TO_TEST" = "BINDINGS" ]; then cmake -DPYTHON_EXECUTABLE=$(python-config --prefix)/bin/python3.5 -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython3.5.so -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python3.5 -D WRAP_PYTHON=ON -D BUILD_UTILS=ON .; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,6 @@ else()
       message("Unknown solver")
 endif()
 
-### Need Boost (only variant.hpp really) ###
-FIND_PACKAGE(Boost REQUIRED)
-INCLUDE_DIRECTORIES(SYSTEM ${Boost_INCLUDE_DIRS})
-
 ### Configure standard-ish libraries ###
 set(BLAS_VENDOR Generic)
 set(BLA_VENDOR Generic)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ These instructions assuming you are building in the source directory.
 To compile just the base library:
 
 ```
-apt-get install build-essential cmake libboost-dev libblas-dev liblapack-dev
+apt-get install build-essential cmake libblas-dev liblapack-dev
 cmake .
 make
 ```
@@ -20,7 +20,7 @@ make
 To compile both the base library and the python bindings:
 
 ```
-apt-get install build-essential cmake libboost-dev libblas-dev liblapack-dev python-dev python-networkx python-numpy python-scipy python-matplotlib python-nose
+apt-get install build-essential cmake libblas-dev liblapack-dev python-dev python-networkx python-numpy python-scipy python-matplotlib python-nose
 cmake -D WRAP_PYTHON=ON .
 make
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ has its own license contained in the rapidxml subdirectory.
 The python package version of the software available on PiPy requires:
 
 1. A working C++ compiler.
-2. The [Boost](https://www.boost.org/) C++ header libraries.
-3. Linkable version of [BLAS](http://www.netlib.org/blas/) and [LAPACK](http://www.netlib.org/lapack/).
+2. Linkable version of [BLAS](http://www.netlib.org/blas/) and [LAPACK](http://www.netlib.org/lapack/).
 
 This version does not support multithreading or linking with external C/C++/Fortran codes.

--- a/src/math/rotations.cxx
+++ b/src/math/rotations.cxx
@@ -8,8 +8,7 @@
 #include <iostream>
 #include <random>
 #include <chrono>
-
-#include "boost/functional/hash.hpp"
+#include <functional>
 
 namespace neml {
 
@@ -228,7 +227,8 @@ size_t Quaternion::hash() const
   size_t key = 0;
 
   for (size_t i = 0; i<4; i++) {
-    boost::hash_combine<double>(key, quat_[i]);
+    // One-liner from boost
+    key ^= (std::hash<double>{}(quat_[i]) + 0x9e3779b9 + (key<<6) + (key>>2));
   }
 
   return key;

--- a/src/objects.cxx
+++ b/src/objects.cxx
@@ -2,6 +2,19 @@
 
 namespace neml {
 
+template <> double & param_type::data<double>() { return double_; }
+template <> int & param_type::data<int>() { return int_; }
+template <> bool & param_type::data<bool>() { return bool_; }
+template <> std::vector<double> & param_type::data<std::vector<double>>() { return vec_double_; }
+template <> std::shared_ptr<NEMLObject> & param_type::data<std::shared_ptr<NEMLObject>>() { return neml_object_; }
+template <> std::vector<std::shared_ptr<NEMLObject>> & param_type::data<std::vector<std::shared_ptr<NEMLObject>>>() { return vec_neml_object_; }
+template <> std::string & param_type::data<std::string>() { return string_; }
+template <> list_systems & param_type::data<list_systems>() { return list_systems_; }
+template <> std::size_t & param_type::data<std::size_t>() { return size_t_; }
+template <> std::vector<std::size_t> & param_type::data<std::vector<std::size_t>>() { return vec_size_t_; }
+
+param_type::param_type(const char * val) { data<std::string>() = *val; }
+
 ParameterSet::ParameterSet() :
     type_("invalid")
 {
@@ -36,7 +49,7 @@ ParamType ParameterSet::get_object_type(std::string name)
 
 bool ParameterSet::is_parameter(std::string name) const
 {
-  return std::find(param_names_.begin(), param_names_.end(), name) != 
+  return std::find(param_names_.begin(), param_names_.end(), name) !=
       param_names_.end();
 }
 
@@ -58,7 +71,7 @@ std::vector<std::string> ParameterSet::unassigned_parameters()
 bool ParameterSet::fully_assigned()
 {
   resolve_objects_();
-  
+
   for (auto it = param_names_.begin(); it != param_names_.end(); ++it) {
     if (params_.find(*it) == params_.end()) return false;
   }
@@ -89,7 +102,7 @@ std::shared_ptr<NEMLObject> Factory::create(ParameterSet & params)
   if (not params.fully_assigned()) {
     throw UndefinedParameters(params.type(), params.unassigned_parameters());
   }
-  
+
   try {
     return creators_[params.type()](params);
   }

--- a/src/objects.h
+++ b/src/objects.h
@@ -12,8 +12,6 @@
 
 #include "windows.h"
 
-#include "boost/variant.hpp"
-
 namespace neml {
 
 /// Typedef for slip systems
@@ -32,22 +30,42 @@ class NEML_EXPORT NEMLObject {
   virtual ~NEMLObject() {};
 };
 
-// This version supports the following types of objects as parameters:
-//    double
-//    int
-//    bool
-//    vector<double>
-//    NEMLObject
-//    vector<NEMLObject>
-//    string
-//    vector<pair<vector<int>,vector<int>>, i.e. groups of slip systems
-//    size_t
-//    vector<size_t>
+/// This black magic lets us store parameters in a unified map (note that this is a replacement for boost::variant
+/// to get rid of a boost dependency which is causing us grief due to spurious memory leaks in boost)
+class param_type
+{
+public:
+  template <typename T>
+  T get() { return data<T>(); }
 
-/// This black magic lets us store parameters in a unified map
-typedef boost::variant<double, int, bool, std::vector<double>,
-        std::shared_ptr<NEMLObject>,std::vector<std::shared_ptr<NEMLObject>>,
-        std::string, list_systems, size_t, std::vector<size_t>> param_type;
+  param_type() {}
+  param_type(const char * val);
+  template <typename T>
+  param_type(const T & val) { data<T>() = val; }
+  template <typename T>
+  param_type(const std::shared_ptr<T> & val) { data<std::shared_ptr<NEMLObject>>() = val; }
+
+  template <typename T>
+  const param_type & operator = (const T & val) { data<T>() = val; return *this; }
+
+protected:
+  template <typename T>
+  T & data();
+
+private:
+  // it'd be tempting to use a union here, but then the compiler generated copy constructor would not work anymore
+  double double_;
+  int int_;
+  bool bool_;
+  std::vector<double> vec_double_;
+  std::shared_ptr<NEMLObject> neml_object_;
+  std::vector<std::shared_ptr<NEMLObject>> vec_neml_object_;
+  std::string string_;
+  list_systems list_systems_;
+  std::size_t size_t_;
+  std::vector<std::size_t> vec_size_t_;
+};
+
 /// This is the enum name we assign to each type for the "external" interfaces
 /// to use in reconstructing a type from data
 enum ParamType {
@@ -168,7 +186,7 @@ class NEML_EXPORT ParameterSet {
   T get_parameter(std::string name)
   {
     resolve_objects_();
-    return boost::get<T>(params_[name]);
+    return params_[name].get<T>();
   }
 
   /// Assign a parameter set to be used to create an object later

--- a/test/drivers/test_drivers.sh
+++ b/test/drivers/test_drivers.sh
@@ -14,7 +14,7 @@ do
       printf "\tTesting c driver..."
       ../../util/c_interface/csimple ../regression/reference.xml "$line" 0.02 100.0 20 300
       printf " done\n"
-      printf "\tTesting c driver..."
+      printf "\tTesting fortran driver..."
       ../../util/f_interface/fsimple ../regression/reference.xml "$line" 0.02 100.0 20 300
       printf " done\n"
       echo ""


### PR DESCRIPTION
I don't like it, but it gets rid of boost and it fits within the design constraints of neml (namely the ability to build with and then link without python support). Ping @bwspenc (this is the low-brow approach)