### PR TITLE
Adds specialized Chaboche model compatible with pyoptmat

### DIFF
--- a/doc/sphinx/hardening/non/special_chaboche.rst
+++ b/doc/sphinx/hardening/non/special_chaboche.rst
@@ -1,0 +1,81 @@
+ChabocheVoceRecovery: a special variant of the Chaboche model
+=============================================================
+
+Overview
+--------
+
+This model describes a variant of the :doc:`Chaboche kinematic hardening <chaboche>` with 
+:doc:`Voce <../simple/iso_voce>` isotropic hardening.  The only differences compared to using the standard
+:doc:`Chaboche <chaboche>` model with Voce isotropic hardening are:
+
+1. The Voce model is reparameterized as described below
+2. The Voce model includes static recovery
+3. There is a subtle difference in the definition of the static recovery on the Chaboche backstress terms.
+
+Voce reparameterization and recovery
+""""""""""""""""""""""""""""""""""""
+
+The Voce model for this hardening option is reparameterized so that the strength is given as 
+
+.. math::
+   Q = -\sigma_0 - R
+
+.. WARNING::
+   All of the NEML yield surfaces assume the opposite of the standard
+   sign convention for isotropic and kinematic hardening.
+   The hardening model is expected to return a negative value of the
+   isotropic hardening stress and a negative value of the backstress.
+
+.. math::
+   \dot{R} = \sqrt{\frac{2}{3}} \theta_0 \left(1 - \frac{R}{R_{max}} \right) \dot{p} + r_1 \left| R_{min} - R \right|^{r_2} \operatorname{sign} \left( R_{min} - R \right)
+
+where :math:`\dot{p}` is the scalar plastic strain rate and the remaining undefined terms are parameters.  
+
+The first term, proportional to the scalar plastic strain rate, is identical to the standard :doc:`Voce <../simple/iso_voce>`
+model in NEML, just reparameterized.  The second term provides power law static recovery, which can reduce the value 
+of the isotropic strength down to the threshold strength :math:`R_{min}`.
+
+Slight change to Chaboche static recovery
+"""""""""""""""""""""""""""""""""""""""""
+
+The  *standard* :doc:`Chaboche kinematic hardening <chaboche>` in NEML uses a static recovery term of
+
+.. math::
+   \dot{\mathbf{X}}_i = - \sqrt{\frac{3}{2}} A_i \left\Vert \mathbf{X}_i \right\Vert^{a_i-1} \mathbf{X}_i
+
+*This* model instead uses
+
+.. math::
+   \dot{\mathbf{X}}_i = - A_i \left(  \sqrt{\frac{3}{2}} \left\Vert \mathbf{X}_i \right\Vert \right)^{a_i-1} \mathbf{X}_i
+
+The only change is the location of the :math:`\sqrt{\frac{3}{2}}` term.  This change makes the current model 
+directly compatible with a 1D formulation.
+
+Parameters
+----------
+
+.. csv-table::
+   :header: "Parameter", "Object type", "Description", "Default"
+   :widths: 12, 30, 50, 8
+   
+   ``s0``, :cpp:class:`neml::Interpolate`, Threshold stress, No
+   ``theta0``, :cpp:class:`neml::Interpolate`, Initial isotropic hardening slope, No
+   ``Rmax``, :cpp:class:`neml::Interpolate`, Maximum (saturated) isotropic hardening strength, No
+   ``Rmin``, :cpp:class:`neml::Interpolate`, Minimum (threshold) isotropic strength for static recovery, No
+   ``r1``, :cpp:class:`neml::Interpolate`, Prefactor for isotropic recovery, No
+   ``r2``, :cpp:class:`neml::Interpolate`, Exponent for isotropic recovery, No
+   ``c``, :code:`std::vector<`:cpp:class:`neml::Interpolate`:code:`>`, Values of constant C for each backstress, No
+   ``gmodels``, :code:`std::vector<`:cpp:class:`neml::GammaModel`:code:`>`, The gamma functions for each backstress, No
+   ``A``, :code:`std::vector<`:cpp:class:`neml::Interpolate`:code:`>`, The value of A for each backstress, No
+   ``a``, :code:`std::vector<`:cpp:class:`neml::Interpolate`:code:`>`, The value of a for each backstress, No
+   ``noniso``, :code:`bool`, Include the nonisothermal term?, ``true``
+
+The number of backstresses is set implicitly from the lengths of these vectors.
+The model will return an error if they have different lengths.
+
+Class description
+-----------------
+
+.. doxygenclass:: neml::ChabocheVoceRecovery
+   :members:
+   :undoc-members:

--- a/doc/sphinx/hardening/nonassociative.rst
+++ b/doc/sphinx/hardening/nonassociative.rst
@@ -29,6 +29,7 @@ Implementations
 
 .. toctree::
    non/chaboche
+   non/special_chaboche
 
 Class description
 -----------------

--- a/include/interpolate.h
+++ b/include/interpolate.h
@@ -235,6 +235,30 @@ class NEML_EXPORT MTSShearInterpolate : public Interpolate {
 
 static Register<MTSShearInterpolate> regMTSShearInterpolate;
 
+
+/// The Mechanical Threshold Stress scaling
+class NEML_EXPORT MTSInterpolate : public Interpolate {
+ public:
+  /// Interpolation using the MTS model
+  MTSInterpolate(ParameterSet & params);
+
+  /// Type for the object system
+  static std::string type();
+  /// Create parameters for the object system
+  static ParameterSet parameters();
+  /// Create object from a ParameterSet
+  static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
+
+  virtual double value(double x) const;
+  virtual double derivative(double x) const;
+
+ private:
+  const double tau0_, g0_, q_, p_, k_, b_;
+  const std::shared_ptr<Interpolate> mu_;
+};
+
+static Register<MTSInterpolate> regMTSInterpolate;
+
 /// A helper to make a vector of constant interpolates from a vector
 NEML_EXPORT std::vector<std::shared_ptr<Interpolate>>
   make_vector(const std::vector<double> & iv);

--- a/src/hardening.cxx
+++ b/src/hardening.cxx
@@ -999,4 +999,397 @@ void Chaboche::backstress_(const double * const alpha, double * const X) const
   }
 }
 
+//
+// ChabocheVoceRecovery with fancy, hard-coded Voce isotropic hardening
+//
+ChabocheVoceRecovery::ChabocheVoceRecovery(ParameterSet & params) :
+    NonAssociativeHardening(params),
+    s0_(params.get_object_parameter<Interpolate>("s0")),
+    theta0_(params.get_object_parameter<Interpolate>("theta0")),
+    Rmax_(params.get_object_parameter<Interpolate>("Rmax")),
+    Rmin_(params.get_object_parameter<Interpolate>("Rmin")),
+    r1_(params.get_object_parameter<Interpolate>("r1")),
+    r2_(params.get_object_parameter<Interpolate>("r2")),
+    c_(params.get_object_parameter_vector<Interpolate>("C")),
+    n_(c_.size()), 
+    gmodels_(params.get_object_parameter_vector<GammaModel>("gmodels")), 
+    A_(params.get_object_parameter_vector<Interpolate>("A")), 
+    a_( params.get_object_parameter_vector<Interpolate>("a")), 
+    noniso_(params.get_parameter<bool>("noniso"))
+{
+
+}
+
+std::string ChabocheVoceRecovery::type()
+{
+  return "ChabocheVoceRecovery";
+}
+
+ParameterSet ChabocheVoceRecovery::parameters()
+{
+  ParameterSet pset(ChabocheVoceRecovery::type());
+
+  pset.add_parameter<NEMLObject>("s0");
+  pset.add_parameter<NEMLObject>("theta0");
+  pset.add_parameter<NEMLObject>("Rmax");
+  pset.add_parameter<NEMLObject>("Rmin");
+  pset.add_parameter<NEMLObject>("r1");
+  pset.add_parameter<NEMLObject>("r2");
+
+  pset.add_parameter<std::vector<NEMLObject>>("C");
+  pset.add_parameter<std::vector<NEMLObject>>("gmodels");
+  pset.add_parameter<std::vector<NEMLObject>>("A");
+  pset.add_parameter<std::vector<NEMLObject>>("a");
+
+  pset.add_optional_parameter<bool>("noniso", true);
+
+  return pset;
+}
+
+std::unique_ptr<NEMLObject> ChabocheVoceRecovery::initialize(ParameterSet & params)
+{
+  return neml::make_unique<ChabocheVoceRecovery>(params); 
+}
+
+size_t ChabocheVoceRecovery::ninter() const
+{
+  return 1 + 6;
+}
+
+size_t ChabocheVoceRecovery::nhist() const
+{
+  return 1 + 6 * n_;
+}
+
+int ChabocheVoceRecovery::init_hist(double * const alpha) const
+{
+  std::fill(alpha, alpha+nhist(), 0.0);
+  return 0;
+}
+
+int ChabocheVoceRecovery::q(const double * const alpha, double T, double * const qv) const
+{
+  // Isotropic part
+  qv[0] = -(s0_->value(T) + alpha[0]);
+
+  std::fill(qv+1, qv+7, 0.0);
+  
+  // Helps with unrolling
+  int n = n_;
+
+  for (int i=0; i<n; i++) {
+    for (int j=0; j<6; j++) {
+      qv[j+1] += alpha[1+i*6+j];
+    }
+  }
+  return 0;
+}
+
+int ChabocheVoceRecovery::dq_da(const double * const alpha, double T, double * const qv) const
+{
+  std::fill(qv, qv+(ninter()*nhist()), 0.0);
+
+  // Isotropic part
+  qv[0] = -1.0;
+  
+  // Help unroll
+  int n = n_;
+
+  for (int i=0; i<n; i++) {
+    for (int j=0; j<6; j++) {
+      qv[CINDEX((j+1),(1+i*6+j), nhist())] = 1.0;
+    }
+  }
+  return 0;
+}
+
+int ChabocheVoceRecovery::h(const double * const s, const double * const alpha, double T,
+              double * const hv) const
+{
+  // Isotropic -- does this need a sqrt(2.0/3.0)?
+  hv[0] = theta0_->value(T) * (1 - alpha[0]/Rmax_->value(T));
+
+  double X[6], nv[6];
+  backstress_(alpha, X);
+  std::copy(s, s+6, nv);
+  dev_vec(nv);
+  add_vec(nv, X, 6, nv);
+  normalize_vec(nv, 6);
+  
+  // Note the extra factor of sqrt(2.0/3.0) -- this is to make it equivalent
+  // to Chaboche's original definition
+  
+  std::vector<double> c = eval_vector(c_, T);
+
+  for (int i=0; i<n_; i++) {
+    for (int j=0; j<6; j++) {
+      hv[1+i*6+j] = - 2.0 / 3.0 * c[i] * nv[j] - sqrt(2.0/3.0) * gmodels_[i]->gamma(alpha[0], T) * alpha[1+i*6+j];
+    }
+  }
+
+  return 0;
+}
+
+int ChabocheVoceRecovery::dh_ds(const double * const s, const double * const alpha, double T,
+              double * const dhv) const
+{
+  std::fill(dhv, dhv + nhist()*6, 0.0);
+
+  std::vector<double> c = eval_vector(c_, T);
+
+  double X[6];
+  backstress_(alpha, X);
+
+  double n[6];
+  std::copy(s, s+6, n);
+  dev_vec(n);
+  add_vec(n, X, 6, n);
+  double nv = norm2_vec(n, 6);
+  normalize_vec(n, 6);
+  
+  double nn[36];
+
+  std::fill(nn, nn+36, 0.0);
+  for (int i=0; i<6; i++) {
+    nn[CINDEX(i,i,6)] += 1.0;
+  }
+  
+  double iv[6];
+  double jv[6];
+  for (int i=0; i<3; i++) {
+    iv[i] = 1.0 / 3.0;
+    jv[i] = 1.0;
+  }
+  for (int i=3; i<6; i++) {
+    iv[i] = 0.0;
+    jv[i] = 0.0;
+  }
+
+  outer_update_minus(iv, 6, jv, 6, nn);
+
+  outer_update_minus(n, 6, n, 6, nn);
+  if (nv != 0.0) {
+    for (int i=0; i<36; i++) {
+      nn[i] /= nv;
+    }
+  }
+  
+  // Fill in...
+  for (int i=0; i<n_; i++) {
+    for (int j=0; j<6; j++) {
+      for (int k=0; k<6; k++) {
+        dhv[CINDEX((1+i*6+j),(k),6)] = -2.0 / 3.0 * c[i] * nn[CINDEX(j,k,6)];
+      }
+    }
+  }
+  
+  return 0;
+}
+
+int ChabocheVoceRecovery::dh_da(const double * const s, const double * const alpha, double T,
+              double * const dhv) const
+{
+  // Again, there should be no earthly reason the compiler can't do this
+  int nh = nhist();
+
+  std::fill(dhv, dhv + nh*nh, 0.0);
+
+  // Isotropic contributiondvh[0] = -theta0_->value(T) / Rmax_->value(T);
+  dhv[0] = -theta0_->value(T) / Rmax_->value(T);
+  std::vector<double> c = eval_vector(c_, T);
+
+  double X[6];
+  backstress_(alpha, X);
+
+  double ss[36];
+  double n[6];
+  std::copy(s, s+6, n);
+  dev_vec(n);
+  add_vec(n, X, 6, n);
+  double nv = norm2_vec(n, 6);
+  normalize_vec(n, 6);
+  
+  std::fill(ss, ss+36, 0.0);
+  for (int i=0; i<6; i++) {
+    ss[CINDEX(i,i,6)] += 1.0;
+  }
+  
+  outer_update_minus(n, 6, n, 6, ss);
+  if (nv != 0.0) {
+    for (int i=0; i<36; i++) {
+      ss[i] /= nv;
+    }
+  }
+  
+  // Fill in the gamma part
+  for (int i=0; i<n_; i++) {
+    for (int j=0; j<6; j++) {
+      dhv[CINDEX((1+i*6+j),(1+i*6+j),nh)] -= sqrt(2.0/3.0) * gmodels_[i]->gamma(alpha[0], T);
+    }
+  }
+
+  // Fill in the ss part
+  for (int bi=0; bi<n_; bi++) {
+    for (int i=0; i<6; i++) {
+      for (int bj=0; bj<n_; bj++) {
+        for (int j=0; j<6; j++) {
+          dhv[CINDEX((1+bi*6+i),(1+bj*6+j),nh)] -= 2.0 / 3.0 * c[bi]  * 
+              ss[CINDEX(i,j,6)];
+        }
+      }
+    }
+  }
+
+  // Fill in the alpha part
+  for (int i=0; i<n_; i++) {
+    for (int j=0; j<6; j++) {
+      dhv[CINDEX((1+i*6+j),0,nhist())] = -sqrt(2.0/3.0) * 
+          gmodels_[i]->dgamma(alpha[0], T) * alpha[1+i*6+j];
+    }
+  }
+
+  return 0;
+}
+
+int ChabocheVoceRecovery::h_time(const double * const s, const double * const alpha, 
+                     double T, double * const hv) const
+{
+  std::fill(hv, hv+nhist(), 0.0);
+
+  // Isotropic recovery term (need sqrt(3/2)?)
+  hv[0] = r1_->value(T) * (Rmin_->value(T) - alpha[0]
+                           ) * std::pow(std::fabs(Rmin_->value(T) - alpha[0]),
+                                        r2_->value(T) - 1.0);
+ 
+  std::vector<double> A = eval_vector(A_, T);
+  std::vector<double> a = eval_vector(a_, T);
+
+  double Xi[6];
+  double nXi;
+  for (int i=0; i<n_; i++) {
+    std::copy(&alpha[1+i*6], &alpha[1+(i+1)*6], Xi);
+    nXi = norm2_vec(Xi, 6);
+    for (int j=0; j<6; j++) {
+      hv[1+i*6+j] = -A[i] * sqrt(3.0/2.0) * pow(nXi, a[i] - 1.0) *
+          alpha[1+i*6+j];
+    }
+  }
+
+  return 0;
+}
+
+int ChabocheVoceRecovery::dh_ds_time(const double * const s, const double * const alpha, 
+                         double T, double * const dhv) const
+{
+  std::fill(dhv, dhv+nhist()*6, 0.0);
+
+  // Also return if relax
+
+  return 0;
+}
+
+int ChabocheVoceRecovery::dh_da_time(const double * const s, const double * const alpha,
+                         double T, double * const dhv) const
+{
+  std::fill(dhv, dhv+nhist()*nhist(), 0.0);
+
+  dhv[0] = std::copysign(r1_->value(T) * r2_->value(T) *
+                         std::pow(std::fabs(Rmin_->value(T) - alpha[0]), r2_->value(T) -
+                                  1.0), Rmin_->value(T) - alpha[0]);
+
+  std::vector<double> A = eval_vector(A_, T);
+  std::vector<double> a = eval_vector(a_, T);
+
+  int nh = nhist();
+  int n = n_;
+  
+  double XX[36];
+  double Xi[6];
+  double nXi;
+  int ia,ib;
+  double d;
+  for (int i=0; i<n; i++) {
+    std::copy(&alpha[1+i*6], &alpha[1+(i+1)*6], Xi);
+    nXi = norm2_vec(Xi, 6);
+    normalize_vec(Xi, 6);
+    outer_vec(Xi, 6, Xi, 6, XX);
+    for (int j=0; j<6; j++) {
+      ia = 1 + i*6 + j;
+      for (int k=0; k<6; k++) {
+        ib = 1 + i*6 + k;
+        if (j == k) {
+          d = 1.0;
+        }
+        else {
+          d = 0.0;
+        }
+        dhv[CINDEX(ia,ib,nh)] = -A[i] * sqrt(3.0/2.0) * pow(nXi, a[i]-1.0) * (
+            d + (a[i] - 1.0) * XX[CINDEX(j,k,6)]);
+      }
+    }
+  }
+
+  return 0;
+}
+
+int ChabocheVoceRecovery::h_temp(const double * const s, const double * const alpha, double T,
+              double * const hv) const
+{
+  std::fill(hv, hv+nhist(), 0.0);
+  if (not noniso_) return 0;
+
+  std::vector<double> c = eval_vector(c_, T);
+  std::vector<double> dc = eval_deriv_vector(c_, T);
+
+  for (int i=0; i<n_; i++) {
+    if (c[i] == 0.0) continue;
+    for (int j=0; j<6; j++) {
+      hv[1+i*6+j] = -sqrt(2.0/3.0) * dc[i] / c[i] * alpha[1+i*6+j];
+    }
+  }
+  return 0;
+}
+
+int ChabocheVoceRecovery::dh_ds_temp(const double * const s, const double * const alpha, double T,
+              double * const dhv) const
+{
+  std::fill(dhv, dhv+nhist()*6, 0.0);
+  return 0;
+}
+
+int ChabocheVoceRecovery::dh_da_temp(const double * const s, const double * const alpha, double T,
+              double * const dhv) const
+{
+  std::fill(dhv, dhv+nhist()*nhist(), 0.0);
+  if (not noniso_) return 0;
+
+  std::vector<double> c = eval_vector(c_, T);
+  std::vector<double> dc = eval_deriv_vector(c_, T);
+
+  for (int i=0; i<n_; i++) {
+    if (c[i] == 0.0) continue;
+    for (int j=0; j<6; j++) {
+      int ci = 1 + i*6 + j;
+      dhv[CINDEX(ci,ci,nhist())] = - sqrt(2.0/3.0) * dc[i] / c[i];
+    }
+  }
+
+  return 0;
+}
+
+int ChabocheVoceRecovery::n() const
+{
+  return n_;
+}
+
+void ChabocheVoceRecovery::backstress_(const double * const alpha, double * const X) const
+{
+  std::fill(X, X+6, 0.0);
+  for (int i=0; i<n_; i++) {
+    for (int j=0; j<6; j++) {
+      X[j] += alpha[1+i*6+j];
+    }
+  }
+}
+
 } // namespace neml

--- a/src/hardening.cxx
+++ b/src/hardening.cxx
@@ -1106,8 +1106,9 @@ int ChabocheVoceRecovery::dq_da(const double * const alpha, double T, double * c
 int ChabocheVoceRecovery::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
-  // Isotropic -- does this need a sqrt(2.0/3.0)?
-  hv[0] = theta0_->value(T) * (1 - alpha[0]/Rmax_->value(T));
+  // Isotropic
+  hv[0] = theta0_->value(T) * (1 - alpha[0]/Rmax_->value(T)) *
+      std::sqrt(2.0/3.0);
 
   double X[6], nv[6];
   backstress_(alpha, X);
@@ -1194,8 +1195,8 @@ int ChabocheVoceRecovery::dh_da(const double * const s, const double * const alp
 
   std::fill(dhv, dhv + nh*nh, 0.0);
 
-  // Isotropic contributiondvh[0] = -theta0_->value(T) / Rmax_->value(T);
-  dhv[0] = -theta0_->value(T) / Rmax_->value(T);
+  // Isotropic contribution
+  dhv[0] = -theta0_->value(T) / Rmax_->value(T) * std::sqrt(2.0/3.0);
   std::vector<double> c = eval_vector(c_, T);
 
   double X[6];
@@ -1256,7 +1257,7 @@ int ChabocheVoceRecovery::h_time(const double * const s, const double * const al
 {
   std::fill(hv, hv+nhist(), 0.0);
 
-  // Isotropic recovery term (need sqrt(3/2)?)
+  // Isotropic recovery term 
   hv[0] = r1_->value(T) * (Rmin_->value(T) - alpha[0]
                            ) * std::pow(std::fabs(Rmin_->value(T) - alpha[0]),
                                         r2_->value(T) - 1.0);
@@ -1270,7 +1271,7 @@ int ChabocheVoceRecovery::h_time(const double * const s, const double * const al
     std::copy(&alpha[1+i*6], &alpha[1+(i+1)*6], Xi);
     nXi = norm2_vec(Xi, 6);
     for (int j=0; j<6; j++) {
-      hv[1+i*6+j] = -A[i] * sqrt(3.0/2.0) * pow(nXi, a[i] - 1.0) *
+      hv[1+i*6+j] = -A[i] * pow(sqrt(3.0/2.0) * nXi, a[i] - 1.0) *
           alpha[1+i*6+j];
     }
   }
@@ -1323,7 +1324,7 @@ int ChabocheVoceRecovery::dh_da_time(const double * const s, const double * cons
         else {
           d = 0.0;
         }
-        dhv[CINDEX(ia,ib,nh)] = -A[i] * sqrt(3.0/2.0) * pow(nXi, a[i]-1.0) * (
+        dhv[CINDEX(ia,ib,nh)] = -A[i] * pow( sqrt(3.0/2.0) * nXi, a[i]-1.0) * (
             d + (a[i] - 1.0) * XX[CINDEX(j,k,6)]);
       }
     }

--- a/src/hardening_wrap.cxx
+++ b/src/hardening_wrap.cxx
@@ -274,6 +274,18 @@ PYBIND11_MODULE(hardening, m) {
           return cv;
          }, "c material constant.")
       ;
+
+  py::class_<ChabocheVoceRecovery, NonAssociativeHardening,
+      std::shared_ptr<ChabocheVoceRecovery>>(m, "ChabocheVoceRecovery")
+      .def(py::init([](py::args args, py::kwargs kwargs)
+        {
+          return create_object_python<ChabocheVoceRecovery>(args, kwargs, {"s0",
+                                                            "theta0", "Rmax",
+                                                            "Rmin", "r1", "r2", "C",
+                                                "gmodels", "A", "a"});
+        }))
+      .def_property_readonly("n", &ChabocheVoceRecovery::n, "Number of backstresses")
+      ;
 }
 
 } // namespace neml

--- a/src/interpolate_wrap.cxx
+++ b/src/interpolate_wrap.cxx
@@ -96,6 +96,14 @@ PYBIND11_MODULE(interpolate, m) {
                                                            {"V0", "D", "T0"});
         }))
       ;
+
+  py::class_<MTSInterpolate, Interpolate, std::shared_ptr<MTSInterpolate>>(m, "MTSInterpolate")
+      .def(py::init([](py::args args, py::kwargs kwargs)
+        {
+          return create_object_python<MTSInterpolate>(args, kwargs, 
+                  {"tau0", "g0", "q", "p", "k", "b", "mu"});
+        }))
+      ;
 }
 
 } // namespace neml

--- a/test/test_hardening.py
+++ b/test/test_hardening.py
@@ -529,3 +529,42 @@ class TestChabocheTempTerm(unittest.TestCase, CommonNonAssociative):
     for i in range(self.n):
       hist[1+i*6:1+(i+1)*6] = make_dev(hist[1+i*6:1+(i+1)*6])
     return hist
+
+class TestChabocheSpecializedRecovery(unittest.TestCase, CommonNonAssociative):
+  """
+    Test ChabocheVoceRecovery, a Chaboche model with a specialized, recoverable
+    isotropic hardening term
+  """
+  def setUp(self):
+    s0 = 200.0
+    theta0 = 2000.0
+    Rmax = 100.0
+    Rmin = 10.0
+    r1 = 1.0e-8
+    r2 = 4.1
+
+    self.n = 2
+    cvals1 = [1000.0,10.0]
+    cvals2 = [100.0,100.0]
+    Ts = [0.0,1000.0]
+
+    cs = [interpolate.PiecewiseLinearInterpolate(Ts, [ci,cj]) for ci,cj in zip(cvals1, cvals2)]
+    rs = [1.0e-2,1.0]
+    gammas = [hardening.ConstantGamma(r) for r in rs]
+    self.As = [1.0e-6] * self.n
+    self.ns = [2.1] * self.n
+
+    self.model = hardening.ChabocheVoceRecovery(s0, theta0, Rmax, Rmin, r1, r2, cs, gammas, self.As, self.ns)
+
+    self.hist0 = np.zeros((1 + self.n*6,))
+    self.conform = 7
+
+    self.T = 300.0
+  
+  def gen_hist(self):
+    hist = np.array(range(1,2+self.n*6)) / (3*self.n)
+    hist[0] = 50.0
+    hist[1:] = (1.0 - 2.0 * hist[1:]) * 100.0
+    for i in range(self.n):
+      hist[1+i*6:1+(i+1)*6] = make_dev(hist[1+i*6:1+(i+1)*6])
+    return hist

--- a/test/test_interpolate.py
+++ b/test/test_interpolate.py
@@ -163,7 +163,7 @@ class TestPowerLawInterpolate(unittest.TestCase, BaseInterpolate):
     self.assertTrue(np.isclose(self.A * self.x**self.B, 
       self.interpolate(self.x)))
 
-class TestMTSInterpolate(unittest.TestCase, BaseInterpolate):
+class TestMTSShearInterpolate(unittest.TestCase, BaseInterpolate):
   def setUp(self):
     self.y0 = 100.0
     self.D = 50.0
@@ -175,5 +175,28 @@ class TestMTSInterpolate(unittest.TestCase, BaseInterpolate):
 
   def test_interpolate(self):
     should = self.y0 - self.D / (np.exp(self.x0 / self.x) - 1.0)
+    act = self.interpolate(self.x)
+    self.assertTrue(np.isclose(should, act))
+
+class TestMTSInterpolate(unittest.TestCase, BaseInterpolate):
+  def setUp(self):
+    self.tau0 = 300.0
+    self.g0 = 0.75
+
+    E_poly = np.array([-3.94833389e-02, -5.20197047e+01, 1.95594836e+05])
+    nu = 0.31
+    self.mu = interpolate.PolynomialInterpolate(E_poly/(2*(1+nu)))
+    self.k = 1.38064e-20
+    self.b = 2.02e-7
+
+    self.p = 0.8
+    self.q = 0.9
+
+    self.interpolate = interpolate.MTSInterpolate(self.tau0, self.g0, self.q, self.p, self.k, self.b, self.mu)
+
+    self.x = 300.0
+
+  def test_interpolate(self):
+    should = self.tau0 * (1.0- (self.k*self.x/(self.mu(self.x)*self.b**3.0*self.g0))**(1.0/self.q))**(1.0/self.p) 
     act = self.interpolate(self.x)
     self.assertTrue(np.isclose(should, act))


### PR DESCRIPTION
This PR adds a specialized variant of the Chaboche model which can be used "one-to-one" with parameters coming from pyoptmat fits.  The only changes versus our standard Chaboche kinematic + Voce isotropic hardening are:

1. Reparameterization of the Voce model
2. Static recovery on the Voce isotropic strength
3. Slight change in the definition of static recovery for the Chaboche kinematic backstress terms.