### PR TITLE
Creates various options for elastic predictors in the crystal model

### DIFF
--- a/include/cp/kinematics.h
+++ b/include/cp/kinematics.h
@@ -145,7 +145,9 @@ class NEML_EXPORT KinematicModel: public NEMLObject {
 
   /// Helper to predict an elastic stress increment
   virtual Symmetric stress_increment(const Symmetric & stress,
-                                     const Symmetric & D, double dt, 
+                                     const Symmetric & D, 
+                                     const Skew & W,
+                                     double dt, 
                                      Lattice & lattice,
                                      const Orientation & Q,
                                      const History & history,
@@ -271,7 +273,9 @@ class NEML_EXPORT StandardKinematicModel: public KinematicModel {
   
   /// Helper to predict an elastic stress increment
   virtual Symmetric stress_increment(const Symmetric & stress,
-                                     const Symmetric & D, double dt, 
+                                     const Symmetric & D,
+                                     const Skew & W,
+                                     double dt, 
                                      Lattice & lattice,
                                      const Orientation & Q,
                                      const History & history,
@@ -373,7 +377,9 @@ class NEML_EXPORT DamagedStandardKinematicModel: public StandardKinematicModel {
 
   /// Helper to predict an elastic stress increment
   virtual Symmetric stress_increment(const Symmetric & stress,
-                                     const Symmetric & D, double dt, 
+                                     const Symmetric & D,
+                                     const Skew & W, 
+                                     double dt, 
                                      Lattice & lattice,
                                      const Orientation & Q,
                                      const History & history,

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -178,6 +178,7 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   size_t static_size_;
 
   bool elastic_predictor_, fallback_elastic_predictor_;
+  int force_divide_;
 };
 
 static Register<SingleCrystalModel> regSingleCrystalModel;

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -179,6 +179,7 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
 
   bool elastic_predictor_, fallback_elastic_predictor_;
   int force_divide_;
+  bool elastic_predictor_first_step_;
 };
 
 static Register<SingleCrystalModel> regSingleCrystalModel;

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -21,17 +21,19 @@ class CrystalPostprocessor; // forward declaration
 /// Store the trial state for the single crystal model
 class SCTrialState: public TrialState {
  public:
-  SCTrialState(const Symmetric & d, const Skew & w, const Symmetric & S, const
-               History & H, const Orientation & Q, const Lattice & lattice,
+  SCTrialState(const Symmetric & d, const Skew & w, const Symmetric & S, 
+               const Symmetric & S_n, const History & H, 
+               const Orientation & Q, const Lattice & lattice,
                double T, double dt,
                const History & fixed) :
-      d(d), w(w), S(S), history(H), Q(Q), lattice(lattice), T(T), dt(dt),
+      d(d), w(w), S(S), S_n(S_n), history(H), Q(Q), lattice(lattice), T(T), dt(dt),
       fixed(fixed)
   {};
 
   Symmetric d;
   Skew w;
   Symmetric S;
+  Symmetric S_n;
   History history;
   Orientation Q;
   Lattice lattice;
@@ -174,6 +176,8 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   std::vector<std::shared_ptr<CrystalPostprocessor>> postprocessors_;
   std::vector<std::string> static_names_;
   size_t static_size_;
+
+  bool elastic_predictor_, fallback_elastic_predictor_;
 };
 
 static Register<SingleCrystalModel> regSingleCrystalModel;

--- a/src/cp/kinematics.cxx
+++ b/src/cp/kinematics.cxx
@@ -270,11 +270,15 @@ Symmetric StandardKinematicModel::elastic_strains(
 
 Symmetric StandardKinematicModel::stress_increment(
     const Symmetric & stress,
-    const Symmetric & D, double dt, Lattice & lattice, const Orientation & Q,
+    const Symmetric & D, const Skew & W, double dt, Lattice & lattice, const Orientation & Q,
     const History & history, double T)
 {
   SymSymR4 C = emodel_->C(T,Q);
-  return C.dot(D*dt);
+  SymSymR4 S = emodel_->S(T,Q);
+  Symmetric e = S.dot(stress);
+  Skew O_s = W;
+  Symmetric net = Symmetric(e*O_s - O_s*e);
+  return C.dot(D - net) * dt;
 }
 
 bool StandardKinematicModel::use_nye() const
@@ -590,7 +594,7 @@ Symmetric DamagedStandardKinematicModel::elastic_strains(
 
 Symmetric DamagedStandardKinematicModel::stress_increment(
     const Symmetric & stress,
-    const Symmetric & D, double dt, Lattice & lattice, const Orientation & Q,
+    const Symmetric & D, const Skew & W, double dt, Lattice & lattice, const Orientation & Q,
     const History & history, double T)
 {
   SymSymR4 C = emodel_->C(T,Q);

--- a/src/cp/singlecrystal.cxx
+++ b/src/cp/singlecrystal.cxx
@@ -18,7 +18,8 @@ SingleCrystalModel::SingleCrystalModel(ParameterSet & params) :
     stored_hist_(false),
     postprocessors_(params.get_object_parameter_vector<CrystalPostprocessor>("postprocessors")),
     elastic_predictor_(params.get_parameter<bool>("elastic_predictor")),
-    fallback_elastic_predictor_(params.get_parameter<bool>("fallback_elastic_predictor"))
+    fallback_elastic_predictor_(params.get_parameter<bool>("fallback_elastic_predictor")),
+    force_divide_(params.get_parameter<int>("force_divide"))
 {
   populate_history(stored_hist_);
   
@@ -56,6 +57,7 @@ ParameterSet SingleCrystalModel::parameters()
   pset.add_optional_parameter<std::vector<NEMLObject>>("postprocessors", {});
   pset.add_optional_parameter<bool>("elastic_predictor", false);
   pset.add_optional_parameter<bool>("fallback_elastic_predictor", true);
+  pset.add_optional_parameter<int>("force_divide", 0);
 
   return pset;
 }
@@ -214,9 +216,9 @@ int SingleCrystalModel::attempt_update_ld_inc_(
   /* Begin adaptive stepping */
   double dT = T_np1 - T_n;
   int progress = 0;
-  int cur_int_inc = pow(2, max_divide_);
-  int target = cur_int_inc;
-  int subdiv = 0;
+  int cur_int_inc = pow(2, max_divide_-force_divide_);
+  int target = pow(2, max_divide_);
+  int subdiv = force_divide_;
 
   // Use S_np1 and H_np1 to iterate
   S_np1.copy_data(S_n.data());

--- a/src/cp/singlecrystal_wrap.cxx
+++ b/src/cp/singlecrystal_wrap.cxx
@@ -16,7 +16,7 @@ PYBIND11_MODULE(singlecrystal, m) {
   m.doc() = "Single crystal constitutive models";
 
   py::class_<SCTrialState, TrialState>(m, "SCTrialState")
-      .def(py::init<Symmetric&,Skew&,Symmetric&,History&,Orientation&,Lattice&,double,double,History&>())
+      .def(py::init<Symmetric&,Skew&,Symmetric&,Symmetric&,History&,Orientation&,Lattice&,double,double,History&>())
       ;
 
   py::class_<SingleCrystalModel, NEMLModel_ldi, Solvable, std::shared_ptr<SingleCrystalModel>>(m, "SingleCrystalModel")

--- a/test/test_crystalmodels.py
+++ b/test/test_crystalmodels.py
@@ -135,7 +135,7 @@ class TestSingleCrystal(unittest.TestCase, CommonTangents, CommonSolver):
     self.fixed = self.kmodel.decouple(self.S_n, self.D, self.W, self.Q, 
         self.H_n, self.L, self.T, history.History())
 
-    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
+    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
         self.fixed)
 
     self.x = np.zeros((self.model.nparams,))
@@ -291,7 +291,7 @@ class TestComplicatedCrystal(unittest.TestCase, CommonTangents, CommonSolver):
     self.fixed = self.kmodel.decouple(self.S_n, self.D, self.W, self.Q, self.H_n, self.L, self.T,
         history.History())
 
-    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
+    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
         self.fixed)
 
     self.x = np.zeros((self.model.nparams,))
@@ -376,7 +376,7 @@ class TestNyeStuffCrystal(unittest.TestCase):
     self.fixed = self.kmodel.decouple(self.S_n, self.D, self.W, self.Q, 
         self.H_n, self.L, self.T, history.History())
 
-    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
+    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
         self.fixed)
 
     self.x = np.zeros((self.model.nparams,))
@@ -490,7 +490,7 @@ class TestFakeDamagedCrystal(unittest.TestCase, CommonTangents, CommonSolver):
     self.fixed = self.kmodel.decouple(self.S_n, self.D, self.W, self.Q, self.H_n, self.L, self.T,
         history.History())
 
-    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
+    self.ts = singlecrystal.SCTrialState(self.D, self.W, self.S_n, self.S_n, self.H_n, self.Q, self.L, self.T, self.dt,
         self.fixed)
 
     self.x = np.zeros((self.model.nparams,))


### PR DESCRIPTION
This PR:

- Corrects the bug with elastic predictors in the crystal models
- Adds various switches to allow the user to apply an elastic predictor