### PR TITLE
Creep integration

### DIFF
--- a/src/cp/singlecrystal.h
+++ b/src/cp/singlecrystal.h
@@ -47,8 +47,8 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
                      std::shared_ptr<Orientation> initial_angle,
                      std::shared_ptr<Interpolate> alpha,
                      bool update_rotation,
-                     double tol, int miter, bool verbose,
-                     int max_divide);
+                     double rtol, double atol, int miter, bool verbose,
+                     bool linesearch, int max_divide);
   /// Destructor
   virtual ~SingleCrystalModel();
 
@@ -156,9 +156,9 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   std::shared_ptr<Orientation> q0_;
   std::shared_ptr<Interpolate> alpha_;
   bool update_rotation_;
-  double tol_;
+  double rtol_, atol_;
   int miter_;
-  bool verbose_;
+  bool verbose_, linesearch_;
   int max_divide_;
 
   History stored_hist_;

--- a/src/creep.h
+++ b/src/creep.h
@@ -352,7 +352,7 @@ class NEML_EXPORT CreepModel: public NEMLObject, public Solvable {
  public:
   /// Parameters are a solver tolerance, the maximum allowable iterations,
   /// and a verbosity flag
-  CreepModel(double tol, int miter, bool verbose);
+  CreepModel(double rtol, double atol, int miter, bool verbose, bool linesearch);
 
   /// Use the creep rate function to update the creep strain
   int update(const double * const s_np1,
@@ -397,9 +397,9 @@ class NEML_EXPORT CreepModel: public NEMLObject, public Solvable {
                     double * const A_np1);
 
  protected:
-  const double tol_;
+  const double rtol_, atol_;
   const int miter_;
-  const bool verbose_;
+  const bool verbose_, linesearch_;
 };
 
 /// J2 creep based on a scalar creep rule
@@ -408,7 +408,8 @@ class NEML_EXPORT J2CreepModel: public CreepModel {
   /// Parameters: scalar creep rule, nonlinear tolerance, maximum solver
   /// iterations, and a verbosity flag
   J2CreepModel(std::shared_ptr<ScalarCreepRule> rule,
-               double tol, int miter, bool verbose);
+               double rtol, double atol, int miter, bool verbose, 
+               bool linesearch);
 
   /// String type for the object system
   static std::string type();

--- a/src/damage.cxx
+++ b/src/damage.cxx
@@ -1484,7 +1484,7 @@ ParameterSet NEMLWorkDamagedModel_sd::parameters()
 
   pset.add_optional_parameter<NEMLObject>("alpha",
                                           std::make_shared<ConstantInterpolate>(0.0));
-  pset.add_optional_parameter<double>("rtol", 1.0e-6);
+  pset.add_optional_parameter<double>("rtol", 1.0e-14);
   pset.add_optional_parameter<double>("atol", 1.0e-8);
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);
@@ -1694,7 +1694,7 @@ ParameterSet NEMLPowerLawDamagedModel_sd::parameters()
 
   pset.add_optional_parameter<NEMLObject>("alpha",
                                           std::make_shared<ConstantInterpolate>(0.0));
-  pset.add_optional_parameter<double>("rtol", 1.0e-6);
+  pset.add_optional_parameter<double>("rtol", 1.0e-10);
   pset.add_optional_parameter<double>("atol", 1.0e-8);
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);
@@ -1801,7 +1801,7 @@ ParameterSet NEMLExponentialWorkDamagedModel_sd::parameters()
 
   pset.add_optional_parameter<NEMLObject>("alpha",
                                           std::make_shared<ConstantInterpolate>(0.0));
-  pset.add_optional_parameter<double>("rtol", 1.0e-8);
+  pset.add_optional_parameter<double>("rtol", 1.0e-10);
   pset.add_optional_parameter<double>("atol", 1.0e-8);
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);

--- a/src/damage.h
+++ b/src/damage.h
@@ -71,8 +71,8 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   NEMLScalarDamagedModel_sd(std::shared_ptr<LinearElasticModel> elastic,
                             std::shared_ptr<NEMLModel_sd> base,
                             std::shared_ptr<Interpolate> alpha,
-                            double tol, int miter,
-                            bool verbose, bool truesdell,
+                            double rtol, double atol, int miter,
+                            bool verbose, bool lineseach, bool truesdell,
                             bool ekill, double dkill, double sfact);
 
   /// Stress update using the scalar damage model
@@ -151,9 +151,11 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
                     double & p_np1, double p_n);
 
  protected:
-  double tol_;
+  double rtol_;
+  double atol_;
   int miter_;
   bool verbose_;
+  bool linesearch_;
   bool ekill_;
   double dkill_;
   double sfact_;
@@ -169,8 +171,8 @@ class NEML_EXPORT CombinedDamageModel_sd: public NEMLScalarDamagedModel_sd {
       std::vector<std::shared_ptr<NEMLScalarDamagedModel_sd>> models,
       std::shared_ptr<NEMLModel_sd> base,
       std::shared_ptr<Interpolate> alpha,
-      double tol, int miter,
-      bool verbose, bool truesdell);
+      double rtol, double atol, int miter,
+      bool verbose, bool linesearch, bool truesdell);
 
   /// String type for the object system
   static std::string type();
@@ -230,8 +232,8 @@ class NEML_EXPORT ClassicalCreepDamageModel_sd: public NEMLScalarDamagedModel_sd
                             std::shared_ptr<Interpolate> phi,
                             std::shared_ptr<NEMLModel_sd> base,
                             std::shared_ptr<Interpolate> alpha,
-                            double tol, int miter,
-                            bool verbose, bool truesdell);
+                            double rtol, double atol, int miter,
+                            bool verbose, bool linesearch, bool truesdell);
 
   /// String type for the object system
   static std::string type();
@@ -430,8 +432,8 @@ class NEML_EXPORT ModularCreepDamageModel_sd: public NEMLScalarDamagedModel_sd {
                             std::shared_ptr<EffectiveStress> estress,
                             std::shared_ptr<NEMLModel_sd> base,
                             std::shared_ptr<Interpolate> alpha,
-                            double tol, int miter,
-                            bool verbose, bool truesdell,
+                            double rtol, double atol, int miter,
+                            bool verbose, bool linesearch, bool truesdell,
                             bool ekill, double dkill,
                             double sfact);
 
@@ -489,8 +491,8 @@ class NEML_EXPORT LarsonMillerCreepDamageModel_sd: public NEMLScalarDamagedModel
                             std::shared_ptr<EffectiveStress> estress,
                             std::shared_ptr<NEMLModel_sd> base,
                             std::shared_ptr<Interpolate> alpha,
-                            double tol, int miter,
-                            bool verbose, bool truesdell, 
+                            double rtol, double atol, int miter,
+                            bool verbose, bool linesearch, bool truesdell, 
                             bool ekill, double dkill,
                             double sfact);
   
@@ -546,8 +548,8 @@ class NEML_EXPORT NEMLStandardScalarDamagedModel_sd: public NEMLScalarDamagedMod
       std::shared_ptr<LinearElasticModel> elastic,
       std::shared_ptr<NEMLModel_sd> base,
       std::shared_ptr<Interpolate> alpha,
-      double tol, int miter,
-      bool verbose, bool truesdell);
+      double rtol, double atol, int miter,
+      bool verbose, bool linesearch, bool truesdell);
 
   /// Damage, now only proportional to the inelastic effective strain
   virtual int damage(double d_np1, double d_n,
@@ -606,8 +608,8 @@ class NEML_EXPORT NEMLWorkDamagedModel_sd: public NEMLScalarDamagedModel_sd {
       double n,
       std::shared_ptr<NEMLModel_sd> base,
       std::shared_ptr<Interpolate> alpha,
-      double tol, int miter,
-      bool verbose, bool truesdell,
+      double rtol, double atol, int miter,
+      bool verbose, bool linesearch, bool truesdell,
       double eps);
 
   /// String type for the object system
@@ -675,8 +677,8 @@ class NEML_EXPORT NEMLPowerLawDamagedModel_sd: public NEMLStandardScalarDamagedM
       std::shared_ptr<Interpolate> A, std::shared_ptr<Interpolate> a,
       std::shared_ptr<NEMLModel_sd> base,
       std::shared_ptr<Interpolate> alpha,
-      double tol, int miter,
-      bool verbose, bool truesdell);
+      double rtol, double atol, int miter,
+      bool verbose, bool linesearch, bool truesdell);
 
   /// String type for the object system
   static std::string type();
@@ -717,8 +719,8 @@ class NEML_EXPORT NEMLExponentialWorkDamagedModel_sd: public NEMLStandardScalarD
       std::shared_ptr<Interpolate> af,
       std::shared_ptr<NEMLModel_sd> base,
       std::shared_ptr<Interpolate> alpha,
-      double tol, int miter,
-      bool verbose, bool truesdell);
+      double rtol, double atol, int miter,
+      bool verbose, bool linesearch, bool truesdell);
 
   /// String type for the object system
   static std::string type();

--- a/src/larsonmiller.h
+++ b/src/larsonmiller.h
@@ -18,7 +18,8 @@ class LMTrialState: public TrialState {
 class NEML_EXPORT LarsonMillerRelation: public NEMLObject, public Solvable {
  public:
   LarsonMillerRelation(std::shared_ptr<Interpolate> fn, double C,
-                       double tol, int miter, bool verbose);
+                       double rtol, double atol, int miter, bool verbose,
+                       bool linesearch);
 
   /// Type for the object system
   static std::string type();
@@ -48,9 +49,9 @@ class NEML_EXPORT LarsonMillerRelation: public NEMLObject, public Solvable {
  protected:
   std::shared_ptr<Interpolate> fn_;
   double C_;
-  double tol_;
+  double rtol_, atol_;
   int miter_;
-  bool verbose_;
+  bool verbose_, linesearch_;
 };
 
 static Register<LarsonMillerRelation> regLarsonMillerRelation;

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -1125,7 +1125,7 @@ ParameterSet SmallStrainCreepPlasticity::parameters()
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);
   pset.add_optional_parameter<double>("sf", 1.0e6);
-  pset.add_optional_parameter<double>("rtol", 1.0e-8);
+  pset.add_optional_parameter<double>("rtol", 1.0e-12);
   pset.add_optional_parameter<bool>("linesearch", true); // Note this
 
   pset.add_optional_parameter<bool>("truesdell", true);

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -188,11 +188,13 @@ int NEMLModel_ldi::init_store(double * const store) const
 SubstepModel_sd::SubstepModel_sd(std::shared_ptr<LinearElasticModel> emodel,
                                  std::shared_ptr<Interpolate> alpha,
                                  bool truesdell, 
-                                 double tol, int miter, bool verbose,                                 
+                                 double rtol, double atol, int miter,
+                                 bool verbose, bool linesearch,
                                  int max_divide, bool force_divide) :
     NEMLModel_sd(emodel, alpha, truesdell), 
-    tol_(tol), miter_(miter), verbose_(verbose),
-    max_divide_(max_divide), force_divide_(force_divide)
+    rtol_(rtol), atol_(atol), miter_(miter), verbose_(verbose), 
+    linesearch_(linesearch), max_divide_(max_divide),
+    force_divide_(force_divide)
 {
 
 }
@@ -352,8 +354,8 @@ int SubstepModel_sd::update_step(
   
   // Solve the system
   double * x = new double [nparams()]; 
-  int ier = solve(this, x, ts, tol_, miter_, verbose_, false, nullptr, 
-                  A); // Keep jacobian
+  int ier = solve(this, x, ts, {rtol_, atol_, miter_, verbose_, linesearch_},
+                  nullptr, A); // Keep jacobian
   if (ier != SUCCESS) {
     delete [] x;
     delete ts;
@@ -477,11 +479,11 @@ SmallStrainPerfectPlasticity::SmallStrainPerfectPlasticity(
     std::shared_ptr<YieldSurface> surface,
     std::shared_ptr<Interpolate> ys,
     std::shared_ptr<Interpolate> alpha,
-    double tol, int miter,
-    bool verbose, int max_divide,
+    double rtol, double atol, int miter,
+    bool verbose, bool linesearch, int max_divide,
     bool force_divide, bool truesdell) :
-      SubstepModel_sd(elastic, alpha, truesdell, tol, miter, verbose, 
-                      max_divide, force_divide),
+      SubstepModel_sd(elastic, alpha, truesdell, rtol, atol, miter, verbose, 
+                      linesearch, max_divide, force_divide),
       surface_(surface), ys_(ys)
 {
 
@@ -502,9 +504,11 @@ ParameterSet SmallStrainPerfectPlasticity::parameters()
 
   pset.add_optional_parameter<NEMLObject>("alpha",
                                           std::make_shared<ConstantInterpolate>(0.0));
-  pset.add_optional_parameter<double>("tol", 1.0e-8);
+  pset.add_optional_parameter<double>("atol", 1.0e-8);
+  pset.add_optional_parameter<double>("rtol", 1.0e-8);
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);
+  pset.add_optional_parameter<bool>("linesearch", false);
   pset.add_optional_parameter<int>("max_divide", 4);
   pset.add_optional_parameter<bool>("force_divide", false);
 
@@ -520,9 +524,11 @@ std::unique_ptr<NEMLObject> SmallStrainPerfectPlasticity::initialize(ParameterSe
       params.get_object_parameter<YieldSurface>("surface"),
       params.get_object_parameter<Interpolate>("ys"),
       params.get_object_parameter<Interpolate>("alpha"),
-      params.get_parameter<double>("tol"),
+      params.get_parameter<double>("rtol"),
+      params.get_parameter<double>("atol"),
       params.get_parameter<int>("miter"),
       params.get_parameter<bool>("verbose"),
+      params.get_parameter<bool>("linesearch"),
       params.get_parameter<int>("max_divide"),
       params.get_parameter<bool>("force_divide"),
       params.get_parameter<bool>("truesdell")
@@ -742,10 +748,10 @@ SmallStrainRateIndependentPlasticity::SmallStrainRateIndependentPlasticity(
     std::shared_ptr<LinearElasticModel> elastic,
     std::shared_ptr<RateIndependentFlowRule> flow, 
     std::shared_ptr<Interpolate> alpha, bool truesdell,
-    double tol, int miter, bool verbose,
+    double rtol, double atol, int miter, bool verbose, bool linesearch,
     int max_divide, bool force_divide) : 
-      SubstepModel_sd(elastic, alpha, truesdell, tol, miter, verbose,
-                      max_divide, force_divide),
+      SubstepModel_sd(elastic, alpha, truesdell, rtol, atol, miter,
+                      verbose, linesearch, max_divide, force_divide),
       flow_(flow)
 {
 
@@ -767,9 +773,11 @@ ParameterSet SmallStrainRateIndependentPlasticity::parameters()
                                           std::make_shared<ConstantInterpolate>(0.0));
   pset.add_optional_parameter<bool>("truesdell", true);
 
-  pset.add_optional_parameter<double>("tol", 1.0e-8);
+  pset.add_optional_parameter<double>("rtol", 1.0e-8);
+  pset.add_optional_parameter<double>("atol", 1.0e-8);
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);
+  pset.add_optional_parameter<bool>("linesearch", false);
 
   pset.add_optional_parameter<int>("max_divide", 4);
   pset.add_optional_parameter<bool>("force_divide", false);
@@ -785,9 +793,11 @@ std::unique_ptr<NEMLObject> SmallStrainRateIndependentPlasticity::initialize(Par
       params.get_object_parameter<RateIndependentFlowRule>("flow"),
       params.get_object_parameter<Interpolate>("alpha"),
       params.get_parameter<bool>("truesdell"),
-      params.get_parameter<double>("tol"),
+      params.get_parameter<double>("rtol"),
+      params.get_parameter<double>("atol"),
       params.get_parameter<int>("miter"),
       params.get_parameter<bool>("verbose"),
+      params.get_parameter<bool>("linesearch"),
       params.get_parameter<int>("max_divide"),
       params.get_parameter<bool>("force_divide")
       ); 
@@ -1087,11 +1097,11 @@ SmallStrainCreepPlasticity::SmallStrainCreepPlasticity(
     std::shared_ptr<LinearElasticModel> elastic,
     std::shared_ptr<NEMLModel_sd> plastic,
     std::shared_ptr<CreepModel> creep,
-    std::shared_ptr<Interpolate> alpha, double tol,
-    int miter, bool verbose, double sf, bool truesdell) :
+    std::shared_ptr<Interpolate> alpha, double rtol, double atol,
+    int miter, bool verbose, bool linesearch, double sf, bool truesdell) :
       NEMLModel_sd(elastic, alpha, truesdell),
-      plastic_(plastic), creep_(creep), tol_(tol), sf_(sf),
-      miter_(miter), verbose_(verbose)
+      plastic_(plastic), creep_(creep), rtol_(rtol), atol_(atol), sf_(sf),
+      miter_(miter), verbose_(verbose), linesearch_(linesearch)
 {
 
 }
@@ -1111,10 +1121,12 @@ ParameterSet SmallStrainCreepPlasticity::parameters()
 
   pset.add_optional_parameter<NEMLObject>("alpha",
                                           std::make_shared<ConstantInterpolate>(0.0));
-  pset.add_optional_parameter<double>("tol", 1.0e-8);
+  pset.add_optional_parameter<double>("atol", 1.0e-10);
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);
   pset.add_optional_parameter<double>("sf", 1.0e6);
+  pset.add_optional_parameter<double>("rtol", 1.0e-8);
+  pset.add_optional_parameter<bool>("linesearch", true); // Note this
 
   pset.add_optional_parameter<bool>("truesdell", true);
 
@@ -1128,9 +1140,11 @@ std::unique_ptr<NEMLObject> SmallStrainCreepPlasticity::initialize(ParameterSet 
       params.get_object_parameter<NEMLModel_sd>("plastic"),
       params.get_object_parameter<CreepModel>("creep"),
       params.get_object_parameter<Interpolate>("alpha"),
-      params.get_parameter<double>("tol"),
+      params.get_parameter<double>("rtol"),
+      params.get_parameter<double>("atol"),
       params.get_parameter<int>("miter"),
       params.get_parameter<bool>("verbose"),
+      params.get_parameter<bool>("linesearch"),
       params.get_parameter<double>("sf"),
       params.get_parameter<bool>("truesdell")
       ); 
@@ -1166,7 +1180,7 @@ int SmallStrainCreepPlasticity::update_sd(
 
   std::vector<double> xv(nparams());
   double * x = &xv[0];
-  ier = solve(this, x, &ts, tol_, miter_, verbose_);
+  ier = solve(this, x, &ts, {rtol_, atol_, miter_, verbose_, linesearch_});
   if (ier != 0) return ier;
 
   // Store the ep strain
@@ -1346,11 +1360,11 @@ int SmallStrainCreepPlasticity::set_elastic_model(std::shared_ptr<LinearElasticM
 GeneralIntegrator::GeneralIntegrator(std::shared_ptr<LinearElasticModel> elastic,
                                      std::shared_ptr<GeneralFlowRule> rule,
                                      std::shared_ptr<Interpolate> alpha,
-                                     bool truesdell, double tol, int miter,
-                                     bool verbose, int max_divide,
-                                     bool force_divide) :
-    SubstepModel_sd(elastic, alpha, truesdell, tol, miter, verbose, max_divide,
-                    force_divide),
+                                     bool truesdell, double rtol, double atol,
+                                     int miter, bool verbose, bool linesearch,
+                                     int max_divide, bool force_divide) :
+    SubstepModel_sd(elastic, alpha, truesdell, rtol, atol, miter, verbose, 
+                    linesearch, max_divide, force_divide),
     rule_(rule)
 {
 
@@ -1371,10 +1385,12 @@ ParameterSet GeneralIntegrator::parameters()
   pset.add_optional_parameter<NEMLObject>("alpha",
                                           std::make_shared<ConstantInterpolate>(0.0));
   pset.add_optional_parameter<bool>("truesdell", true);
-
-  pset.add_optional_parameter<double>("tol", 1.0e-8);
+  
+  pset.add_optional_parameter<double>("rtol", 1.0e-8);
+  pset.add_optional_parameter<double>("atol", 1.0e-8);
   pset.add_optional_parameter<int>("miter", 50);
   pset.add_optional_parameter<bool>("verbose", false);
+  pset.add_optional_parameter<bool>("linesearch", false);
   pset.add_optional_parameter<int>("max_divide", 4);
   pset.add_optional_parameter<bool>("force_divide", false);
 
@@ -1388,9 +1404,11 @@ std::unique_ptr<NEMLObject> GeneralIntegrator::initialize(ParameterSet & params)
       params.get_object_parameter<GeneralFlowRule>("rule"),
       params.get_object_parameter<Interpolate>("alpha"),
       params.get_parameter<bool>("truesdell"),
-      params.get_parameter<double>("tol"),
+      params.get_parameter<double>("rtol"),
+      params.get_parameter<double>("atol"),
       params.get_parameter<int>("miter"),
       params.get_parameter<bool>("verbose"),
+      params.get_parameter<bool>("linesearch"),
       params.get_parameter<int>("max_divide"),
       params.get_parameter<bool>("force_divide")
       ); 

--- a/src/models.h
+++ b/src/models.h
@@ -179,7 +179,8 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
  public:
   SubstepModel_sd(std::shared_ptr<LinearElasticModel> emodel,
                   std::shared_ptr<Interpolate> alpha,
-                  bool truesdell, double tol, int miter, bool verbose,
+                  bool truesdell, double rtol, double atol,
+                  int miter, bool verbose, bool linesearch,
                   int max_divide, bool force_divide);
 
   /// Complete substep update
@@ -252,9 +253,9 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
       double & p_np1, double p_n) = 0;
 
  protected:
-  double tol_;
+  double rtol_, atol_;
   int miter_;
-  bool verbose_;
+  bool verbose_, linesearch_;
   int max_divide_;
   bool force_divide_;
 };
@@ -354,8 +355,8 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
                                std::shared_ptr<YieldSurface> surface,
                                std::shared_ptr<Interpolate> ys,
                                std::shared_ptr<Interpolate> alpha,
-                               double tol, int miter,
-                               bool verbose,
+                               double rtol, double atol, int miter,
+                               bool verbose, bool linesearch,
                                int max_divide,
                                bool force_divide,
                                bool truesdell);
@@ -456,7 +457,8 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
   SmallStrainRateIndependentPlasticity(std::shared_ptr<LinearElasticModel> elastic,
                                        std::shared_ptr<RateIndependentFlowRule> flow,
                                        std::shared_ptr<Interpolate> alpha, bool truesdell,
-                                       double tol, int miter, bool verbose,
+                                       double rtol, double atol, int miter,
+                                       bool verbose, bool linesearch,
                                        int max_divide, bool force_divide);
 
   /// Type for the object system
@@ -556,8 +558,8 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
                              std::shared_ptr<NEMLModel_sd> plastic,
                              std::shared_ptr<CreepModel> creep,
                              std::shared_ptr<Interpolate> alpha,
-                             double tol, int miter,
-                             bool verbose, double sf,
+                             double rtol, double atol, int miter,
+                             bool verbose, bool linesearch, double sf,
                              bool truesdell);
 
   /// Type for the object system
@@ -608,9 +610,9 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
   std::shared_ptr<NEMLModel_sd> plastic_;
   std::shared_ptr<CreepModel> creep_;
 
-  double tol_, sf_;
+  double rtol_, atol_, sf_;
   int miter_;
-  bool verbose_;
+  bool verbose_, linesearch_;
 };
 
 static Register<SmallStrainCreepPlasticity> regSmallStrainCreepPlasticity;
@@ -627,7 +629,8 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
   GeneralIntegrator(std::shared_ptr<LinearElasticModel> elastic,
                     std::shared_ptr<GeneralFlowRule> rule,
                     std::shared_ptr<Interpolate> alpha,
-                    bool truesdell, double tol, int miter, bool verbose,
+                    bool truesdell, double rtol, double atol,
+                    int miter, bool verbose, bool linesearch,
                     int max_divide, bool force_divide);
 
   /// Type for the object system

--- a/src/solvers.cxx
+++ b/src/solvers.cxx
@@ -13,17 +13,16 @@ namespace neml {
 
 // This function is configured by the build
 int solve(Solvable * system, double * x, TrialState * ts,
-          double tol, int miter, bool verbose, bool relative,
-          double * R, double * J)
+          SolverParameters p, double * R, double * J)
 {
 #ifdef SOLVER_NOX
-  return nox(system, x, ts, tol, miter, verbose, R, J);
+  return nox(system, x, ts, p.atol, p.miter, p.verbose, R, J);
 #elif SOLVER_NEWTON
   // Actually selected the newton solver
-  return newton(system, x, ts, tol, miter, verbose, relative, R, J);
+  return newton(system, x, ts, p.atol, p.miter, p.verbose, false, R, J);
 #else
   // Default solver: plain NR
-  return newton(system, x, ts, tol, miter, verbose, relative, R, J);
+  return newton(system, x, ts, p.atol, p.miter, p.verbose, false, R, J);
 #endif
 }
 

--- a/src/solvers.cxx
+++ b/src/solvers.cxx
@@ -355,4 +355,31 @@ int nox(Solvable * system, double * x, TrialState * ts,
 }
 
 #endif
+
+TestPower::TestPower(double A, double n, double b, double x0) :
+    A_(A), n_(n), b_(b), x0_(x0)
+{
+
+}
+
+size_t TestPower::nparams() const
+{
+  return 1;
+}
+
+int TestPower::init_x(double * const x, TrialState * ts)
+{
+  x[0] = x0_;
+  return 0;
+}
+
+int TestPower::RJ(const double * const x, TrialState * ts, double * const R, 
+       double * const J)
+{
+  R[0] = A_ * std::pow(x[0], n_) + b_;
+  J[0] = A_ * n_ * std::pow(x[0], n_-1.0);
+  return 0;
+}
+
+
 } // namespace neml

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -52,8 +52,7 @@ int NEML_EXPORT solve(Solvable * system, double * x, TrialState * ts,
 
 /// Default solver: plain NR
 int NEML_EXPORT newton(Solvable * system, double * x, TrialState * ts,
-          double tol, int miter, bool verbose, bool relative,
-          double * R, double * J);
+          SolverParameters p, double * R, double * J);
 
 #ifdef SOLVER_NOX
 /// NOX object-oriented interface

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -20,6 +20,17 @@ class TrialState {
   virtual ~TrialState() {};
 };
 
+/// Nonlinear solver parameters
+// I debated several options, but basically I just provide a common set
+// for all models and don't use those that the solvers don't require
+struct SolverParameters {
+  double rtol;
+  double atol;
+  int miter;
+  bool verbose;
+  bool linesearch;
+};
+
 /// Generic nonlinear solver interface
 class NEML_EXPORT Solvable {
  public:
@@ -36,9 +47,8 @@ class NEML_EXPORT Solvable {
 
 /// Call the built-in solver
 int NEML_EXPORT solve(Solvable * system, double * x, TrialState * ts,
-          double tol = 1.0e-8, int miter = 50,
-          bool verbose = false, bool relative = false,
-          double * R = nullptr, double * J = nullptr);
+                      SolverParameters p, double * R = nullptr,
+                      double * J = nullptr);
 
 /// Default solver: plain NR
 int NEML_EXPORT newton(Solvable * system, double * x, TrialState * ts,
@@ -69,7 +79,8 @@ class NEML_EXPORT NOXSolver: public NOX::LAPACK::Interface {
 
 /// Interface to nox
 int NEML_EXPORT nox(Solvable * system, double * x, TrialState * ts,
-        double tol, int miter, bool verbose, double * R, double * J);
+        double tol, int miter, bool verbose, double * R,
+        double * J);
 
 #endif
 

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -95,6 +95,20 @@ int NEML_EXPORT diff_jac(Solvable * system, const double * const x, TrialState *
 double NEML_EXPORT diff_jac_check(Solvable * system, const double * const x, TrialState * ts,
                       const double * const J);
 
+// Test functions
+class TestPower: public Solvable {
+ public:
+  TestPower(double A, double n, double b, double x0);
+
+  size_t nparams() const;
+  int init_x(double * const x, TrialState * ts);
+  int RJ(const double * const x, TrialState * ts, double * const R,
+                 double * const J);
+
+ private:
+  double A_, n_, b_, x0_;
+};
+
 } // namespace neml
 
 #endif // SOLVERS_H

--- a/src/solvers.h
+++ b/src/solvers.h
@@ -24,11 +24,16 @@ class TrialState {
 // I debated several options, but basically I just provide a common set
 // for all models and don't use those that the solvers don't require
 struct SolverParameters {
+  SolverParameters(double rtol, double atol, int miter, bool verbose, 
+                   bool linesearch) : 
+      rtol(rtol), atol(atol), miter(miter), verbose(verbose), 
+      linesearch(linesearch){};
   double rtol;
   double atol;
   int miter;
   bool verbose;
   bool linesearch;
+  int mline;
 };
 
 /// Generic nonlinear solver interface

--- a/src/solvers_wrap.cxx
+++ b/src/solvers_wrap.cxx
@@ -41,18 +41,20 @@ PYBIND11_MODULE(solvers, m) {
       ;
 
   m.def("solve",
-        [](std::shared_ptr<Solvable> system, TrialState & ts, double tol, int miter, bool verbose) -> py::array_t<double>
+        [](std::shared_ptr<Solvable> system, TrialState & ts, double rtol,
+           double atol, int miter, bool verbose, bool linesearch) -> py::array_t<double>
         {
           auto x = alloc_vec<double>(system->nparams());
           
-          int ier = solve(system.get(), arr2ptr<double>(x), &ts, tol, miter, verbose);
+          int ier = solve(system.get(), arr2ptr<double>(x), &ts, 
+                          {rtol, atol, miter, verbose, linesearch});
           py_error(ier);
 
           return x;
         }, "Solve a nonlinear system", 
-        py::arg("solvable"), py::arg("trial_state"), py::arg("tol") = 1.0e-8,
+        py::arg("solvable"), py::arg("trial_state"), py::arg("rtol") = 1.0e-6, py::arg("atol") = 1.0e-8,
         py::arg("miter") = 50,
-        py::arg("verbose") = false);
+        py::arg("verbose") = false, py::arg("linesearch") = false);
 }
 
 } // namespace neml

--- a/src/solvers_wrap.cxx
+++ b/src/solvers_wrap.cxx
@@ -17,6 +17,17 @@ PYBIND11_MODULE(solvers, m) {
       .def(py::init<>())
       ;
 
+  py::class_<SolverParameters, std::shared_ptr<SolverParameters>>(m,
+                                                                  "SolverParameters")
+      .def(py::init<double, double, int, bool, bool>())
+      .def_readwrite("rtol", &SolverParameters::rtol)
+      .def_readwrite("atol", &SolverParameters::atol)
+      .def_readwrite("miter", &SolverParameters::miter)
+      .def_readwrite("verbose", &SolverParameters::verbose)
+      .def_readwrite("linesearch", &SolverParameters::linesearch)
+      .def_readwrite("mline", &SolverParameters::mline)
+    ;
+
   py::class_<Solvable, std::shared_ptr<Solvable>>(m, "Solvable")
       .def_property_readonly("nparams", &Solvable::nparams, "Number of variables in nonlinear equations.")
       .def("init_x",
@@ -55,6 +66,10 @@ PYBIND11_MODULE(solvers, m) {
         py::arg("solvable"), py::arg("trial_state"), py::arg("rtol") = 1.0e-6, py::arg("atol") = 1.0e-8,
         py::arg("miter") = 50,
         py::arg("verbose") = false, py::arg("linesearch") = false);
+
+  py::class_<TestPower, Solvable, std::shared_ptr<TestPower>>(m, "TestPower")
+      .def(py::init<double, double, double, double>())
+      ;
 }
 
 } // namespace neml

--- a/test/test_damage.py
+++ b/test/test_damage.py
@@ -198,11 +198,11 @@ class TestWorkDamage(unittest.TestCase, CommonScalarDamageModel,
     self.bmodel = models.SmallStrainRateIndependentPlasticity(self.elastic, 
         flow)
     
-    self.fn = interpolate.PolynomialInterpolate([0.1,5.0, 0])
+    self.fn = interpolate.PolynomialInterpolate([0.1,5.0, 1e-8])
     self.n = 2.1
 
     self.model = damage.NEMLWorkDamagedModel_sd(
-        self.elastic, self.fn, self.n, self.bmodel)
+        self.elastic, self.fn, self.n, self.bmodel, verbose = False)
 
     self.stress = np.array([100,-50.0,300.0,-99,50.0,125.0]) * 0.75
     self.T = 100.0
@@ -232,7 +232,7 @@ class TestWorkDamage(unittest.TestCase, CommonScalarDamageModel,
 
     self.nsteps = 10
     self.etarget = np.array([0.1,-0.025,0.02,0.015,-0.02,-0.05])
-    self.ttarget = 10.0
+    self.ttarget = 2.0
 
     self.ee = np.dot(self.elastic.S(self.T_np1), self.s_np1*(1.0-self.d_np1) - self.s_n*(1.0-self.d_n))
     self.de = self.e_np1 - self.e_n

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -1,0 +1,38 @@
+import sys
+sys.path.append('..')
+
+import unittest
+
+import numpy as np
+
+from neml import solvers
+
+class TestConvergence(unittest.TestCase):
+  def setUp(self):
+    self.A = 1.0
+    self.n = 4.0
+    self.b = -16.0
+    self.x0 = 4.0
+    self.model = solvers.TestPower(self.A, self.n, self.b, self.x0)
+    self.ts = solvers.TrialState()
+
+  def test_correct(self):
+    x = solvers.solve(self.model, self.ts, rtol = 1.0e-20, atol = 1.0e-12,
+        linesearch = False, verbose = False)
+    self.assertAlmostEqual(x[0], (-self.b/self.A)**(1.0/self.x0))
+
+  def test_rtol(self):
+    R0, J0 = self.model.RJ(np.array([self.x0]), self.ts)
+
+    x = solvers.solve(self.model, self.ts, rtol = 1.0e-4, atol = 1.0e-40,
+        linesearch = False, verbose = False)
+    Rf, Rj = self.model.RJ(x, self.ts)
+    self.assertTrue(Rf[0]/R0[0] < 1.0e-4)
+
+  def test_atol(self):
+    R0, J0 = self.model.RJ(np.array([self.x0]), self.ts)
+
+    x = solvers.solve(self.model, self.ts, rtol = 1.0e-40, atol = 1.0e-4,
+        linesearch = False, verbose = False)
+    Rf, Rj = self.model.RJ(x, self.ts)
+    self.assertTrue(Rf[0] < 1.0e-4)


### PR DESCRIPTION
This adds a line search capability to the entire NEML nonlinear solver system.  It, however, only turns it on by default for the creep + plasticity models, in an effort to improve the robustness of the model integration.