### PR TITLE
Emergency fix for srlife creep models

### DIFF
--- a/src/solvers.cxx
+++ b/src/solvers.cxx
@@ -104,8 +104,9 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
       }
       nR = nRt;
       if (nsearch == mline) {
-        ier = MAX_ITERATIONS;
-        break;
+        // Arguably it's better to let it fall through
+        // ier = MAX_ITERATIONS;
+        // break;
       }
     }
     else {


### PR DESCRIPTION
This bugfix lets failed backtracking linesearch iterations fall through the newton-raphson loop, rather than triggering a linesearch failure.  This fixes an odd problem I noticed in srlife where the linesearch would fail even though if you let the loop continue you'd achieve good convergence on the next iteration.

I'm okay with making this the default behavior as it's safe -- the worst that will happen is that it will delay the failure of the nonlinear solver to later in the Newton-Raphson process.