### PR TITLE
Added upper strain rate limit to NEML, applied to look at fixing issue #89

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ else()
       message("Unknown solver")
 endif()
 
+### Limits designed to make bad updates fail gracefully ###
+set(STRESS_LIMIT "1.0e10" CACHE STRING "Limit on stress values -- NEML may return an error if a stress grows beyond this value")
+mark_as_advanced(STRESS_LIMIT)
+add_definitions(-DSTRESS_LIMIT=${STRESS_LIMIT})
+
 ### Configure standard-ish libraries ###
 set(BLAS_VENDOR Generic)
 set(BLA_VENDOR Generic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,9 @@ else()
 endif()
 
 ### Limits designed to make bad updates fail gracefully ###
-set(STRESS_LIMIT "1.0e10" CACHE STRING "Limit on stress values -- NEML may return an error if a stress grows beyond this value")
-mark_as_advanced(STRESS_LIMIT)
-add_definitions(-DSTRESS_LIMIT=${STRESS_LIMIT})
+set(STRAIN_RATE_LIMIT "1.0e10" CACHE STRING "Limit on strain rate -- NEML may return an error if a strain rate grows beyond this value")
+mark_as_advanced(STRAIN_RATE_LIMIT)
+add_definitions(-DSTRAIN_RATE_LIMIT=${STRAIN_RATE_LIMIT})
 
 ### Configure standard-ish libraries ###
 set(BLAS_VENDOR Generic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 ### Limits designed to make bad updates fail gracefully ###
 set(STRAIN_RATE_LIMIT "1.0e10" CACHE STRING "Limit on strain rate -- NEML may return an error if a strain rate grows beyond this value")
 mark_as_advanced(STRAIN_RATE_LIMIT)
-add_definitions(-DSTRAIN_RATE_LIMIT=${STRAIN_RATE_LIMIT})
+add_definitions(-DNEML_STRAIN_RATE_LIMIT=${STRAIN_RATE_LIMIT})
 
 ### Configure standard-ish libraries ###
 set(BLAS_VENDOR Generic)

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -80,6 +80,7 @@ int TVPFlowRule::s(const double * const s, const double * const alpha,
   if (ier != SUCCESS) return ier;
   ier = flow_->y(s, alpha, T, yv);
   if (ier != SUCCESS) return ier;
+  if (yv > STRESS_LIMIT) return EXCEEDS_STRESS_LIMIT;
   
   for (int i=0; i<6; i++) {
     erate[i] -= yv * temp[i];

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -80,7 +80,7 @@ int TVPFlowRule::s(const double * const s, const double * const alpha,
   if (ier != SUCCESS) return ier;
   ier = flow_->y(s, alpha, T, yv);
   if (ier != SUCCESS) return ier;
-  if (yv > STRAIN_RATE_LIMIT) return EXCEEDS_STRAIN_RATE_LIMIT;
+  if (yv > NEML_STRAIN_RATE_LIMIT) return EXCEEDS_STRAIN_RATE_LIMIT;
   
   for (int i=0; i<6; i++) {
     erate[i] -= yv * temp[i];

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -80,7 +80,7 @@ int TVPFlowRule::s(const double * const s, const double * const alpha,
   if (ier != SUCCESS) return ier;
   ier = flow_->y(s, alpha, T, yv);
   if (ier != SUCCESS) return ier;
-  if (yv > STRESS_LIMIT) return EXCEEDS_STRESS_LIMIT;
+  if (yv > STRAIN_RATE_LIMIT) return EXCEEDS_STRAIN_RATE_LIMIT;
   
   for (int i=0; i<6; i++) {
     erate[i] -= yv * temp[i];

--- a/src/nemlerror.h
+++ b/src/nemlerror.h
@@ -26,7 +26,8 @@ typedef enum Error {
   UNKNOWN_ERROR = -13,
   INCOMPATIBLE_KM = -14,
   DUMMY_ELASTIC = -15,
-  INCOMPATIBLE_VECTORS = -16
+  INCOMPATIBLE_VECTORS = -16,
+  EXCEEDS_STRESS_LIMIT = -17
 } Error;
 
 /// Translate an error code to an exception

--- a/src/nemlerror.h
+++ b/src/nemlerror.h
@@ -27,7 +27,7 @@ typedef enum Error {
   INCOMPATIBLE_KM = -14,
   DUMMY_ELASTIC = -15,
   INCOMPATIBLE_VECTORS = -16,
-  EXCEEDS_STRESS_LIMIT = -17
+  EXCEEDS_STRAIN_RATE_LIMIT = -17
 } Error;
 
 /// Translate an error code to an exception


### PR DESCRIPTION
This branch provides a configuration compile-time limit `STRAIN_RATE_LIMIT` model developers can check strain rate values against (for example, in a stress rate calculation) to prevent conditions that would otherwise cause a `SIGFPE` with those compile-time options set.