### PR TITLE
Updated parser to be more robust

### DIFF
--- a/src/parse.cxx
+++ b/src/parse.cxx
@@ -35,6 +35,7 @@ std::unique_ptr<NEMLModel> parse_string_unique(std::string input, std::string mn
 
   // Find the node with the right name
   const rapidxml::xml_node<> * found = root->first_node(mname.c_str());
+  if (found == 0) throw ModelNotFound(mname);
 
   // Get the NEMLObject
   std::unique_ptr<NEMLObject> obj = get_object_unique(found);
@@ -61,6 +62,7 @@ std::shared_ptr<NEMLModel> parse_xml(std::string fname, std::string mname)
 
   // Find the node with the right name
   const rapidxml::xml_node<> * found = root->first_node(mname.c_str());
+  if (found == 0) throw ModelNotFound(mname);
 
   // Get the NEMLObject
   std::shared_ptr<NEMLObject> obj = get_object(found);
@@ -87,6 +89,7 @@ std::unique_ptr<NEMLModel> parse_xml_unique(std::string fname, std::string mname
 
   // Find the node with the right name
   const rapidxml::xml_node<> * found = root->first_node(mname.c_str());
+  if (found == 0) throw ModelNotFound(mname);
 
   // Get the NEMLObject
   std::unique_ptr<NEMLObject> obj = get_object_unique(found);

--- a/src/parse.h
+++ b/src/parse.h
@@ -201,6 +201,29 @@ class UnregisteredXML: public std::exception {
 
 };
 
+/// The model isn't in the file
+class ModelNotFound: public std::exception {
+ public:
+  ModelNotFound(std::string name) :
+      name_(name)
+  {
+    std::stringstream ss;
+
+    ss << "Model named " << name_ << " is not in the XML file!";
+
+    message_ = ss.str();
+  };
+
+  const char * what() const throw ()
+  {
+    return message_.c_str();
+  };
+
+ private:
+  std::string name_, message_;
+
+};
+
 } // namespace neml
 
 #endif // PARSE_H

--- a/test/malformed.xml
+++ b/test/malformed.xml
@@ -1,0 +1,17 @@
+<models>
+  <test_j2iso type="SmallStrainRateIndependentPlasticity">
+    <elastic type="IsotropicLinearElasticModel">
+      <m1>103561.64383561644</m1>
+      <m1_type>youngs</m1_type>
+      <m2>0.2945205479452055</m2>
+      <m2_type>poissons</m2_type>
+    </elastic>
+    
+    <flow type="RateIndependentAssociativeFlow">
+      <surface type="IsoJ2"/>
+      <hardening type="LinearIsotropicHardeningRule">
+        <s0>100.0</s0>
+        <K>1000.0</K>
+      </hardening>
+    </flow>
+</models>

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -10,6 +10,18 @@ class TestErrors(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       test = parse.parse_xml(localize("examples.xml"), "test_badobject")
 
+  def test_nomodel(self):
+    with self.assertRaises(RuntimeError):
+      test = parse.parse_xml(localize("examples.xml"), "not_in_file")
+
+  def test_malformed(self):
+    with self.assertRaises(RuntimeError):
+      test = parse.parse_xml(localize("malformed.xml"), "test_j2iso")
+
+  def test_nofiles(self):
+    with self.assertRaises(RuntimeError):
+      test = parse.parse_xml(localize("nothere.xml"), "idk")
+
 class CompareMats(object):
   def test_same(self):
     t_n = 0.0


### PR DESCRIPTION
Currently we were segfaulting if the user asked for a model that did not exist in the XML file.  This PR fixes this issue and adds some extra testing to the parser to (hopefully) ensure it remains robust against errors like this.