### PR TITLE
Fixes bug in new CrystalOrientation class

### DIFF
--- a/examples/cp/cpmodel.xml
+++ b/examples/cp/cpmodel.xml
@@ -1,6 +1,6 @@
 <materials>
   <example type="SingleCrystalModel">
-    <initial_rotation type="Orientation">
+    <initial_rotation type="CrystalOrientation">
       <angles>-81.3 128.8 146.7</angles>
       <angle_type>degrees</angle_type>
     </initial_rotation>
@@ -31,7 +31,7 @@
     </lattice>
   </example>
   <tvm type="SingleCrystalModel">
-    <initial_rotation type="Orientation">
+    <initial_rotation type="CrystalOrientation">
       <angles>-81.3 128.8 146.7</angles>
       <angle_type>degrees</angle_type>
     </initial_rotation>

--- a/examples/rate_independent.py
+++ b/examples/rate_independent.py
@@ -30,8 +30,7 @@ if __name__ == "__main__":
   hrule = hardening.Chaboche(iso, c, gmodels, As, ns)
 
   flow = ri_flow.RateIndependentNonAssociativeHardening(surface, hrule)
-  model = models.SmallStrainRateIndependentPlasticity(elastic, flow, verbose = False,
-      check_kt = False)
+  model = models.SmallStrainRateIndependentPlasticity(elastic, flow)
   
   
   # Uniaxial stress/strain curves at decades of strain rates

--- a/include/math/rotations.h
+++ b/include/math/rotations.h
@@ -243,10 +243,26 @@ NEML_EXPORT Orientation operator*(const Orientation & lhs, const Orientation & r
 /// Compose a rotation with the inverse of a rotation
 NEML_EXPORT Orientation operator/(const Orientation & lhs, const Orientation & rhs);
 
+class NEML_EXPORT CrystalOrientation : public NEMLObject, public Orientation { 
+ public:
+  CrystalOrientation(ParameterSet & params);
+
+  /// Type for the object system
+  static std::string type();
+  /// Parameters for the object system
+  static ParameterSet parameters();
+  /// Setup from a ParameterSet
+  static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
+};
+
+static Register<CrystalOrientation> regCrystalOrientation;
+
+std::shared_ptr<CrystalOrientation> zero_orientation();
+
 /// Generate n random orientations
 //    This algorithm comes from LaValle, 2006 who I believe grabbed it
 //    from Shoemake, 1992
-NEML_EXPORT std::vector<Orientation> random_orientations(int n);
+NEML_EXPORT std::vector<CrystalOrientation> random_orientations(int n);
 
 /// Exponential map of a skew tensor in my convention
 NEML_EXPORT Orientation wexp(const Skew & w);
@@ -263,21 +279,8 @@ NEML_EXPORT Orientation rotate_to(const Vector & a, const Vector & b);
 /// Family of rotations from a to b parameterized by an angle
 NEML_EXPORT Orientation rotate_to_family(const Vector & a, const Vector & b, double ang);
 
-class NEML_EXPORT CrystalOrientation : public NEMLObject, public Orientation { 
- public:
-  CrystalOrientation(ParameterSet & params);
-
-  /// Type for the object system
-  static std::string type();
-  /// Parameters for the object system
-  static ParameterSet parameters();
-  /// Setup from a ParameterSet
-  static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
-};
-
-static Register<CrystalOrientation> regCrystalOrientation;
-
-std::shared_ptr<CrystalOrientation> zero_orientation();
+/// Convert an orientation to a crystal orientation
+NEML_EXPORT CrystalOrientation make_crystal_orientation(const Orientation & o);
 
 } // namespace neml
 

--- a/src/math/rotations.cxx
+++ b/src/math/rotations.cxx
@@ -970,11 +970,11 @@ double Orientation::distance(const Orientation & other) const
   return acos(d);
 }
 
-std::vector<Orientation> random_orientations(int n)
+std::vector<CrystalOrientation> random_orientations(int n)
 {
   double u[3];
   double w, x, y, z;
-  std::vector<Orientation> result;
+  std::vector<CrystalOrientation> result;
 
   std::random_device rdev{};
   std::default_random_engine generator{rdev()};
@@ -990,7 +990,7 @@ std::vector<Orientation> random_orientations(int n)
     y = sqrt(u[0]) * sin(2.0 * M_PI * u[2]);
     z = sqrt(u[0]) * cos(2.0 * M_PI * u[2]);
 
-    result.emplace_back(Orientation({w,x,y,z}));
+    result.emplace_back(make_crystal_orientation(Orientation({w,x,y,z})));
   }
 
   return result;
@@ -1087,6 +1087,16 @@ std::shared_ptr<CrystalOrientation> zero_orientation()
   params.assign_parameter("angles", std::vector<double>({0,0,0}));
 
   return std::make_shared<CrystalOrientation>(params);
+}
+
+CrystalOrientation make_crystal_orientation(const Orientation & o)
+{
+  ParameterSet params = CrystalOrientation::parameters();
+  double a, b, c;
+  o.to_euler(a, b, c);
+  params.assign_parameter("angles", std::vector<double>({a,b,c}));
+
+  return CrystalOrientation(params);
 }
 
 } // namespace cpfmwk


### PR DESCRIPTION
The CP classes now take a subclass of `Orientation` called `CrystalOrientation` as input, rather than `Orientation`.  This change required updating the XML files in the examples plus the `generate_random_orientations` routien.