### PR TITLE
Make apt a bit more stable in the build scripts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,8 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        sudo apt-get install python3-dev python3-pip cmake libboost-dev libblas-dev liblapack-dev
+        sudo apt update
+        sudo apt install python3-dev python3-pip cmake libboost-dev libblas-dev liblapack-dev
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     - name: Build and publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
                         btype: [Release, Debug]
             steps:
             - uses: actions/checkout@v2
+            - run: sudo apt update
             - run: sudo apt install build-essential cmake libblas-dev liblapack-dev python3-dev python3-networkx python3-numpy python3-scipy python3-matplotlib python3-nose
             - run: cmake -D CMAKE_BUILD_TYPE=${{ matrix.btype }} -D WRAP_PYTHON=ON .
             - run: make -j 2
@@ -19,6 +20,7 @@ jobs:
                         btype: [Release, Debug]
             steps:
             - uses: actions/checkout@v2
+            - run: sudo apt update
             - run: sudo apt install build-essential cmake libblas-dev liblapack-dev
             - run: cmake -D CMAKE_BUILD_TYPE=${{ matrix.btype }} -D BUILD_UTILS=ON .
             - run: make -j 2


### PR DESCRIPTION
We just had a build failure that had nothing to do with the package.  It may have just been a random issue with the package repo, but maybe running update first will help in the future.