### PR TITLE
Brew treats upgrades as errors, need to ignore that

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             steps:
             - uses: actions/checkout@v2
             - run: brew update
-            - run: brew install cmake openblas superlu python
+            - run: brew install cmake openblas superlu python 1>/dev/null || true
             - run: pip3 install --user networkx numpy scipy matplotlib nose
             - run: cmake -D CMAKE_BUILD_TYPE=${{ matrix.btype }} -D WRAP_PYTHON=ON -D PYTHON_EXECUTABLE=$(python3-config --prefix)/bin/python3.9 -D PYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython3.9.dylib -D PYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python3.9 -D USE_OPENMP=OFF .
             - run: make -j 2
@@ -46,7 +46,7 @@ jobs:
             steps:
             - uses: actions/checkout@v2
             - run: brew update
-            - run: brew install cmake openblas superlu gfortran
+            - run: brew install cmake openblas superlu gfortran 1>/dev/null || true
             - run: brew reinstall gcc
             - run: which gfortran
             - run: cmake -D CMAKE_CXX_COMPILER=/usr/bin/g++ -D CMAKE_C_COMPILER=/usr/bin/gcc -D CMAKE_Fortran_COMPILER=/usr/local/bin/gfortran -D CMAKE_BUILD_TYPE=${{ matrix.btype }} -D USE_OPENMP=OFF -D BUILD_UTILS=ON .


### PR DESCRIPTION
The mac tests are failing because brew returns an error code if you includes a packages that is already installed in the `brew install` list.  Of course we don't know what a particular test instance will have installed so we need to cover this case.