### PR TITLE
Remove error codes from the library

### DIFF
--- a/include/block.h
+++ b/include/block.h
@@ -8,7 +8,7 @@ namespace neml {
 //  Update an entire block of models
 //  Input data must be in row major order (i.e. nblock is the first axes)
 //  Input and output must be as full tensors (not Mandel vectors)
-NEML_EXPORT int block_evaluate(
+NEML_EXPORT void block_evaluate(
     std::shared_ptr<NEMLModel> model,
     size_t nblock,
     const double * const e_np1, const double * const e_n,

--- a/include/cp/batch.h
+++ b/include/cp/batch.h
@@ -9,7 +9,7 @@
 
 namespace neml {
 
-NEML_EXPORT int evaluate_crystal_batch(SingleCrystalModel & model, size_t n,
+NEML_EXPORT void evaluate_crystal_batch(SingleCrystalModel & model, size_t n,
                            const double * const d_np1, const double * const d_n,
                            const double * const w_np1, const double * const w_n,
                            const double * const T_np1, const double * const T_n,
@@ -20,11 +20,11 @@ NEML_EXPORT int evaluate_crystal_batch(SingleCrystalModel & model, size_t n,
                            double * const u_np1, const double * const u_n,
                            double * const p_np1, const double * const p_n,
                            int nthreads = 1);
-NEML_EXPORT int init_history_batch(SingleCrystalModel & model, size_t n, double * const hist);
-NEML_EXPORT int set_orientation_passive_batch(SingleCrystalModel & model, size_t n,
+NEML_EXPORT void init_history_batch(SingleCrystalModel & model, size_t n, double * const hist);
+NEML_EXPORT void set_orientation_passive_batch(SingleCrystalModel & model, size_t n,
                                   double * const hist,
                                   std::vector<Orientation> orientations);
-NEML_EXPORT int get_orientation_passive_batch(SingleCrystalModel & model, size_t n,
+NEML_EXPORT void get_orientation_passive_batch(SingleCrystalModel & model, size_t n,
                                   double * const hist,
                                   std::vector<Orientation> & orientations);
 

--- a/include/cp/polycrystal.h
+++ b/include/cp/polycrystal.h
@@ -50,7 +50,7 @@ class NEML_EXPORT TaylorModel: public PolycrystalModel
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   virtual size_t nstore() const;
-  virtual int init_store(double * const store) const;
+  virtual void init_store(double * const store) const;
 
   /// Large strain incremental update
   virtual int update_ld_inc(

--- a/include/cp/polycrystal.h
+++ b/include/cp/polycrystal.h
@@ -17,7 +17,7 @@ class NEML_EXPORT PolycrystalModel: public NEMLModel_ldi
   size_t n() const;
 
   virtual size_t nhist() const;
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 
   double * history(double * const store, size_t i) const;
   double * stress(double * const store, size_t i) const;
@@ -53,7 +53,7 @@ class NEML_EXPORT TaylorModel: public PolycrystalModel
   virtual void init_store(double * const store) const;
 
   /// Large strain incremental update
-  virtual int update_ld_inc(
+  virtual void update_ld_inc(
      const double * const d_np1, const double * const d_n,
      const double * const w_np1, const double * const w_n,
      double T_np1, double T_n,
@@ -65,7 +65,7 @@ class NEML_EXPORT TaylorModel: public PolycrystalModel
      double & p_np1, double p_n);
 
   virtual double alpha(double T) const;
-  virtual int elastic_strains(const double * const s_np1,
+  virtual void elastic_strains(const double * const s_np1,
                               double T_np1, const double * const h_np1,
                               double * const e_np1) const;
 };

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -71,7 +71,7 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
           double * Fe) const;
   
   /// Large deformation incremental update
-  virtual int update_ld_inc(
+  virtual void update_ld_inc(
        const double * const d_np1, const double * const d_n,
        const double * const w_np1, const double * const w_n,
        double T_np1, double T_n,
@@ -85,13 +85,13 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   /// Number of stored history variables
   virtual size_t nhist() const;
   /// Initialize history raw pointer array
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 
   /// Instantaneous CTE
   virtual double alpha(double T) const;
 
   /// Helper to calculate the elastic strain
-  virtual int elastic_strains(const double * const s_np1,
+  virtual void elastic_strains(const double * const s_np1,
                                double T_np1, const double * const h_np1,
                                double * const e_np1) const;
 
@@ -128,7 +128,7 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   void update_nye(double * const hist, const double * const nye) const;
 
  private:
-  int attempt_update_ld_inc_(
+  void attempt_update_ld_inc_(
        const double * const d_np1, const double * const d_n,
        const double * const w_np1, const double * const w_n,
        double T_np1, double T_n,
@@ -154,7 +154,7 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
                         const Orientation & Q_n, const History & H_np1,
                         const History & H_n) const;
 
-  int solve_substep_(SCTrialState * ts, Symmetric & stress, History & hist);
+  void solve_substep_(SCTrialState * ts, Symmetric & stress, History & hist);
 
   std::vector<std::string> not_updated_() const;
 

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -98,9 +98,9 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   /// Number of nonlinear equations to solve in the integration
   virtual size_t nparams() const;
   /// Setup an initial guess for the nonlinear solution
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// Integration residual and jacobian equations
-  virtual int RJ(const double * const x, TrialState * ts, double * const R,
+  virtual void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J);
 
   /// Get the current orientation in the active convention (raw ptr history)

--- a/include/creep.h
+++ b/include/creep.h
@@ -16,19 +16,19 @@ class NEML_EXPORT ScalarCreepRule: public NEMLObject {
    ScalarCreepRule(ParameterSet & params);
    /// Scalar creep strain rate as a function of effective stress,
    /// effective strain, time, and temperature
-   virtual int g(double seq, double eeq, double t, double T, double & g)
+   virtual void g(double seq, double eeq, double t, double T, double & g)
        const = 0;
    /// Derivative of scalar creep rate wrt effective stress
-   virtual int dg_ds(double seq, double eeq, double t, double T, double & dg)
+   virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
        const = 0;
    /// Derivative of scalar creep rate wrt effective strain
-   virtual int dg_de(double seq, double eeq, double t, double T, double & dg)
+   virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
        const = 0;
    /// Derivative of scalar creep rate wrt time, defaults to zero
-   virtual int dg_dt(double seq, double eeq, double t, double T, double & dg)
+   virtual void dg_dt(double seq, double eeq, double t, double T, double & dg)
        const;
    /// Derivative of scalar creep rate wrt temperature, defaults to zero
-   virtual int dg_dT(double seq, double eeq, double t, double T, double & dg)
+   virtual void dg_dT(double seq, double eeq, double t, double T, double & dg)
        const;
 };
 
@@ -45,15 +45,15 @@ class NEML_EXPORT BlackburnMinimumCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = A * (sinh(beta*s/n)^n * exp(-Q/(R*T))
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
       const;
   /// Derivative of rate wrt effective strain = 0
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
       const;
   /// Derivative of rate wrt temperature
-  virtual int dg_dT(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_dT(double seq, double eeq, double t, double T, double & dg)
       const;
 
  private:
@@ -76,15 +76,15 @@ class NEML_EXPORT SwindemanMinimumCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = C * S^n * exp(V*S) * exp(-Q/T)
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
       const;
   /// Derivative of rate wrt effective strain = 0
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
       const;
   /// Derivative of rate wrt temperature
-  virtual int dg_dT(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_dT(double seq, double eeq, double t, double T, double & dg)
       const;
 
  private:
@@ -107,12 +107,12 @@ class NEML_EXPORT PowerLawCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = A * seq**n
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
       const;
   /// Derivative of rate wrt effective strain = 0
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
       const;
 
   /// Getter for the prefactor
@@ -140,12 +140,12 @@ class NEML_EXPORT NormalizedPowerLawCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = (seq/s0)**n
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
       const;
   /// Derivative of rate wrt effective strain = 0
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
       const;
 
  private:
@@ -170,11 +170,11 @@ class NEML_EXPORT RegionKMCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// See documentation for details of the creep rate
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of creep rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
   /// Derivative of creep rate wrt effective strain
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
 
  private:
   void select_region_(double seq, double T, double & Ai, double & Bi) const;
@@ -204,11 +204,11 @@ class NEML_EXPORT NortonBaileyCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// creep rate = m * A**(1/m) * seq**(n/m) * eeq ** ((m-1)/m)
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of creep rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
   /// Derivative of creep rate wrt effective strain
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
 
   /// Getter for the prefactor
   double A(double T) const;
@@ -240,11 +240,11 @@ class NEML_EXPORT MukherjeeCreep: public ScalarCreepRule {
 
   /// scalar creep rate = A * D0 * exp(Q / (RT)) * mu * b / (k * T) *
   /// (seq / mu)**n
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of creep rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
   /// Derivative of creep rate wrt effective strain
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
 
   /// Getter for A
   double A() const;
@@ -282,11 +282,11 @@ class NEML_EXPORT GenericCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// scalar creep rate = exp(f(log(sigma)))
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of creep rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
   /// Derivative of creep rate wrt effective strain
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
 
  private:
   const std::shared_ptr<Interpolate> cfn_;
@@ -309,12 +309,12 @@ class NEML_EXPORT MinCreep225Cr1MoCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// See documentation for the hideous formula
-  virtual int g(double seq, double eeq, double t, double T, double & g) const;
+  virtual void g(double seq, double eeq, double t, double T, double & g) const;
   /// Derivative of rate wrt effective stress
-  virtual int dg_ds(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
       const;
   /// Derivative of rate wrt effective strain = 0
-  virtual int dg_de(double seq, double eeq, double t, double T, double & dg)
+  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
       const;
 
  private:
@@ -347,30 +347,30 @@ class NEML_EXPORT CreepModel: public NEMLObject, public Solvable {
   CreepModel(ParameterSet & params);
 
   /// Use the creep rate function to update the creep strain
-  int update(const double * const s_np1,
+  void update(const double * const s_np1,
              double * const e_np1, const double * const e_n,
              double T_np1, double T_n,
              double t_np1, double t_n,
              double * const A_np1);
 
   /// The creep rate as a function of stress, strain, time, and temperature
-  virtual int f(const double * const s, const double * const e, double t, double T,
+  virtual void f(const double * const s, const double * const e, double t, double T,
                 double * const f) const = 0;
   /// The derivative of the creep rate wrt stress
-  virtual int df_ds(const double * const s, const double * const e, double t, double T,
+  virtual void df_ds(const double * const s, const double * const e, double t, double T,
                 double * const df) const = 0;
   /// The derivative of the creep rate wrt strain
-  virtual int df_de(const double * const s, const double * const e, double t, double T,
+  virtual void df_de(const double * const s, const double * const e, double t, double T,
                 double * const df) const = 0;
   /// The derivative of the creep rate wrt time, defaults to zero
-  virtual int df_dt(const double * const s, const double * const e, double t, double T,
+  virtual void df_dt(const double * const s, const double * const e, double t, double T,
                 double * const df) const;
   /// The derivative of the creep rate wrt temperature, defaults to zero
-  virtual int df_dT(const double * const s, const double * const e, double t, double T,
+  virtual void df_dT(const double * const s, const double * const e, double t, double T,
                 double * const df) const;
 
   /// Setup a trial state for the solver
-  int make_trial_state(const double * const s_np1,
+  void make_trial_state(const double * const s_np1,
                        const double * const e_n,
                        double T_np1, double T_n,
                        double t_np1, double t_n,
@@ -379,13 +379,13 @@ class NEML_EXPORT CreepModel: public NEMLObject, public Solvable {
   /// Number of solver parameters
   virtual size_t nparams() const;
   /// Setup the initial guess for the solver
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// The nonlinear residual and jacobian to solve
-  virtual int RJ(const double * const x, TrialState * ts, double * const R,
+  virtual void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J);
 
  private:
-  int calc_tangent_(const double * const e_np1, CreepModelTrialState & ts,
+  void calc_tangent_(const double * const e_np1, CreepModelTrialState & ts,
                     double * const A_np1);
 
  protected:
@@ -410,27 +410,27 @@ class NEML_EXPORT J2CreepModel: public CreepModel {
 
   /// creep_rate = dev(s) / ||dev(s)|| * scalar(effective_strain,
   /// effective_stress, time, temperature)
-  virtual int f(const double * const s, const double * const e, double t, double T,
+  virtual void f(const double * const s, const double * const e, double t, double T,
                 double * const f) const;
   /// Derivative of creep rate wrt stress
-  virtual int df_ds(const double * const s, const double * const e, double t, double T,
+  virtual void df_ds(const double * const s, const double * const e, double t, double T,
                 double * const df) const;
   /// Derivative of creep rate wrt strain
-  virtual int df_de(const double * const s, const double * const e, double t, double T,
+  virtual void df_de(const double * const s, const double * const e, double t, double T,
                 double * const df) const;
   /// Derivative of creep rate wrt time
-  virtual int df_dt(const double * const s, const double * const e, double t, double T,
+  virtual void df_dt(const double * const s, const double * const e, double t, double T,
                 double * const df) const;
   /// Derivative of creep rate wrt temperature
-  virtual int df_dT(const double * const s, const double * const e, double t, double T,
+  virtual void df_dT(const double * const s, const double * const e, double t, double T,
                 double * const df) const;
 
  private:
   // Helpers for computing the above
   double seq(const double * const s) const;
   double eeq(const double * const e) const;
-  int sdir(double * const s) const;
-  int edir(double * const e) const;
+  void sdir(double * const s) const;
+  void edir(double * const e) const;
 
  private:
   std::shared_ptr<ScalarCreepRule> rule_;

--- a/include/damage.h
+++ b/include/damage.h
@@ -21,10 +21,10 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
   virtual size_t nhist() const;
   /// Initialize base according to the base model and damage according to
   /// init_damage
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 
   /// The damaged stress update
-  virtual int update_sd(
+  virtual void update_sd(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -37,10 +37,10 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
   /// Number of damage variables
   virtual size_t ndamage() const = 0;
   /// Setup the damage variables
-  virtual int init_damage(double * const damage) const = 0;
+  virtual void init_damage(double * const damage) const = 0;
 
   /// Override the elastic model
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
  protected:
    std::shared_ptr<NEMLModel_sd> base_;
@@ -67,7 +67,7 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   NEMLScalarDamagedModel_sd(ParameterSet & params);
 
   /// Stress update using the scalar damage model
-  virtual int update_sd(
+  virtual void update_sd(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -80,7 +80,7 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   /// Equal to 1
   virtual size_t ndamage() const;
   /// Initialize to zero
-  virtual int init_damage(double * const damage) const;
+  virtual void init_damage(double * const damage) const;
 
   /// Number of parameters for the solver
   virtual size_t nparams() const;
@@ -100,28 +100,28 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   virtual double d_guess() const {return 0;};
 
   /// The scalar damage model
-  virtual int damage(double d_np1, double d_n,
+  virtual void damage(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const = 0;
   /// Derivative with respect to the damage variable
-  virtual int ddamage_dd(double d_np1, double d_n,
+  virtual void ddamage_dd(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const = 0;
   /// Derivative with respect to the strain
-  virtual int ddamage_de(double d_np1, double d_n,
+  virtual void ddamage_de(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const = 0;
   /// Derivative with respect to the stress
-  virtual int ddamage_ds(double d_np1, double d_n,
+  virtual void ddamage_ds(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
@@ -129,12 +129,12 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
                      double * const dd) const = 0;
 
  protected:
-  int tangent_(const double * const e_np1, const double * const e_n,
+  void tangent_(const double * const e_np1, const double * const e_n,
                const double * const s_np1, const double * const s_n,
                double T_np1, double T_n, double t_np1, double t_n,
                double w_np1, double w_n, const double * const A_prime,
                double * const A);
-  int ekill_update_(double T_np1, const double * const e_np1, 
+  void ekill_update_(double T_np1, const double * const e_np1, 
                     double * const s_np1, 
                     double * const h_np1, const double * const h_n,
                     double * A_np1, 
@@ -167,35 +167,35 @@ class NEML_EXPORT CombinedDamageModel_sd: public NEMLScalarDamagedModel_sd {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// The combined damage variable
-  virtual int damage(double d_np1, double d_n,
+  virtual void damage(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative with respect to damage
-  virtual int ddamage_dd(double d_np1, double d_n,
+  virtual void ddamage_dd(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative with respect to strain
-  virtual int ddamage_de(double d_np1, double d_n,
+  virtual void ddamage_de(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative with respect to stress
-  virtual int ddamage_ds(double d_np1, double d_n,
+  virtual void ddamage_ds(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
 
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
 
  protected:
@@ -220,28 +220,28 @@ class NEML_EXPORT ClassicalCreepDamageModel_sd: public NEMLScalarDamagedModel_sd
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// The damage function d_np1 = d_n + (se / A)**xi (1 - d_np1)**(-phi) * dt
-  virtual int damage(double d_np1, double d_n,
+  virtual void damage(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt damage
-  virtual int ddamage_dd(double d_np1, double d_n,
+  virtual void ddamage_dd(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt strain
-  virtual int ddamage_de(double d_np1, double d_n,
+  virtual void ddamage_de(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt stress
-  virtual int ddamage_ds(double d_np1, double d_n,
+  virtual void ddamage_ds(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
@@ -263,8 +263,8 @@ static Register<ClassicalCreepDamageModel_sd> regClassicalCreepDamageModel_sd;
 class NEML_EXPORT EffectiveStress: public NEMLObject {
  public:
   EffectiveStress(ParameterSet & params);
-  virtual int effective(const double * const s, double & eff) const = 0;
-  virtual int deffective(const double * const s, double * const deff) const = 0;
+  virtual void effective(const double * const s, double & eff) const = 0;
+  virtual void deffective(const double * const s, double * const deff) const = 0;
 };
 
 /// von Mises stress
@@ -280,8 +280,8 @@ class NEML_EXPORT VonMisesEffectiveStress: public EffectiveStress
   /// Initialize from a parameter set
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
-  virtual int effective(const double * const s, double & eff) const;
-  virtual int deffective(const double * const s, double * const deff) const;
+  virtual void effective(const double * const s, double & eff) const;
+  virtual void deffective(const double * const s, double * const deff) const;
 };
 
 static Register<VonMisesEffectiveStress> regVonMisesEffectiveStress;
@@ -299,8 +299,8 @@ class NEML_EXPORT MeanEffectiveStress: public EffectiveStress
   /// Initialize from a parameter set
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
-  virtual int effective(const double * const s, double & eff) const;
-  virtual int deffective(const double * const s, double * const deff) const;
+  virtual void effective(const double * const s, double & eff) const;
+  virtual void deffective(const double * const s, double * const deff) const;
 };
 
 static Register<MeanEffectiveStress> regMeanEffectiveStress;
@@ -318,8 +318,8 @@ class NEML_EXPORT HuddlestonEffectiveStress: public EffectiveStress
   /// Initialize from a parameter set
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
-  virtual int effective(const double * const s, double & eff) const;
-  virtual int deffective(const double * const s, double * const deff) const;
+  virtual void effective(const double * const s, double & eff) const;
+  virtual void deffective(const double * const s, double * const deff) const;
 
  private:
   double b_;
@@ -340,8 +340,8 @@ class NEML_EXPORT MaxPrincipalEffectiveStress: public EffectiveStress
   /// Initialize from a parameter set
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
-  virtual int effective(const double * const s, double & eff) const;
-  virtual int deffective(const double * const s, double * const deff) const;
+  virtual void effective(const double * const s, double & eff) const;
+  virtual void deffective(const double * const s, double * const deff) const;
 };
 
 static Register<MaxPrincipalEffectiveStress> regMaxPrincipalEffectiveStress;
@@ -359,8 +359,8 @@ class NEML_EXPORT MaxSeveralEffectiveStress: public EffectiveStress
   /// Initialize from a parameter set
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
-  virtual int effective(const double * const s, double & eff) const;
-  virtual int deffective(const double * const s, double * const deff) const;
+  virtual void effective(const double * const s, double & eff) const;
+  virtual void deffective(const double * const s, double * const deff) const;
 
  private:
   void select_(const double * const s, size_t & ind, double & value) const;
@@ -384,8 +384,8 @@ class NEML_EXPORT SumSeveralEffectiveStress: public EffectiveStress
   /// Initialize from a parameter set
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
-  virtual int effective(const double * const s, double & eff) const;
-  virtual int deffective(const double * const s, double * const deff) const;
+  virtual void effective(const double * const s, double & eff) const;
+  virtual void deffective(const double * const s, double * const deff) const;
 
  private:
   std::vector<std::shared_ptr<EffectiveStress>> measures_;
@@ -411,28 +411,28 @@ class NEML_EXPORT ModularCreepDamageModel_sd: public NEMLScalarDamagedModel_sd {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// The damage function d_np1 = d_n + (se / A)**xi * (1-d_np1)**xi * (1 - d_np1)**(-phi) * dt
-  virtual int damage(double d_np1, double d_n,
+  virtual void damage(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt damage
-  virtual int ddamage_dd(double d_np1, double d_n,
+  virtual void ddamage_dd(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt strain
-  virtual int ddamage_de(double d_np1, double d_n,
+  virtual void ddamage_de(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt stress
-  virtual int ddamage_ds(double d_np1, double d_n,
+  virtual void ddamage_ds(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
@@ -461,28 +461,28 @@ class NEML_EXPORT LarsonMillerCreepDamageModel_sd: public NEMLScalarDamagedModel
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
   
   /// The damage function d_np1 = d_n + 1/tr(s*(1-w), T) * dt
-  virtual int damage(double d_np1, double d_n, 
+  virtual void damage(double d_np1, double d_n, 
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt damage
-  virtual int ddamage_dd(double d_np1, double d_n, 
+  virtual void ddamage_dd(double d_np1, double d_n, 
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt strain
-  virtual int ddamage_de(double d_np1, double d_n, 
+  virtual void ddamage_de(double d_np1, double d_n, 
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt stress
-  virtual int ddamage_ds(double d_np1, double d_n, 
+  virtual void ddamage_ds(double d_np1, double d_n, 
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
@@ -504,28 +504,28 @@ class NEML_EXPORT NEMLStandardScalarDamagedModel_sd: public NEMLScalarDamagedMod
   NEMLStandardScalarDamagedModel_sd(ParameterSet & params);
 
   /// Damage, now only proportional to the inelastic effective strain
-  virtual int damage(double d_np1, double d_n,
+  virtual void damage(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt damage
-  virtual int ddamage_dd(double d_np1, double d_n,
+  virtual void ddamage_dd(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt strain
-  virtual int ddamage_de(double d_np1, double d_n,
+  virtual void ddamage_de(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt stress
-  virtual int ddamage_ds(double d_np1, double d_n,
+  virtual void ddamage_ds(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
@@ -533,13 +533,13 @@ class NEML_EXPORT NEMLStandardScalarDamagedModel_sd: public NEMLScalarDamagedMod
                      double * const dd) const;
 
   /// The part of the damage rate proportional to the inelastic strain rate
-  virtual int f(const double * const s_np1, double d_np1,
+  virtual void f(const double * const s_np1, double d_np1,
                 double T_np1, double & f) const = 0;
   /// Derivative with respect to stress
-  virtual int df_ds(const double * const s_np1, double d_np1,
+  virtual void df_ds(const double * const s_np1, double d_np1,
                    double T_np1, double * const df) const = 0;
   /// Derivative with respect to damage
-  virtual int df_dd(const double * const s_np1, double d_np1,
+  virtual void df_dd(const double * const s_np1, double d_np1,
                    double T_np1, double & df) const = 0;
 
  protected:
@@ -567,28 +567,28 @@ class NEML_EXPORT NEMLWorkDamagedModel_sd: public NEMLScalarDamagedModel_sd {
   virtual double d_guess() const {return eps_;};
 
   /// damage rate = n * d**((n-1)/n) * W_dot / W_crit
-  virtual int damage(double d_np1, double d_n,
+  virtual void damage(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt damage
-  virtual int ddamage_dd(double d_np1, double d_n,
+  virtual void ddamage_dd(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt strain
-  virtual int ddamage_de(double d_np1, double d_n,
+  virtual void ddamage_de(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
                      double t_np1, double t_n,
                      double * const dd) const;
   /// Derivative of damage wrt stress
-  virtual int ddamage_ds(double d_np1, double d_n,
+  virtual void ddamage_ds(double d_np1, double d_n,
                      const double * const e_np1, const double * const e_n,
                      const double * const s_np1, const double * const s_n,
                      double T_np1, double T_n,
@@ -626,13 +626,13 @@ class NEML_EXPORT NEMLPowerLawDamagedModel_sd: public NEMLStandardScalarDamagedM
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Damage = A * s_eq**a (times the inelastic strain rate)
-  virtual int f(const double * const s_np1, double d_np1,
+  virtual void f(const double * const s_np1, double d_np1,
                 double T_np1, double & f) const;
   /// Derivative of f wrt stress
-  virtual int df_ds(const double * const s_np1, double d_np1, double T_np1,
+  virtual void df_ds(const double * const s_np1, double d_np1, double T_np1,
                 double * const df) const;
   /// Derivative of f wrt damage
-  virtual int df_dd(const double * const s_np1, double d_np1, double T_np1,
+  virtual void df_dd(const double * const s_np1, double d_np1, double T_np1,
                 double & df) const;
 
  protected:
@@ -661,13 +661,13 @@ class NEML_EXPORT NEMLExponentialWorkDamagedModel_sd: public NEMLStandardScalarD
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// damage rate is (d + k0)**af / W0 * s_eq
-  virtual int f(const double * const s_np1, double d_np1,
+  virtual void f(const double * const s_np1, double d_np1,
                 double T_np1, double & f) const;
   /// Derivative of damage wrt stress
-  virtual int df_ds(const double * const s_np1, double d_np1, double T_np1,
+  virtual void df_ds(const double * const s_np1, double d_np1, double T_np1,
                 double * const df) const;
   /// Derivative of damage wrt damage
-  virtual int df_dd(const double * const s_np1, double d_np1, double T_np1,
+  virtual void df_dd(const double * const s_np1, double d_np1, double T_np1,
                 double & df) const;
 
  protected:

--- a/include/damage.h
+++ b/include/damage.h
@@ -85,12 +85,12 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   /// Number of parameters for the solver
   virtual size_t nparams() const;
   /// Initialize the solver vector
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// The actual nonlinear residual and Jacobian to solve
-  virtual int RJ(const double * const x, TrialState * ts,double * const R,
+  virtual void RJ(const double * const x, TrialState * ts,double * const R,
                  double * const J);
   /// Setup a trial state from known information
-  int make_trial_state(const double * const e_np1, const double * const e_n,
+  void make_trial_state(const double * const e_np1, const double * const e_n,
                        double T_np1, double T_n, double t_np1, double t_n,
                        const double * const s_n, const double * const h_n,
                        double u_n, double p_n,

--- a/include/elasticity.h
+++ b/include/elasticity.h
@@ -22,9 +22,9 @@ class NEML_EXPORT LinearElasticModel: public NEMLObject {
   LinearElasticModel(ParameterSet & params);
 
   /// The stiffness tensor, in Mandel notation
-  virtual int C(double T, double * const Cv) const = 0;
+  virtual void C(double T, double * const Cv) const = 0;
   /// The compliance tensor, in Mandel notation
-  virtual int S(double T, double * const Sv) const = 0;
+  virtual void S(double T, double * const Sv) const = 0;
 
   /// The stiffness tensor in a tensor object
   SymSymR4 C(double T) const;
@@ -57,9 +57,9 @@ class NEML_EXPORT IsotropicLinearElasticModel: public LinearElasticModel {
   static ParameterSet parameters();
 
   /// Implement the stiffness tensor
-  virtual int C(double T, double * const Cv) const;
+  virtual void C(double T, double * const Cv) const;
   /// Implement the compliance tensor
-  virtual int S(double T, double * const Sv) const;
+  virtual void S(double T, double * const Sv) const;
 
   /// The Young's modulus
   virtual double E(double T) const;
@@ -69,8 +69,8 @@ class NEML_EXPORT IsotropicLinearElasticModel: public LinearElasticModel {
   virtual double K(double T) const;
 
  private:
-  int C_calc_(double G, double K, double * const Cv) const;
-  int S_calc_(double G, double K, double * const Sv) const;
+  void C_calc_(double G, double K, double * const Cv) const;
+  void S_calc_(double G, double K, double * const Sv) const;
 
   void get_GK_(double T, double & G, double & K) const;
 
@@ -95,9 +95,9 @@ class NEML_EXPORT CubicLinearElasticModel: public LinearElasticModel {
   static ParameterSet parameters();
 
   /// Implement the stiffness tensor
-  virtual int C(double T, double * const Cv) const;
+  virtual void C(double T, double * const Cv) const;
   /// Implement the compliance tensor
-  virtual int S(double T, double * const Sv) const;
+  virtual void S(double T, double * const Sv) const;
 
  private:
   void get_components_(double T, double & C1, double & C2, double & C3) const;
@@ -122,9 +122,9 @@ class NEML_EXPORT TransverseIsotropicLinearElasticModel: public LinearElasticMod
   static ParameterSet parameters();
 
   /// Implement the stiffness tensor
-  virtual int C(double T, double * const Cv) const;
+  virtual void C(double T, double * const Cv) const;
   /// Implement the compliance tensor
-  virtual int S(double T, double * const Sv) const;
+  virtual void S(double T, double * const Sv) const;
 
  private:
   void get_components_(double T, double & C11, double & C33, double & C12,

--- a/include/general_flow.h
+++ b/include/general_flow.h
@@ -19,62 +19,62 @@ class NEML_EXPORT GeneralFlowRule: public NEMLObject {
   /// Number of history variables
   virtual size_t nhist() const = 0;
   /// Initialize the history at time zero
-  virtual int init_hist(double * const h) = 0;
+  virtual void init_hist(double * const h) = 0;
 
   /// Stress rate
-  virtual int s(const double * const s, const double * const alpha,
+  virtual void s(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const sdot) = 0;
   /// Partial of stress rate wrt stress
-  virtual int ds_ds(const double * const s, const double * const alpha,
+  virtual void ds_ds(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot) = 0;
   /// Partial of stress rate wrt history
-  virtual int ds_da(const double * const s, const double * const alpha,
+  virtual void ds_da(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot) = 0;
   /// Partial of stress rate wrt strain rate
-  virtual int ds_de(const double * const s, const double * const alpha,
+  virtual void ds_de(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot) = 0;
 
   /// History rate
-  virtual int a(const double * const s, const double * const alpha,
+  virtual void a(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const adot) = 0;
   /// Partial of history rate wrt stress
-  virtual int da_ds(const double * const s, const double * const alpha,
+  virtual void da_ds(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot) = 0;
   /// Partial of history rate wrt history
-  virtual int da_da(const double * const s, const double * const alpha,
+  virtual void da_da(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot) = 0;
   /// Partial of history rate wrt strain rate
-  virtual int da_de(const double * const s, const double * const alpha,
+  virtual void da_de(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot) = 0;
 
   /// The implementation needs to define inelastic dissipation
-  virtual int work_rate(const double * const s, const double * const alpha,
+  virtual void work_rate(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double & p_rate);
 
   /// The implementation needs to define elastic strain
-  virtual int elastic_strains(const double * const s_np1, double T_np1,
+  virtual void elastic_strains(const double * const s_np1, double T_np1,
                               double * const e_np1) const = 0;
 
   /// Set a new elastic model
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
   /// Optional method for modifying the initial guess
   virtual void override_guess(double * const x);
@@ -97,62 +97,62 @@ class NEML_EXPORT TVPFlowRule : public GeneralFlowRule {
   /// Number of history variables
   virtual size_t nhist() const;
   /// Initialize history
-  virtual int init_hist(double * const h);
+  virtual void init_hist(double * const h);
 
   /// Stress rate
-  virtual int s(const double * const s, const double * const alpha,
+  virtual void s(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const sdot);
   /// Partial of stress rate wrt stress
-  virtual int ds_ds(const double * const s, const double * const alpha,
+  virtual void ds_ds(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot);
   /// Partial of stress rate wrt history
-  virtual int ds_da(const double * const s, const double * const alpha,
+  virtual void ds_da(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot);
   /// Partial of stress rate wrt strain rate
-  virtual int ds_de(const double * const s, const double * const alpha,
+  virtual void ds_de(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot);
 
   /// History rate
-  virtual int a(const double * const s, const double * const alpha,
+  virtual void a(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const adot);
   /// Partial of history rate wrt stress
-  virtual int da_ds(const double * const s, const double * const alpha,
+  virtual void da_ds(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot);
   /// Partial of history rate wrt history
-  virtual int da_da(const double * const s, const double * const alpha,
+  virtual void da_da(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot);
   /// Partial of history rate wrt strain rate
-  virtual int da_de(const double * const s, const double * const alpha,
+  virtual void da_de(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot);
 
   /// The implementation needs to define inelastic dissipation
-  virtual int work_rate(const double * const s, const double * const alpha,
+  virtual void work_rate(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double & p_rate);
 
   /// The implementation needs to define elastic strain
-  virtual int elastic_strains(const double * const s_np1, double T_np1,
+  virtual void elastic_strains(const double * const s_np1, double T_np1,
                               double * const e_np1) const;
 
   /// Set a new elastic model
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
   /// Override the initial guess
   virtual void override_guess(double * const x);

--- a/include/hardening.h
+++ b/include/hardening.h
@@ -21,11 +21,11 @@ class NEML_EXPORT HardeningRule: public NEMLObject {
   /// The number of history variables
   virtual size_t nhist() const = 0;
   /// Initialize the history
-  virtual int init_hist(double * const alpha) const = 0;
+  virtual void init_hist(double * const alpha) const = 0;
   /// The map between strain-like and stress-like variables
-  virtual int q(const double * const alpha, double T, double * const qv) const = 0;
+  virtual void q(const double * const alpha, double T, double * const qv) const = 0;
   /// The derivative of the map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const = 0;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const = 0;
 };
 
 /// Isotropic hardening rules
@@ -35,12 +35,12 @@ class NEML_EXPORT IsotropicHardeningRule: public HardeningRule {
   /// Number of strain-like history variable, defaults to 1
   virtual size_t nhist() const;
   /// Initialize the history, defaults to initializing one variable to 0.0
-  virtual int init_hist(double * const alpha) const;
+  virtual void init_hist(double * const alpha) const;
   /// Map between the strain variables and the single isotropic hardening
   /// parameter
-  virtual int q(const double * const alpha, double T, double * const qv) const = 0;
+  virtual void q(const double * const alpha, double T, double * const qv) const = 0;
   /// Derivative of the map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const = 0;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const = 0;
 };
 
 /// Linear, isotropic hardening
@@ -57,9 +57,9 @@ class NEML_EXPORT LinearIsotropicHardeningRule: public IsotropicHardeningRule {
   static ParameterSet parameters();
 
   /// q = -s0 - K * alpha[0]
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const;
 
   /// Getter for the yield stress
   double s0(double T) const;
@@ -89,9 +89,9 @@ class NEML_EXPORT InterpolatedIsotropicHardeningRule: public IsotropicHardeningR
   static ParameterSet parameters();
 
   /// q = -interpolate(T)
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of the map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const;
 
  private:
   const std::shared_ptr<const Interpolate> flow_;
@@ -115,9 +115,9 @@ class NEML_EXPORT VoceIsotropicHardeningRule: public IsotropicHardeningRule {
   static ParameterSet parameters();
 
   /// q = -s0 - R * (1 - exp(-d * alpha[0]))
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const;
 
   /// Getter for initial yield stress
   double s0(double T) const;
@@ -146,9 +146,9 @@ class NEML_EXPORT PowerLawIsotropicHardeningRule: public IsotropicHardeningRule 
   static ParameterSet parameters();
 
   /// q = -s0 - A * alpha[0]**n
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const;
 
  private:
   const std::shared_ptr<const Interpolate> s0_, A_, n_;
@@ -170,9 +170,9 @@ class NEML_EXPORT CombinedIsotropicHardeningRule: public IsotropicHardeningRule 
   static ParameterSet parameters();
 
   /// q = Sum(q_i(alpha))
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const;
 
   /// Getter on the number of combined rules
   size_t nrules() const;
@@ -191,12 +191,12 @@ class NEML_EXPORT KinematicHardeningRule: public HardeningRule {
   /// Number of history variables (6)
   virtual size_t nhist() const;
   /// Initialize the 6 backstress components to zero
-  virtual int init_hist(double * const alpha) const;
+  virtual void init_hist(double * const alpha) const;
 
   /// Map between the backstrain and the backstress
-  virtual int q(const double * const alpha, double T, double * const qv) const = 0;
+  virtual void q(const double * const alpha, double T, double * const qv) const = 0;
   /// Derivative of the map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const = 0;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const = 0;
 };
 
 /// Simple linear kinematic hardening
@@ -213,9 +213,9 @@ class NEML_EXPORT LinearKinematicHardeningRule: public KinematicHardeningRule {
   static ParameterSet parameters();
 
   /// q = -H * alpha[:6]
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of the map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const;
 
   /// Getter for the hardening coefficieint
   double H(double T) const;
@@ -242,11 +242,11 @@ class NEML_EXPORT CombinedHardeningRule: public HardeningRule {
   /// Sum of the two model nhists
   virtual size_t nhist() const;
   /// Call init_hist on each model
-  virtual int init_hist(double * const alpha) const;
+  virtual void init_hist(double * const alpha) const;
   /// q[0] = isotropic model, q[1:7] = kinematic model
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of the map
-  virtual int dq_da(const double * const alpha, double T, double * const dqv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const dqv) const;
 
  private:
   std::shared_ptr<IsotropicHardeningRule> iso_;
@@ -265,41 +265,41 @@ class NEML_EXPORT NonAssociativeHardening: public NEMLObject {
   virtual size_t nhist() const = 0; // How many internal variables it stores
 
   /// Initialize the strain-like variables
-  virtual int init_hist(double * const alpha) const = 0;
+  virtual void init_hist(double * const alpha) const = 0;
 
   /// Map from strain to stress
-  virtual int q(const double * const alpha, double T, double * const qv) const = 0;
+  virtual void q(const double * const alpha, double T, double * const qv) const = 0;
   /// Derivative of the map
-  virtual int dq_da(const double * const alpha, double T, double * const qv) const = 0;
+  virtual void dq_da(const double * const alpha, double T, double * const qv) const = 0;
 
   /// Hardening proportional to the equivalent inelastic strain
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const = 0;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const = 0;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const = 0;
 
   /// Hardening proportional to time
-  virtual int h_time(const double * const s, const double * const alpha, double T,
+  virtual void h_time(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_time wrt stress
-  virtual int dh_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_time wrt history
-  virtual int dh_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening proportional to the temperature rate
-  virtual int h_temp(const double * const s, const double * const alpha, double T,
+  virtual void h_temp(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_temp wrt stress
-  virtual int dh_ds_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_temp wrt history
-  virtual int dh_da_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 };
 
@@ -396,48 +396,48 @@ class NEML_EXPORT Chaboche: public NonAssociativeHardening {
   virtual size_t nhist() const; // How many internal variables it stores
 
   /// Initialize everything to zero
-  virtual int init_hist(double * const alpha) const;
+  virtual void init_hist(double * const alpha) const;
 
   /// Map the isotropic variable, map the backstresses
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of map
-  virtual int dq_da(const double * const alpha, double T, double * const qv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const qv) const;
 
   /// Hardening proportional to inelastic strain rate
   /// Assume associated isotropic hardening, each backstress is
   /// -2/3 * C * X/norm(X) - sqrt(2/3) gamma(ep) * X
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening proportional to time
   /// Zero for the isotropic part, -A sqrt(3/2) pow(norm(X), a-1) * X
   /// for each backstress
-  virtual int h_time(const double * const s, const double * const alpha, double T,
+  virtual void h_time(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_time wrt stress
-  virtual int dh_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_time wrt history
-  virtual int dh_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening proportional to the temperature rate
   /// Zero for the isotropic part
   /// Zero for each backstress if noniso = False
   /// -sqrt(2/3) * dC/dT / C * X for each backstress if noniso = True
-  virtual int h_temp(const double * const s, const double * const alpha, double T,
+  virtual void h_temp(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_temp wrt stress
-  virtual int dh_ds_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_temp wrt history
-  virtual int dh_da_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Getter for the number of backstresses
@@ -485,43 +485,43 @@ class NEML_EXPORT ChabocheVoceRecovery: public NonAssociativeHardening {
   virtual size_t nhist() const; // How many internal variables it stores
 
   /// Initialize internal variables
-  virtual int init_hist(double * const alpha) const;
+  virtual void init_hist(double * const alpha) const;
 
   /// Map the isotropic variable, map the backstresses
-  virtual int q(const double * const alpha, double T, double * const qv) const;
+  virtual void q(const double * const alpha, double T, double * const qv) const;
   /// Derivative of map
-  virtual int dq_da(const double * const alpha, double T, double * const qv) const;
+  virtual void dq_da(const double * const alpha, double T, double * const qv) const;
 
   /// Hardening proportional to inelastic strain rate
   /// Assume associated isotropic hardening, each backstress is
   /// -2/3 * C * X/norm(X) - sqrt(2/3) gamma(ep) * X
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening proportional to time
-  virtual int h_time(const double * const s, const double * const alpha, double T,
+  virtual void h_time(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_time wrt stress
-  virtual int dh_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_time wrt history
-  virtual int dh_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening proportional to the temperature rate
-  virtual int h_temp(const double * const s, const double * const alpha, double T,
+  virtual void h_temp(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_temp wrt stress
-  virtual int dh_ds_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_temp wrt history
-  virtual int dh_da_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Getter for the number of backstresses

--- a/include/larsonmiller.h
+++ b/include/larsonmiller.h
@@ -27,21 +27,21 @@ class NEML_EXPORT LarsonMillerRelation: public NEMLObject, public Solvable {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
   
   /// Stress as a function of rupture time (not really used)
-  int sR(double t, double T, double & s) const;
+  void sR(double t, double T, double & s) const;
 
   /// Rupture time as a function of stress
-  int tR(double s, double T, double & t);
+  void tR(double s, double T, double & t);
 
   /// Derivative of rupture time with respect to stress
-  int dtR_ds(double s, double T, double & dt);
+  void dtR_ds(double s, double T, double & dt);
 
   /// Number of solver parameters
   virtual size_t nparams() const;
   /// Setup an iteration vector in the solver
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// Solver function returning the residual and jacobian of the nonlinear
   /// system of equations integrating the model
-  virtual int RJ(const double * const x, TrialState * ts, double * const R,
+  virtual void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J);
 
  protected:

--- a/include/math/nemlmath.h
+++ b/include/math/nemlmath.h
@@ -34,72 +34,72 @@ const double idsym[81] = {1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.5,0.0,0.5,0.
 const double idskew[81] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.5,0.0,-0.5,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.5,0.0,0.0,0.0,-0.5,0.0,0.0,0.0,-0.5,0.0,0.5,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.5,0.0,-0.5,0.0,0.0,0.0,-0.5,0.0,0.0,0.0,0.5,0.0,0.0,0.0,0.0,0.0,0.0,0.0,-0.5,0.0,0.5,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
 
 /// Specialty crystal plasticity operator: M_kmab*W_ml - W_km*M_mlab
-NEML_EXPORT int SymSymR4SkewmSkewSymR4SymR4(const double * const M, const double * const W, double * const SS);
+NEML_EXPORT void SymSymR4SkewmSkewSymR4SymR4(const double * const M, const double * const W, double * const SS);
 
 /// Specialty crystal plasticity operator: D_km * M_mlab - M_kmab D_ml
-NEML_EXPORT int SymSkewR4SymmSkewSymR4SymR4(const double * const D, const double * const M, double * const SS);
+NEML_EXPORT void SymSkewR4SymmSkewSymR4SymR4(const double * const D, const double * const M, double * const SS);
 
 /// Specialty operator for the skew part of the tangent: C_ijkb * e_ka - C_ijal * e_bl
-NEML_EXPORT int SpecialSymSymR4Sym(const double * const D, const double * const M, double * const SW);
+NEML_EXPORT void SpecialSymSymR4Sym(const double * const D, const double * const M, double * const SW);
 
-/// Convert the symmetric and skew parts into a complete fourth order
-NEML_EXPORT int transform_fourth(const double * const D, const double * const W, double * const M);
+/// Convert the symmetric and skew parts voido a complete fourth order
+NEML_EXPORT void transform_fourth(const double * const D, const double * const W, double * const M);
 
 /// The outer product used in constructing the truesdell tangent
-NEML_EXPORT int truesdell_tangent_outer(const double * const S, double * const M);
+NEML_EXPORT void truesdell_tangent_outer(const double * const S, double * const M);
 
 /// Convert a 9x9 to a skew derivative matrix
-NEML_EXPORT int full2skew(const double * const A, double * const M);
+NEML_EXPORT void full2skew(const double * const A, double * const M);
 
 /// Convert a skew derivative matrix to a 9x9
-NEML_EXPORT int skew2full(const double * const M, double * const A);
+NEML_EXPORT void skew2full(const double * const M, double * const A);
 
-/// Convert a 9x9 into a ws matrix
-NEML_EXPORT int full2wws(const double * const A, double * const M);
+/// Convert a 9x9 voido a ws matrix
+NEML_EXPORT void full2wws(const double * const A, double * const M);
 
-/// Convert a 3x6 ws matrix into a 9x9
-NEML_EXPORT int wws2full(const double * const M, double * const A);
+/// Convert a 3x6 ws matrix voido a 9x9
+NEML_EXPORT void wws2full(const double * const M, double * const A);
 
 /// Convert a 9x9 to a mandel matrix
-NEML_EXPORT int full2mandel(const double * const A, double * const M);
+NEML_EXPORT void full2mandel(const double * const A, double * const M);
 
 /// Convert a mandel matrix to a full 9x9
-NEML_EXPORT int mandel2full(const double * const M, double * const A);
+NEML_EXPORT void mandel2full(const double * const M, double * const A);
 
 /// Convect a symmetric tensor with a Truesdell rate
-NEML_EXPORT int truesdell_update_sym(const double * const D, const double * const W,
+NEML_EXPORT void truesdell_update_sym(const double * const D, const double * const W,
                          const double * const Sn, const double * const So,
                          double * const Snp1);
 
 /// Form the 9x9 matrix used in the update
-NEML_EXPORT int truesdell_mat(const double * const D, const double * const W,
+NEML_EXPORT void truesdell_mat(const double * const D, const double * const W,
                   double * const M);
 
 /// Form the RHS of the update, as a symmetric vector
-NEML_EXPORT int truesdell_rhs(const double * const D, const double * const W,
+NEML_EXPORT void truesdell_rhs(const double * const D, const double * const W,
                   const double * const Sn, const double * const So,
                   double * const St);
 
 /// Convert a full symmetric rank 2 to a Mandel vector
-NEML_EXPORT int sym(const double * const A, double * const v);
+NEML_EXPORT void sym(const double * const A, double * const v);
 
 /// Convert a symmetric vector to a full matrix
-NEML_EXPORT int usym(const double * const v, double * const A);
+NEML_EXPORT void usym(const double * const v, double * const A);
 
 /// Convert a full skew rank 2 to a skew vector
-NEML_EXPORT int skew(const double * const A, double * const v);
+NEML_EXPORT void skew(const double * const A, double * const v);
 
 /// Convert a skew vector to a full matrix
-NEML_EXPORT int uskew(const double * const v, double * const A);
+NEML_EXPORT void uskew(const double * const v, double * const A);
 
 /// Negate a vector in place
-NEML_EXPORT int minus_vec(double * const a, int n);
+NEML_EXPORT void minus_vec(double * const a, int n);
 
 /// Add vectors
-NEML_EXPORT int add_vec(const double * const a, const double * const b, int n, double * const c);
+NEML_EXPORT void add_vec(const double * const a, const double * const b, int n, double * const c);
 
 /// Subtract vectors
-NEML_EXPORT int sub_vec(const double * const a, const double * const b, int n, double * const c);
+NEML_EXPORT void sub_vec(const double * const a, const double * const b, int n, double * const c);
 
 /// Compute a dot product
 NEML_EXPORT double dot_vec(const double * const a, const double * const b, int n);
@@ -108,37 +108,37 @@ NEML_EXPORT double dot_vec(const double * const a, const double * const b, int n
 NEML_EXPORT double norm2_vec(const double * const a, int n);
 
 /// Normalize a vector in place (2-norm)
-NEML_EXPORT int normalize_vec(double * const a, int n);
+NEML_EXPORT void normalize_vec(double * const a, int n);
 
 /// Return the deviatoric vector
-NEML_EXPORT int dev_vec(double * const a);
+NEML_EXPORT void dev_vec(double * const a);
 
 /// Outer product of two vectors
-NEML_EXPORT int outer_vec(const double * const a, int na, const double * const b, int nb, double * const C);
+NEML_EXPORT void outer_vec(const double * const a, int na, const double * const b, int nb, double * const C);
 
 /// Rank 2 update
-NEML_EXPORT int outer_update(const double * const a, int na, const double * const b, int nb, double * const C);
+NEML_EXPORT void outer_update(const double * const a, int na, const double * const b, int nb, double * const C);
 
 /// Rank 2 update
-NEML_EXPORT int outer_update_minus(const double * const a, int na, const double * const b, int nb, double * const C);
+NEML_EXPORT void outer_update_minus(const double * const a, int na, const double * const b, int nb, double * const C);
 
 /// Matrix-vector c = A . b
-NEML_EXPORT int mat_vec(const double * const A, int m, const double * const b, int n, double * const c);
+NEML_EXPORT void mat_vec(const double * const A, int m, const double * const b, int n, double * const c);
 
 /// Matrix-vector c = A.T . b
-NEML_EXPORT int mat_vec_trans(const double * const A, int m, const double * const b, int n, double * const c);
+NEML_EXPORT void mat_vec_trans(const double * const A, int m, const double * const b, int n, double * const c);
 
 // Matrix-matrix C = A . B
-NEML_EXPORT int mat_mat(int m, int n, int k, const double * const A, const double * const B, double * const C);
+NEML_EXPORT void mat_mat(int m, int n, int k, const double * const A, const double * const B, double * const C);
 
 // Matrix-matrix C = A . B.T
-NEML_EXPORT int mat_mat_ABT(int m, int n, int k, const double * const A, const double * const B, double * const C);
+NEML_EXPORT void mat_mat_ABT(int m, int n, int k, const double * const A, const double * const B, double * const C);
 
 /// Invert a matrix in place
-NEML_EXPORT int invert_mat(double* const A, int n);
+NEML_EXPORT void invert_mat(double* const A, int n);
 
 /// Solve unsymmetric system
-NEML_EXPORT int solve_mat(const double * const A, int n, double * const x);
+NEML_EXPORT void solve_mat(const double * const A, int n, double * const x);
 
 /// Get the condition number of a matrix
 NEML_EXPORT double condition(const double * const A, int n);
@@ -179,7 +179,7 @@ NEML_EXPORT void qmult_vec(const double * const As, const double * const B,
 NEML_EXPORT bool isclose(double a, double b);
 
 /// Perform A * B * A.T
-NEML_EXPORT int rotate_matrix(int m, int n, const double * const A,
+NEML_EXPORT void rotate_matrix(int m, int n, const double * const A,
                   const double * const B, double * C);
 
 /// Factorial
@@ -189,10 +189,10 @@ NEML_EXPORT int fact(int n);
 NEML_EXPORT double factorial(int n);
 
 /// Get the eigenvalues of a symmetric 3x3 matrix in Mandel notation
-NEML_EXPORT int eigenvalues_sym(const double * const s, double * values);
+NEML_EXPORT void eigenvalues_sym(const double * const s, double * values);
 
 /// Get the eigenvectors of a symmetric 3x3 matrix (row major)
-NEML_EXPORT int eigenvectors_sym(const double * const s, double * vectors);
+NEML_EXPORT void eigenvectors_sym(const double * const s, double * vectors);
 
 /// First principal invariant
 NEML_EXPORT double I1(const double * const s);

--- a/include/models.h
+++ b/include/models.h
@@ -33,7 +33,7 @@ class NEML_EXPORT NEMLModel: public NEMLObject {
    /// Total number of stored internal variables
    virtual size_t nstore() const = 0;
    /// Initialize the internal variables
-   virtual int init_store(double * const store) const = 0;
+   virtual void init_store(double * const store) const = 0;
 
    /// Small strain update interface
    virtual int update_sd(
@@ -102,7 +102,7 @@ class NEML_EXPORT NEMLModel_ldi: public NEMLModel {
    /// Number of stored variables
    virtual size_t nstore() const;
    /// Initialize stored variables
-   virtual int init_store(double * const store) const;
+   virtual void init_store(double * const store) const;
 
    /// Number of stored variables that are true material history
    virtual size_t nhist() const = 0;
@@ -142,7 +142,7 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
    /// Number of stored variables
    virtual size_t nstore() const;
    /// Initialize stored variables
-   virtual int init_store(double * const store) const;
+   virtual void init_store(double * const store) const;
 
    /// Number of stored variables that are true material history
    virtual size_t nhist() const = 0;
@@ -364,9 +364,9 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
   /// Number of nonlinear equations to solve in the integration
   virtual size_t nparams() const;
   /// Setup an initial guess for the nonlinear solution
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// Integration residual and jacobian equations
-  virtual int RJ(const double * const x, TrialState * ts, double * const R,
+  virtual void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J);
 
   /// Setup the trial state
@@ -506,10 +506,10 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
   /// Number of solver parameters
   virtual size_t nparams() const;
   /// Setup an iteration vector in the solver
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// Solver function returning the residual and jacobian of the nonlinear
   /// system of equations integrating the model
-  virtual int RJ(const double * const x, TrialState * ts, double * const R,
+  virtual void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J);
 
   /// Return the elastic model for subobjects
@@ -564,9 +564,9 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
   /// The number of parameters in the nonlinear equation
   virtual size_t nparams() const;
   /// Initialize the nonlinear solver
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// Residual equation to solve and corresponding jacobian
-  virtual int RJ(const double * const x, TrialState * ts, double * const R,
+  virtual void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J);
 
   /// Setup a trial state from known information
@@ -666,9 +666,9 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
   /// Number of nonlinear equations
   virtual size_t nparams() const;
   /// Initialize a guess for the nonlinear iterations
-  virtual int init_x(double * const x, TrialState * ts);
+  virtual void init_x(double * const x, TrialState * ts);
   /// The residual and jacobian for the nonlinear solve
-  virtual int RJ(const double * const x, TrialState * ts,
+  virtual void RJ(const double * const x, TrialState * ts,
                  double * const R, double * const J);
 
   /// Initialize a trial state

--- a/include/models.h
+++ b/include/models.h
@@ -36,7 +36,7 @@ class NEML_EXPORT NEMLModel: public NEMLObject {
    virtual void init_store(double * const store) const = 0;
 
    /// Small strain update interface
-   virtual int update_sd(
+   virtual void update_sd(
        const double * const e_np1, const double * const e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
@@ -47,7 +47,7 @@ class NEML_EXPORT NEMLModel: public NEMLObject {
        double & p_np1, double p_n) = 0;
 
    /// Large strain incremental update
-   virtual int update_ld_inc(
+   virtual void update_ld_inc(
        const double * const d_np1, const double * const d_n,
        const double * const w_np1, const double * const w_n,
        double T_np1, double T_n,
@@ -61,12 +61,12 @@ class NEML_EXPORT NEMLModel: public NEMLObject {
    /// Number of internal variables that are true material history
    virtual size_t nhist() const = 0;
    /// Initialize the history variables
-   virtual int init_hist(double * const hist) const = 0;
+   virtual void init_hist(double * const hist) const = 0;
 
    /// Instantaneous thermal expansion coefficient as a function of temperature
    virtual double alpha(double T) const = 0;
    /// Elastic strain for a given stress, temperature, and history state
-   virtual int elastic_strains(const double * const s_np1,
+   virtual void elastic_strains(const double * const s_np1,
                                double T_np1, const double * const h_np1,
                                double * const e_np1) const = 0;
 };
@@ -77,7 +77,7 @@ class NEML_EXPORT NEMLModel_ldi: public NEMLModel {
     NEMLModel_ldi(ParameterSet & params);
 
    /// The small strain stress update interface
-   virtual int update_sd(
+   virtual void update_sd(
        const double * const e_np1, const double * const e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
@@ -88,7 +88,7 @@ class NEML_EXPORT NEMLModel_ldi: public NEMLModel {
        double & p_np1, double p_n);
 
    /// Large strain incremental update
-   virtual int update_ld_inc(
+   virtual void update_ld_inc(
        const double * const d_np1, const double * const d_n,
        const double * const w_np1, const double * const w_n,
        double T_np1, double T_n,
@@ -107,7 +107,7 @@ class NEML_EXPORT NEMLModel_ldi: public NEMLModel {
    /// Number of stored variables that are true material history
    virtual size_t nhist() const = 0;
    /// Initialize the stored history
-   virtual int init_hist(double * const hist) const = 0;
+   virtual void init_hist(double * const hist) const = 0;
 };
 
 /// Small deformation stress update
@@ -117,7 +117,7 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
     NEMLModel_sd(ParameterSet & params);
 
    /// The small strain stress update interface
-   virtual int update_sd(
+   virtual void update_sd(
        const double * const e_np1, const double * const e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
@@ -128,7 +128,7 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
        double & p_np1, double p_n) = 0;
 
    /// Large strain incremental update
-   virtual int update_ld_inc(
+   virtual void update_ld_inc(
        const double * const d_np1, const double * const d_n,
        const double * const w_np1, const double * const w_n,
        double T_np1, double T_n,
@@ -147,7 +147,7 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
    /// Number of stored variables that are true material history
    virtual size_t nhist() const = 0;
    /// Initialize the stored history
-   virtual int init_hist(double * const hist) const = 0;
+   virtual void init_hist(double * const hist) const = 0;
 
    /// Provide the instantaneous CTE
    virtual double alpha(double T) const;
@@ -155,15 +155,15 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
    const std::shared_ptr<const LinearElasticModel> elastic() const;
 
    /// Return the elastic strains
-   virtual int elastic_strains(const double * const s_np1,
+   virtual void elastic_strains(const double * const s_np1,
                                double T_np1, const double * const h_np1,
                                double * const e_np1) const;
 
    /// Used to override the linear elastic model to match another object's
-   virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
   private:
-   int calc_tangent_(const double * const D, const double * const W,
+   void calc_tangent_(const double * const D, const double * const W,
                      const double * const C, const double * const S,
                      double * const A, double * const B);
 
@@ -182,7 +182,7 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
   SubstepModel_sd(ParameterSet & params);
 
   /// Complete substep update
-  virtual int update_sd(
+  virtual void update_sd(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -193,7 +193,7 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
       double & p_np1, double p_n);
 
   /// Single step update
-  virtual int update_step(
+  virtual void update_step(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -221,7 +221,7 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
       const double * const h_n) = 0;
 
   /// Interpret the x vector
-  virtual int update_internal(
+  virtual void update_internal(
       const double * const x,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -230,7 +230,7 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
       double * const h_np1, const double * const h_n) = 0;
 
   /// Minus the partial derivative of the residual with respect to the strain
-  virtual int strain_partial(
+  virtual void strain_partial(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -240,7 +240,7 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
       double * const de) = 0;
 
   /// Do the work calculation
-  virtual int work_and_energy(
+  virtual void work_and_energy(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -273,7 +273,7 @@ class NEML_EXPORT SmallStrainElasticity: public NEMLModel_sd {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Small strain stress update
-  virtual int update_sd(
+  virtual void update_sd(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -285,7 +285,7 @@ class NEML_EXPORT SmallStrainElasticity: public NEMLModel_sd {
   /// Number of history variables (=0)
   virtual size_t nhist() const;
   /// Initialize history (none to setup)
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 };
 
 static Register<SmallStrainElasticity> regSmallStrainElasticity;
@@ -359,7 +359,7 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
   /// Number of history variables (=0)
   virtual size_t nhist() const;
   /// Initialize history (nothing to do)
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
   
   /// Number of nonlinear equations to solve in the integration
   virtual size_t nparams() const;
@@ -387,7 +387,7 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
       const double * const h_n);
 
   /// Interpret the x vector
-  virtual int update_internal(
+  virtual void update_internal(
       const double * const x,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -396,7 +396,7 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
       double * const h_np1, const double * const h_n);
 
   /// Minus the partial derivative of the residual with respect to the strain
-  virtual int strain_partial(
+  virtual void strain_partial(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -406,7 +406,7 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
       double * de);
 
   /// Do the work calculation
-  virtual int work_and_energy(
+  virtual void work_and_energy(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -420,7 +420,7 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
   double ys(double T) const;
 
   /// Setup a trial state for the solver from the input information
-  int make_trial_state(const double * const e_np1, const double * const e_n,
+  void make_trial_state(const double * const e_np1, const double * const e_n,
                        double T_np1, double T_n, double t_np1, double t_n,
                        const double * const s_n, const double * const h_n,
                        SSPPTrialState & ts);
@@ -454,7 +454,7 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
   /// Number of history variables
   virtual size_t nhist() const;
   /// Initialize history at time zero
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 
   /// Setup the trial state
   virtual TrialState * setup(
@@ -474,7 +474,7 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
       const double * const h_n);
 
   /// Interpret the x vector
-  virtual int update_internal(
+  virtual void update_internal(
       const double * const x,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -483,7 +483,7 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
       double * const h_np1, const double * const h_n);
 
   /// Minus the partial derivative of the residual with respect to the strain
-  virtual int strain_partial(
+  virtual void strain_partial(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -493,7 +493,7 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
       double * const de);
 
   /// Do the work calculation
-  virtual int work_and_energy(
+  virtual void work_and_energy(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -516,7 +516,7 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
   const std::shared_ptr<const LinearElasticModel> elastic() const;
 
   /// Setup a trial state
-  int make_trial_state(const double * const e_np1, const double * const e_n,
+  void make_trial_state(const double * const e_np1, const double * const e_n,
                        double T_np1, double T_n, double t_np1, double t_n,
                        const double * const s_n, const double * const h_n,
                        SSRIPTrialState & ts);
@@ -546,7 +546,7 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Small strain stress update
-  virtual int update_sd(
+  virtual void update_sd(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -559,7 +559,7 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
   /// Number of history variables matches the base model
   virtual size_t nhist() const;
   /// Passes call for initial history to base model
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 
   /// The number of parameters in the nonlinear equation
   virtual size_t nparams() const;
@@ -570,16 +570,16 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
                  double * const J);
 
   /// Setup a trial state from known information
-  int make_trial_state(const double * const e_np1, const double * const e_n,
+  void make_trial_state(const double * const e_np1, const double * const e_n,
                        double T_np1, double T_n, double t_np1, double t_n,
                        const double * const s_n, const double * const h_n,
                        SSCPTrialState & ts);
 
   /// Set a new elastic model
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
  private:
-  int form_tangent_(double * const A, double * const B,
+  void form_tangent_(double * const A, double * const B,
                     double * const A_np1);
 
  private:
@@ -629,7 +629,7 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
       const double * const h_n);
 
   /// Interpret the x vector
-  virtual int update_internal(
+  virtual void update_internal(
       const double * const x,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -638,7 +638,7 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
       double * const h_np1, const double * const h_n);
 
   /// Minus the partial derivative of the residual with respect to the strain
-  virtual int strain_partial(
+  virtual void strain_partial(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -648,7 +648,7 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
       double * de);
 
   /// Do the work calculation
-  virtual int work_and_energy(
+  virtual void work_and_energy(
       const TrialState * ts,
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
@@ -661,7 +661,7 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
   /// Number of history variables
   virtual size_t nhist() const;
   /// Initialize the history at time zero
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 
   /// Number of nonlinear equations
   virtual size_t nparams() const;
@@ -672,13 +672,13 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
                  double * const R, double * const J);
 
   /// Initialize a trial state
-  int make_trial_state(const double * const e_np1, const double * const e_n,
+  void make_trial_state(const double * const e_np1, const double * const e_n,
                        double T_np1, double T_n, double t_np1, double t_n,
                        const double * const s_n, const double * const h_n,
                        GITrialState & ts);
 
   /// Set a new elastic model
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
  private:
   std::shared_ptr<GeneralFlowRule> rule_;
@@ -718,7 +718,7 @@ class NEML_EXPORT KMRegimeModel: public NEMLModel_sd {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// The small strain stress update
-  virtual int update_sd(
+  virtual void update_sd(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -731,10 +731,10 @@ class NEML_EXPORT KMRegimeModel: public NEMLModel_sd {
   /// The number of model history variables
   virtual size_t nhist() const;
   /// Initialize history at time zero
-  virtual int init_hist(double * const hist) const;
+  virtual void init_hist(double * const hist) const;
 
   /// Set a new elastic model
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
  private:
   double activation_energy_(const double * const e_np1,

--- a/include/nemlerror.h
+++ b/include/nemlerror.h
@@ -8,17 +8,6 @@
 
 namespace neml {
 
-// The global error codes
-typedef enum Error {
-  SUCCESS = 0,
-} Error;
-
-/// Translate an error code to an exception
-NEML_EXPORT void py_error(int ier);
-
-/// Translate an error code to a string
-NEML_EXPORT std::string string_error(int ier);
-
 class NEML_EXPORT NEMLError: public std::runtime_error {
  public:
   NEMLError(std::string msg);

--- a/include/nemlerror.h
+++ b/include/nemlerror.h
@@ -11,23 +11,6 @@ namespace neml {
 // The global error codes
 typedef enum Error {
   SUCCESS = 0,
-  INCOMPATIBLE_MODELS = -1,
-  LINALG_FAILURE = -2,
-  MAX_ITERATIONS = -3,
-  KT_VIOLATION = -4,
-  NODE_NOT_FOUND = -5,
-  TOO_MANY_NODES = -6,
-  ATTRIBUTE_NOT_FOUND = -7,
-  UNKNOWN_TYPE = -8,
-  BAD_TEXT = -9,
-  INVALID_TYPE = -10,
-  FILE_NOT_FOUND = -11,
-  CREEP_PLASTICITY = -12,
-  UNKNOWN_ERROR = -13,
-  INCOMPATIBLE_KM = -14,
-  DUMMY_ELASTIC = -15,
-  INCOMPATIBLE_VECTORS = -16,
-  EXCEEDS_STRAIN_RATE_LIMIT = -17
 } Error;
 
 /// Translate an error code to an exception
@@ -36,11 +19,22 @@ NEML_EXPORT void py_error(int ier);
 /// Translate an error code to a string
 NEML_EXPORT std::string string_error(int ier);
 
-/// Descriptive exception for problems with BLAS/LAPACK
-class NEML_EXPORT LinalgError: public std::runtime_error {
+class NEML_EXPORT NEMLError: public std::runtime_error {
  public:
-  LinalgError(const char* m);
+  NEMLError(std::string msg);
 
+};
+
+/// Descriptive exception for problems with BLAS/LAPACK
+class NEML_EXPORT LinalgError: public NEMLError {
+ public:
+  LinalgError(std::string msg);
+};
+
+/// Descriptive error for when a nonlinear solve failed
+class NEML_EXPORT NonlinearSolverError: public NEMLError {
+ public:
+  NonlinearSolverError(std::string msg);
 };
 
 } // namespace neml

--- a/include/parse.h
+++ b/include/parse.h
@@ -16,7 +16,6 @@
 #include <sstream>
 #include <vector>
 #include <algorithm>
-#include <exception>
 
 namespace neml {
 
@@ -97,141 +96,53 @@ std::string & strip(std::string & s);
 bool is_empty(const rapidxml::xml_node<> * node);
 
 // Exceptions
-/// If a node is not found
-class NodeNotFound: public std::exception {
+
+/// Generic class of parser errors which take line numbers
+class XMLParseError: public NEMLError {
  public:
-  NodeNotFound(std::string node_name, int line) :
-      node_name_(node_name), line_(line)
+  XMLParseError(std::string msg) :
+      NEMLError(msg)
   {
-    std::stringstream ss;
-    ss << "Node with name " << node_name_
-        << " was not found near line " << line_ << "!";
-    message_ = ss.str();
+    
   };
-
-  const char * what() const throw ()
-  {
-    return message_.c_str();
-  };
-
- private:
-  std::string node_name_;
-  int line_;
-  std::string message_;
-};
-
-/// If a node is not unique (and it should be)
-class DuplicateNode: public std::exception {
- public:
-  DuplicateNode(std::string node_name, int line) :
-      node_name_(node_name), line_(line)
-  {
-      std::stringstream ss;
-      ss << "Multiple nodes with name " << node_name_ << " were found!";
-      message_ = ss.str();
-  };
-
-    const char * what() const throw ()
-    {
-      return message_.c_str();
-    };
-
-  private:
-    std::string node_name_;
-    int line_;
-    std::string message_;
 };
 
 /// If the object can't be converted
-class InvalidType: public std::exception {
+class InvalidType: public XMLParseError {
  public:
   InvalidType(std::string name, std::string type, std::string ctype) :
-      name_(name), type_(type), ctype_(ctype)
+      XMLParseError("Node with name " + name + " and type " + type +
+                    "cannot be converted to the correct type " + ctype)
   {
-    std::stringstream ss;
-
-    ss << "Node with name " << name_ << " and type " << type_
-        << "cannot be converted to the correct type " << ctype_ << "!";
-
-    message_ = ss.str();
   };
-
-  const char * what() const throw ()
-  {
-    return message_.c_str();
-  };
-
- private:
-  std::string name_, type_, ctype_, message_;
 };
 
 /// If a parameter doesn't exist
-class UnknownParameterXML: public std::exception {
+class UnknownParameterXML: public XMLParseError {
  public:
   UnknownParameterXML(std::string name, std::string param) :
-      name_(name), param_(param)
+      XMLParseError("Object " + name + " does not have a parameter called " +
+                    param)
   {
-    std::stringstream ss;
-
-    ss << "Object " << name_ << " does not have a parameter called " << param_ << "!";
-
-    message_ = ss.str();
   };
-
-  const char * what() const throw ()
-  {
-    return message_.c_str();
-  };
-
- private:
-  std::string name_, param_, message_;
-
 };
 
 /// The object isn't in the factory
-class UnregisteredXML: public std::exception {
+class UnregisteredXML: public XMLParseError {
  public:
   UnregisteredXML(std::string name, std::string type) :
-      name_(name), type_(type)
+      XMLParseError("Unregistered type " + type + " for node named " + name)
   {
-    std::stringstream ss;
-
-    ss << "Node named " << name_ << " has an unregistered type of " << type_ << "!";
-
-    message_ = ss.str();
   };
-
-  const char * what() const throw ()
-  {
-    return message_.c_str();
-  };
-
- private:
-  std::string name_, type_, message_;
-
 };
 
 /// The model isn't in the file
-class ModelNotFound: public std::exception {
+class ModelNotFound: public XMLParseError {
  public:
   ModelNotFound(std::string name) :
-      name_(name)
+      XMLParseError("Model named " + name + " is not in the XML file!")
   {
-    std::stringstream ss;
-
-    ss << "Model named " << name_ << " is not in the XML file!";
-
-    message_ = ss.str();
   };
-
-  const char * what() const throw ()
-  {
-    return message_.c_str();
-  };
-
- private:
-  std::string name_, message_;
-
 };
 
 } // namespace neml

--- a/include/ri_flow.h
+++ b/include/ri_flow.h
@@ -20,36 +20,36 @@ class NEML_EXPORT RateIndependentFlowRule: public NEMLObject {
   /// Number of history variables
   virtual size_t nhist() const = 0;
   /// Setup the history at time zero
-  virtual int init_hist(double * const h) const = 0;
+  virtual void init_hist(double * const h) const = 0;
 
   /// Yield surface
-  virtual int f(const double* const s, const double* const alpha, double T,
+  virtual void f(const double* const s, const double* const alpha, double T,
                 double & fv) const = 0;
   /// Partial derivative of the surface wrt stress
-  virtual int df_ds(const double* const s, const double* const alpha, double T,
+  virtual void df_ds(const double* const s, const double* const alpha, double T,
                 double * const dfv) const = 0;
   /// Partial derivative of the surface wrt history
-  virtual int df_da(const double* const s, const double* const alpha, double T,
+  virtual void df_da(const double* const s, const double* const alpha, double T,
                 double * const dfv) const = 0;
 
   /// Flow function
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const = 0;
   /// Partial derivative of the flow function wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const = 0;
   /// Partial derivative of the flow function wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const = 0;
 
   /// Hardening rule
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const = 0;
   /// Partial derivative of the hardening rule wrt. stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const = 0;
   /// Partial derivative of the hardening rule wrt. history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const = 0;
 };
 
@@ -69,36 +69,36 @@ class NEML_EXPORT RateIndependentAssociativeFlow: public RateIndependentFlowRule
   /// History size according to the HardeningRule
   virtual size_t nhist() const;
   /// Initialize history with the HardeningRule
-  virtual int init_hist(double * const h) const;
+  virtual void init_hist(double * const h) const;
 
   /// Yield surface
-  virtual int f(const double* const s, const double* const alpha, double T,
+  virtual void f(const double* const s, const double* const alpha, double T,
                 double & fv) const;
   /// Partial derivative of the surface wrt stress
-  virtual int df_ds(const double* const s, const double* const alpha, double T,
+  virtual void df_ds(const double* const s, const double* const alpha, double T,
                 double * const dfv) const;
   /// Partial derivative of the surface wrt history
-  virtual int df_da(const double* const s, const double* const alpha, double T,
+  virtual void df_da(const double* const s, const double* const alpha, double T,
                 double * const dfv) const;
 
   /// Flow function
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Partial derivative of the flow function wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Partial derivative of the flow function wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
 
   /// Hardening rule
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Partial derivative of the hardening rule wrt. stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Partial derivative of the hardening rule wrt. history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
  private:
@@ -130,36 +130,36 @@ class NEML_EXPORT RateIndependentNonAssociativeHardening: public RateIndependent
   /// History size according to the HardeningRule
   virtual size_t nhist() const;
   /// Initialize history with the HardeningRule
-  virtual int init_hist(double * const h) const;
+  virtual void init_hist(double * const h) const;
 
   /// Yield surface
-  virtual int f(const double* const s, const double* const alpha, double T,
+  virtual void f(const double* const s, const double* const alpha, double T,
                 double & fv) const;
   /// Partial derivative of the surface wrt stress
-  virtual int df_ds(const double* const s, const double* const alpha, double T,
+  virtual void df_ds(const double* const s, const double* const alpha, double T,
                 double * const dfv) const;
   /// Partial derivative of the surface wrt history
-  virtual int df_da(const double* const s, const double* const alpha, double T,
+  virtual void df_da(const double* const s, const double* const alpha, double T,
                 double * const dfv) const;
 
   /// Flow function
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Partial derivative of the flow function wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Partial derivative of the flow function wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
 
   /// Hardening rule
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Partial derivative of the hardening rule wrt. stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Partial derivative of the hardening rule wrt. history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
  private:

--- a/include/solvers.h
+++ b/include/solvers.h
@@ -44,19 +44,19 @@ class NEML_EXPORT Solvable {
   /// Number of parameters in the nonlinear equation
   virtual size_t nparams() const = 0;
   /// Initialize a guess to start the solution iterations
-  virtual int init_x(double * const x, TrialState * ts) = 0;
+  virtual void init_x(double * const x, TrialState * ts) = 0;
   /// Nonlinear residual equations and corresponding jacobian
-  virtual int RJ(const double * const x, TrialState * ts, double * const R,
+  virtual void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J) = 0;
 };
 
 /// Call the built-in solver
-int NEML_EXPORT solve(Solvable * system, double * x, TrialState * ts,
+void NEML_EXPORT solve(Solvable * system, double * x, TrialState * ts,
                       SolverParameters p, double * R = nullptr,
                       double * J = nullptr);
 
 /// Default solver: plain NR
-int NEML_EXPORT newton(Solvable * system, double * x, TrialState * ts,
+void NEML_EXPORT newton(Solvable * system, double * x, TrialState * ts,
           SolverParameters p, double * R, double * J);
 
 #ifdef SOLVER_NOX
@@ -82,14 +82,14 @@ class NEML_EXPORT NOXSolver: public NOX::LAPACK::Interface {
 };
 
 /// Interface to nox
-int NEML_EXPORT nox(Solvable * system, double * x, TrialState * ts,
+void NEML_EXPORT nox(Solvable * system, double * x, TrialState * ts,
         double tol, int miter, bool verbose, double * R,
         double * J);
 
 #endif
 
 /// Helper to get numerical jacobian
-int NEML_EXPORT diff_jac(Solvable * system, const double * const x, TrialState * ts,
+void NEML_EXPORT diff_jac(Solvable * system, const double * const x, TrialState * ts,
              double * const nJ, double eps = 1.0e-9);
 /// Helper to get checksum
 double NEML_EXPORT diff_jac_check(Solvable * system, const double * const x, TrialState * ts,
@@ -102,8 +102,8 @@ class NEML_EXPORT TestPower: public Solvable {
   virtual ~TestPower() {}; // clang...
 
   size_t nparams() const;
-  int init_x(double * const x, TrialState * ts);
-  int RJ(const double * const x, TrialState * ts, double * const R,
+  void init_x(double * const x, TrialState * ts);
+  void RJ(const double * const x, TrialState * ts, double * const R,
                  double * const J);
 
  private:

--- a/include/surfaces.h
+++ b/include/surfaces.h
@@ -31,27 +31,27 @@ class NEML_EXPORT YieldSurface: public NEMLObject {
   virtual size_t nhist() const = 0;
 
   /// Yield function
-  virtual int f(const double* const s, const double* const q, double T,
+  virtual void f(const double* const s, const double* const q, double T,
                 double & fv) const = 0;
 
   /// Gradient wrt stress
-  virtual int df_ds(const double* const s, const double* const q, double T,
+  virtual void df_ds(const double* const s, const double* const q, double T,
                 double * const df) const = 0;
   /// Gradient wrt history
-  virtual int df_dq(const double* const s, const double* const q, double T,
+  virtual void df_dq(const double* const s, const double* const q, double T,
                 double * const df) const = 0;
 
   /// Hessian dsds
-  virtual int df_dsds(const double* const s, const double* const q, double T,
+  virtual void df_dsds(const double* const s, const double* const q, double T,
                 double * const ddf) const = 0;
   /// Hessian dqdq
-  virtual int df_dqdq(const double* const s, const double* const q, double T,
+  virtual void df_dqdq(const double* const s, const double* const q, double T,
                 double * const ddf) const = 0;
   /// Hessian dsdq
-  virtual int df_dsdq(const double* const s, const double* const q, double T,
+  virtual void df_dsdq(const double* const s, const double* const q, double T,
                 double * const ddf) const = 0;
   /// Hessian dqds
-  virtual int df_dqds(const double* const s, const double* const q, double T,
+  virtual void df_dqds(const double* const s, const double* const q, double T,
                 double * const ddf) const = 0;
 };
 
@@ -73,88 +73,81 @@ class NEML_EXPORT IsoFunction: public YieldSurface {
   }
 
   /// Just call with zero kinematic hardening
-  virtual int f(const double* const s, const double* const q, double T,
+  virtual void f(const double* const s, const double* const q, double T,
                 double & fv) const
   {
     double * qn = expand_hist_(q);
-    int ier = base_->f(s, qn, T, fv);
+    base_->f(s, qn, T, fv);
     delete [] qn;
-    return ier;
   }
 
   /// Call with zero kinematic hardening
-  virtual int df_ds(const double* const s, const double* const q, double T,
+  virtual void df_ds(const double* const s, const double* const q, double T,
                 double * const df) const
   {
     double * qn = expand_hist_(q);
-    int ier = base_->df_ds(s, qn, T, df);
+    base_->df_ds(s, qn, T, df);
     delete [] qn;
-    return ier;
   }
 
   /// Call with zero kinematic hardening
-  virtual int df_dq(const double* const s, const double* const q, double T,
+  virtual void df_dq(const double* const s, const double* const q, double T,
                 double * const df) const
   {
     double * qn = expand_hist_(q);
     double * dfn = new double[base_->nhist()];
-    int ier = base_->df_dq(s, qn, T, dfn);
+     base_->df_dq(s, qn, T, dfn);
     df[0] = dfn[0];
     delete [] qn;
     delete [] dfn;
-    return ier;
   }
 
   /// Call with zero kinematic hardening
-  virtual int df_dsds(const double* const s, const double* const q, double T,
+  virtual void df_dsds(const double* const s, const double* const q, double T,
                 double * const ddf) const
   {
     double * qn = expand_hist_(q);
-    int ier = base_->df_dsds(s, qn, T, ddf);
+    base_->df_dsds(s, qn, T, ddf);
     delete [] qn;
-    return ier;
   }
 
   /// Call with zero kinematic hardening
-  virtual int df_dqdq(const double* const s, const double* const q, double T,
+  virtual void df_dqdq(const double* const s, const double* const q, double T,
                 double * const ddf) const
   {
     double * qn = expand_hist_(q);
     double * ddfn = new double[(base_->nhist())*(base_->nhist())];
-    int ier = base_->df_dqdq(s, qn, T, ddfn);
+    base_->df_dqdq(s, qn, T, ddfn);
     ddf[0] = ddfn[0];
     delete [] qn;
     delete [] ddfn;
-    return ier;
   }
 
   /// Call with zero kinematic hardening
-  virtual int df_dsdq(const double* const s, const double* const q, double T,
+  virtual void df_dsdq(const double* const s, const double* const q, double T,
                 double * const ddf) const
   {
     // This one is annoying
     double * qn = expand_hist_(q);
     double * ddfn = new double[6*(base_->nhist())];
-    int ier = base_->df_dsdq(s, qn, T, ddfn);
+     base_->df_dsdq(s, qn, T, ddfn);
     for (int i=0; i<6; i++) {
       ddf[i] = ddfn[CINDEX(i,0,base_->nhist())];
     }
     delete [] qn;
     delete [] ddfn;
-    return ier;
   }
 
   /// Call with zero kinematic hardening
-  virtual int df_dqds(const double* const s, const double* const q, double T,
+  virtual void df_dqds(const double* const s, const double* const q, double T,
                 double * const ddf) const
   {
     double * qn = expand_hist_(q);
     double * ddfn = new double[(base_->nhist())*6];
-    int ier = base_->df_dqds(s, qn, T, ddfn);
+    base_->df_dqds(s, qn, T, ddfn);
     std::copy(ddfn,ddfn+6,ddf);
     delete [] qn;
     delete [] ddfn;
-    return ier;
   }
 
  private:
@@ -193,27 +186,27 @@ class NEML_EXPORT IsoKinJ2: public YieldSurface {
   virtual size_t nhist() const;
 
   /// J2(stress + backstress) + sqrt(2/3) * isotropic
-  virtual int f(const double* const s, const double* const q, double T,
+  virtual void f(const double* const s, const double* const q, double T,
                 double & fv) const;
 
   /// Gradient wrt stress
-  virtual int df_ds(const double* const s, const double* const q, double T,
+  virtual void df_ds(const double* const s, const double* const q, double T,
                 double * const df) const;
   /// Gradient wrt history
-  virtual int df_dq(const double* const s, const double* const q, double T,
+  virtual void df_dq(const double* const s, const double* const q, double T,
                 double * const df) const;
 
   /// Hessian dsds
-  virtual int df_dsds(const double* const s, const double* const q, double T,
+  virtual void df_dsds(const double* const s, const double* const q, double T,
                 double * const ddf) const;
   /// Hessian dqdq
-  virtual int df_dqdq(const double* const s, const double* const q, double T,
+  virtual void df_dqdq(const double* const s, const double* const q, double T,
                 double * const ddf) const;
   /// Hessian dsdq
-  virtual int df_dsdq(const double* const s, const double* const q, double T,
+  virtual void df_dsdq(const double* const s, const double* const q, double T,
                 double * const ddf) const;
   /// Hessian dqds
-  virtual int df_dqds(const double* const s, const double* const q, double T,
+  virtual void df_dqds(const double* const s, const double* const q, double T,
                 double * const ddf) const;
 
 };
@@ -270,27 +263,27 @@ class NEML_EXPORT IsoKinJ2I1: public YieldSurface {
 
   /// J2(stress + backstress) + isotropic + sign(mean_stress) * h *
   /// |mean_stress|^l
-  virtual int f(const double* const s, const double* const q, double T,
+  virtual void f(const double* const s, const double* const q, double T,
                 double & fv) const;
 
   /// Gradient wrt stress
-  virtual int df_ds(const double* const s, const double* const q, double T,
+  virtual void df_ds(const double* const s, const double* const q, double T,
                 double * const df) const;
   /// Gradient wrt q
-  virtual int df_dq(const double* const s, const double* const q, double T,
+  virtual void df_dq(const double* const s, const double* const q, double T,
                 double * const df) const;
 
   /// Hessian dsds
-  virtual int df_dsds(const double* const s, const double* const q, double T,
+  virtual void df_dsds(const double* const s, const double* const q, double T,
                 double * const ddf) const;
   /// Hessian dqdq
-  virtual int df_dqdq(const double* const s, const double* const q, double T,
+  virtual void df_dqdq(const double* const s, const double* const q, double T,
                 double * const ddf) const;
   /// Hessian dsdq
-  virtual int df_dsdq(const double* const s, const double* const q, double T,
+  virtual void df_dsdq(const double* const s, const double* const q, double T,
                 double * const ddf) const;
   /// Hessian dqds
-  virtual int df_dqds(const double* const s, const double* const q, double T,
+  virtual void df_dqds(const double* const s, const double* const q, double T,
                 double * const ddf) const;
 
  private:

--- a/include/visco_flow.h
+++ b/include/visco_flow.h
@@ -21,77 +21,77 @@ class NEML_EXPORT ViscoPlasticFlowRule: public NEMLObject {
   /// Number of history variables
   virtual size_t nhist() const = 0;
   /// Initialize history at time zero
-  virtual int init_hist(double * const h) const = 0;
+  virtual void init_hist(double * const h) const = 0;
 
   /// Scalar flow rate
-  virtual int y(const double* const s, const double* const alpha, double T,
+  virtual void y(const double* const s, const double* const alpha, double T,
                 double & yv) const = 0;
   /// Derivative of scalar flow wrt stress
-  virtual int dy_ds(const double* const s, const double* const alpha, double T,
+  virtual void dy_ds(const double* const s, const double* const alpha, double T,
                 double * const dyv) const = 0;
   /// Derivative of scalar flow wrt history
-  virtual int dy_da(const double* const s, const double* const alpha, double T,
+  virtual void dy_da(const double* const s, const double* const alpha, double T,
                 double * const dyv) const = 0;
 
   /// Contribution towards the flow proportional to the scalar inelastic
   /// strain rate
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const = 0;
   /// Derivative of g wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const = 0;
   /// Derivative of g wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const = 0;
 
   /// Contribution towards the flow proportional directly to time
-  virtual int g_time(const double * const s, const double * const alpha, double T,
+  virtual void g_time(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Derivative of g_time wrt stress
-  virtual int dg_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Derivative of g_time wrt history
-  virtual int dg_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dg_da_time(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
 
   /// Contribution towards the flow proportional to the temperature rate
-  virtual int g_temp(const double * const s, const double * const alpha, double T,
+  virtual void g_temp(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Derivative of g_temp wrt stress
-  virtual int dg_ds_temp(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds_temp(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Derivative of g_temp wrt history
-  virtual int dg_da_temp(const double * const s, const double * const alpha, double T,
+  virtual void dg_da_temp(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
 
   /// Hardening rate proportional to the scalar inelastic strain rate
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const = 0;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const = 0;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const = 0;
 
   /// Hardening rate proportional directly to time
-  virtual int h_time(const double * const s, const double * const alpha, double T,
+  virtual void h_time(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_time wrt stress
-  virtual int dh_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_time wrt history
-  virtual int dh_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening rate proportional to the temperature rate
-  virtual int h_temp(const double * const s, const double * const alpha, double T,
+  virtual void h_temp(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_temp wrt. stress
-  virtual int dh_ds_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_temp wrt history
-  virtual int dh_da_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Optional method to give a better initial guess
@@ -156,36 +156,36 @@ class NEML_EXPORT PerzynaFlowRule : public ViscoPlasticFlowRule {
   /// Number of history variables
   virtual size_t nhist() const;
   /// Initialize history at time zero
-  virtual int init_hist(double * const h) const;
+  virtual void init_hist(double * const h) const;
 
   /// Scalar strain rate
-  virtual int y(const double* const s, const double* const alpha, double T,
+  virtual void y(const double* const s, const double* const alpha, double T,
                 double & yv) const;
   /// Derivative of y wrt stress
-  virtual int dy_ds(const double* const s, const double* const alpha, double T,
+  virtual void dy_ds(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
   /// Derivative of y wrt history
-  virtual int dy_da(const double* const s, const double* const alpha, double T,
+  virtual void dy_da(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
 
   /// Flow rule proportional to the scalar strain rate
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Derivative of g wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Derivative of g wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
 
   /// Hardening rule proportional to the scalar strain rate
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
  private:
@@ -279,56 +279,56 @@ class NEML_EXPORT ChabocheFlowRule: public ViscoPlasticFlowRule {
   /// Number of history variables (from the hardening model)
   virtual size_t nhist() const;
   /// Initialize history at time zero
-  virtual int init_hist(double * const h) const;
+  virtual void init_hist(double * const h) const;
 
   // Scalar inelastic strain rate
-  virtual int y(const double* const s, const double* const alpha, double T,
+  virtual void y(const double* const s, const double* const alpha, double T,
                 double & yv) const;
   /// Derivative of y wrt stress
-  virtual int dy_ds(const double* const s, const double* const alpha, double T,
+  virtual void dy_ds(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
   /// Derivative of y wrt history
-  virtual int dy_da(const double* const s, const double* const alpha, double T,
+  virtual void dy_da(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
 
   /// Flow rule proportional to the scalar strain rate
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Derivative of g wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Derivative of g wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
 
   /// Hardening rule proportional to the scalar strain rate
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening rule proportional to time
-  virtual int h_time(const double * const s, const double * const alpha, double T,
+  virtual void h_time(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_time wrt stress
-  virtual int dh_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_time wrt history
-  virtual int dh_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening rule proportional to temperature rate
-  virtual int h_temp(const double * const s, const double * const alpha, double T,
+  virtual void h_temp(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_temp wrt stress
-  virtual int dh_ds_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_temp wrt history
-  virtual int dh_da_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
  private:
@@ -368,46 +368,46 @@ class NEML_EXPORT YaguchiGr91FlowRule: public ViscoPlasticFlowRule {
   virtual size_t nhist() const;
   /// Initialize history (6 values for X1, 6 values for X2, 1 value for Q and
   /// 1 value for sigma_a)
-  virtual int init_hist(double * const h) const;
+  virtual void init_hist(double * const h) const;
 
   /// Scalar inelastic strain rate
-  virtual int y(const double* const s, const double* const alpha, double T,
+  virtual void y(const double* const s, const double* const alpha, double T,
                 double & yv) const;
   /// Derivative of y wrt stress
-  virtual int dy_ds(const double* const s, const double* const alpha, double T,
+  virtual void dy_ds(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
   /// Derivative of y wrt history
-  virtual int dy_da(const double* const s, const double* const alpha, double T,
+  virtual void dy_da(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
 
   /// Flow rule proportional to the scalar strain rate
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Derivative of g wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Derivative of g wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
 
   /// Hardening rule proportional to scalar inelastic strain rate
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Hardening rule proportional to time
-  virtual int h_time(const double * const s, const double * const alpha, double T,
+  virtual void h_time(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Derivative of h_time wrt stress
-  virtual int dh_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Derivative of h_time wrt history
-  virtual int dh_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
 
   /// Value of parameter D

--- a/include/walker.h
+++ b/include/walker.h
@@ -32,68 +32,68 @@ class NEML_EXPORT WalkerKremplSwitchRule : public GeneralFlowRule {
   /// Number of history variables
   virtual size_t nhist() const;
   /// Initialize history
-  virtual int init_hist(double * const h);
+  virtual void init_hist(double * const h);
 
   /// Stress rate
-  virtual int s(const double * const s, const double * const alpha,
+  virtual void s(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const sdot);
   /// Partial of stress rate wrt stress
-  virtual int ds_ds(const double * const s, const double * const alpha,
+  virtual void ds_ds(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot);
   /// Partial of stress rate wrt history
-  virtual int ds_da(const double * const s, const double * const alpha,
+  virtual void ds_da(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot);
   /// Partial of stress rate wrt strain rate
-  virtual int ds_de(const double * const s, const double * const alpha,
+  virtual void ds_de(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_sdot);
 
   /// History rate
-  virtual int a(const double * const s, const double * const alpha,
+  virtual void a(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const adot);
   /// Partial of history rate wrt stress
-  virtual int da_ds(const double * const s, const double * const alpha,
+  virtual void da_ds(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot);
   /// Partial of history rate wrt history
-  virtual int da_da(const double * const s, const double * const alpha,
+  virtual void da_da(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot);
   /// Partial of history rate wrt strain rate
-  virtual int da_de(const double * const s, const double * const alpha,
+  virtual void da_de(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double * const d_adot);
 
   /// The implementation needs to define inelastic dissipation
-  virtual int work_rate(const double * const s, const double * const alpha,
+  virtual void work_rate(const double * const s, const double * const alpha,
                 const double * const edot, double T,
                 double Tdot,
                 double & p_rate);
 
   /// The implementation needs to define elastic strain
-  virtual int elastic_strains(const double * const s_np1, double T_np1,
+  virtual void elastic_strains(const double * const s_np1, double T_np1,
                               double * const e_np1) const;
 
   /// Set a new elastic model
-  virtual int set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
+  virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
   
   /// The kappa function controlling rate sensitivity (public for testing)
-  int kappa(const double * const edot, double T, double & kap);
+  void kappa(const double * const edot, double T, double & kap);
 
   /// Derivative of kappa wrt the strain rate (public for testing)
-  int dkappa(const double * const edot, double T, double * const dkap);
+  void dkappa(const double * const edot, double T, double * const dkap);
 
   /// Override initial guess
   virtual void override_guess(double * const x);
@@ -518,84 +518,84 @@ class NEML_EXPORT WrappedViscoPlasticFlowRule : public ViscoPlasticFlowRule {
   /// Number of history variables (from the hardening model)
   virtual size_t nhist() const;
   /// Initialize history at time zero
-  virtual int init_hist(double * const h) const;
+  virtual void init_hist(double * const h) const;
 
   /// Scalar inelastic strain rate
-  virtual int y(const double* const s, const double* const alpha, double T,
+  virtual void y(const double* const s, const double* const alpha, double T,
                 double & yv) const;
   /// Wrapped scalar inelastic strain rate
   virtual void y(const State & state, double & res) const = 0;
   /// Derivative of y wrt stress
-  virtual int dy_ds(const double* const s, const double* const alpha, double T,
+  virtual void dy_ds(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
   /// Wrapped derivative of y wrt stress
   virtual void dy_ds(const State & state, Symmetric & res) const = 0;
   /// Derivative of y wrt history
-  virtual int dy_da(const double* const s, const double* const alpha, double T,
+  virtual void dy_da(const double* const s, const double* const alpha, double T,
                 double * const dyv) const;
   /// Wrapped derivative of y wrt history
   virtual void dy_da(const State & state, History & res) const = 0;
 
   /// Flow rule proportional to the scalar strain rate
-  virtual int g(const double * const s, const double * const alpha, double T,
+  virtual void g(const double * const s, const double * const alpha, double T,
                 double * const gv) const;
   /// Wrapped flow rule proportional to the scalar strain rate
   virtual void g(const State & state, Symmetric & res) const = 0;
   /// Derivative of g wrt stress
-  virtual int dg_ds(const double * const s, const double * const alpha, double T,
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
                 double * const dgv) const;
   /// Wrapped derivative of g wrt stress
   virtual void dg_ds(const State & state, SymSymR4 & res) const = 0;
   /// Derivative of g wrt history
-  virtual int dg_da(const double * const s, const double * const alpha, double T,
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
                double * const dgv) const;
   /// Wrapped derivative of g wrt history
   virtual void dg_da(const State & state, History & res) const = 0;
 
   /// Hardening rule proportional to the scalar strain rate
-  virtual int h(const double * const s, const double * const alpha, double T,
+  virtual void h(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Wrapped hardening rule proportional to the scalar strain rate
   virtual void h(const State & state, History & res) const = 0;
   /// Derivative of h wrt stress
-  virtual int dh_ds(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Wrapped derivative of h wrt stress
   virtual void dh_ds(const State & state, History & res) const = 0;
   /// Derivative of h wrt history
-  virtual int dh_da(const double * const s, const double * const alpha, double T,
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Wrapped derivative of h wrt history
   virtual void dh_da(const State & state, History & res) const = 0;
 
   /// Hardening rule proportional to time
-  virtual int h_time(const double * const s, const double * const alpha, double T,
+  virtual void h_time(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Wrapped hardening rule proportional to time
   virtual void h_time(const State & state, History & res) const;
   /// Derivative of h_time wrt stress
-  virtual int dh_ds_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Wrapped derivative of h_time wrt stress
   virtual void dh_ds_time(const State & state, History & res) const;
   /// Derivative of h_time wrt history
-  virtual int dh_da_time(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Wrapped derivative of h_time wrt history
   virtual void dh_da_time(const State & state, History & res) const;
 
   /// Hardening rule proportional to temperature rate
-  virtual int h_temp(const double * const s, const double * const alpha, double T,
+  virtual void h_temp(const double * const s, const double * const alpha, double T,
                 double * const hv) const;
   /// Wrapped hardening rule proportional to temperature rate
   virtual void h_temp(const State & state, History & res) const;
   /// Derivative of h_temp wrt stress
-  virtual int dh_ds_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_ds_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Wrapped derivative of h_temp wrt stress
   virtual void dh_ds_temp(const State & state, History & res) const;
   /// Derivative of h_temp wrt history
-  virtual int dh_da_temp(const double * const s, const double * const alpha, double T,
+  virtual void dh_da_temp(const double * const s, const double * const alpha, double T,
                 double * const dhv) const;
   /// Wrapped derivative of h_temp wrt history
   virtual void dh_da_temp(const State & state, History & res) const;

--- a/src/block.cxx
+++ b/src/block.cxx
@@ -165,20 +165,21 @@ void block_evaluate(
 #ifdef USE_OMP
 #pragma omp parallel for
 #endif
-  try {
-    for (size_t i = 0; i < nblock; i++) {
+  for (size_t i = 0; i < nblock; i++) { 
+    try {
       model->update_sd(
           &e_np1_local[i*6], &e_n_local[i*6], T_np1[i], T_n[i], t_np1, t_n,
           &s_np1_local[i*6], &s_n_local[i*6], &h_np1[i*nh], &h_n[i*nh],
           &A_np1_local[i*36], u_np1[i], u_n[i], p_np1[i], p_n[i]);
     }
-  }
-  catch (const NEMLError & e) {
-    delete [] e_np1_local;
-    delete [] e_n_local;
-    delete [] s_np1_local;
-    delete [] s_n_local;
-    delete [] A_np1_local; 
+    catch (const NEMLError & e) {
+      delete [] e_np1_local;
+      delete [] e_n_local;
+      delete [] s_np1_local;
+      delete [] s_n_local;
+      delete [] A_np1_local; 
+      return;
+    }
   }
 
   m2t(s_np1_local, s_np1, nblock);

--- a/src/block_wrap.cxx
+++ b/src/block_wrap.cxx
@@ -147,19 +147,15 @@ PYBIND11_MODULE(block, m) {
           double * p_n_ptr = arr2ptr<double>(p_n);
 
           // Release the GIL and call the batch update
-          int ier;
           {
             py::gil_scoped_release release;
 
-            ier = block_evaluate(model, nblock, 
+            block_evaluate(model, nblock, 
                                  e_np1_ptr, e_n_ptr, T_np1_ptr, T_n_ptr,
                                  t_np1, t_n, s_np1_ptr, s_n_ptr,
                                  h_np1_ptr, h_n_ptr, A_np1_ptr,
                                  u_np1_ptr, u_n_ptr, p_np1_ptr, p_n_ptr);
           }
-
-          // Grab the GIL and check for errors
-          py_error(ier);
 
         }, "Block evaluate a bunch of models in tensor notation");
 

--- a/src/cinterface.cxx
+++ b/src/cinterface.cxx
@@ -62,7 +62,7 @@ int nstore_nemlmodel(NEMLMODEL * model)
 void init_store_nemlmodel(NEMLMODEL * model, double * store, int * ier)
 {
   try {
-    *ier = model->init_store(store);
+    model->init_store(store);
   }
   catch (...) {
     *ier = -1;

--- a/src/cinterface.cxx
+++ b/src/cinterface.cxx
@@ -42,7 +42,7 @@ void elastic_strains_nemlmodel(NEMLMODEL * model, double * s_np1,
                                double * e_np1, int * ier)
 {
   try {
-    *ier = model->elastic_strains(s_np1, T_np1, h_np1, e_np1);
+     model->elastic_strains(s_np1, T_np1, h_np1, e_np1);
   }
   catch (...) {
     *ier = -1;
@@ -80,7 +80,7 @@ void update_sd_nemlmodel(NEMLMODEL * model, double * e_np1, double * e_n,
                          int * ier)
 {
   try {
-    *ier = model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
+    model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
                             h_np1, h_n, A_np1, *u_np1, u_n, *p_np1, p_n);
   }
   catch (...) {

--- a/src/cinterface.cxx
+++ b/src/cinterface.cxx
@@ -11,7 +11,7 @@ NEMLMODEL * create_nemlmodel(const char * fname, const char * mname, int * ier)
     return umodel.release();
   }
   catch (...) {
-    *ier = neml::UNKNOWN_ERROR;
+    *ier = -1;
     return NULL;
   }
 }
@@ -23,7 +23,7 @@ void destroy_nemlmodel(NEMLMODEL * model, int * ier)
     *ier = 0;
   }
   catch (...) {
-    *ier = neml::UNKNOWN_ERROR;
+    *ier = -1;
   }
 }
 
@@ -45,7 +45,7 @@ void elastic_strains_nemlmodel(NEMLMODEL * model, double * s_np1,
     *ier = model->elastic_strains(s_np1, T_np1, h_np1, e_np1);
   }
   catch (...) {
-    *ier = neml::UNKNOWN_ERROR;
+    *ier = -1;
   }
 }
 
@@ -65,7 +65,7 @@ void init_store_nemlmodel(NEMLMODEL * model, double * store, int * ier)
     *ier = model->init_store(store);
   }
   catch (...) {
-    *ier = neml::UNKNOWN_ERROR;
+    *ier = -1;
   }
 }
 
@@ -84,6 +84,6 @@ void update_sd_nemlmodel(NEMLMODEL * model, double * e_np1, double * e_n,
                             h_np1, h_n, A_np1, *u_np1, u_n, *p_np1, p_n);
   }
   catch (...) {
-    *ier = neml::UNKNOWN_ERROR;
+    *ier = -1;
   }
 }

--- a/src/cp/batch.cxx
+++ b/src/cp/batch.cxx
@@ -63,7 +63,8 @@ int set_orientation_passive_batch(SingleCrystalModel & model, size_t n,
                                   double * const hist,
                                   std::vector<Orientation> orientations)
 {
-  if (orientations.size() != n) return INCOMPATIBLE_VECTORS;
+  if (orientations.size() != n) 
+    throw NEMLError("Vector of orientations does not match batch size");
   
   size_t nh = model.nstore();
 

--- a/src/cp/batch.cxx
+++ b/src/cp/batch.cxx
@@ -6,7 +6,7 @@
 
 namespace neml {
 
-int evaluate_crystal_batch(SingleCrystalModel & model, size_t n, 
+void evaluate_crystal_batch(SingleCrystalModel & model, size_t n, 
                            const double * const d_np1, const double * const d_n, 
                            const double * const w_np1, const double * const w_n, 
                            const double * const T_np1, const double * const T_n, 
@@ -19,7 +19,6 @@ int evaluate_crystal_batch(SingleCrystalModel & model, size_t n,
                            int nthreads)
 {
   size_t nh = model.nstore();
-  int * ier = new int [n];
   
   #ifdef USE_OMP
   omp_set_num_threads(nthreads);
@@ -29,37 +28,23 @@ int evaluate_crystal_batch(SingleCrystalModel & model, size_t n,
 #pragma omp parallel for
 #endif
   for (size_t i=0; i<n; i++) {
-    ier[i] = model.update_ld_inc(&d_np1[i*6], &d_n[i*6], &w_np1[i*3], &w_n[i*3],
+    model.update_ld_inc(&d_np1[i*6], &d_n[i*6], &w_np1[i*3], &w_n[i*3],
                                  T_np1[i], T_n[i], t_np1, t_n, &s_np1[i*6],
                                  &s_n[i*6], &h_np1[i*nh], &h_n[i*nh],
                                  &A_np1[i*36], &B_np1[i*18], 
                                  u_np1[i], u_n[i], p_np1[i], p_n[i]);
   }
-  
-  int ret = 0;
-  for (size_t i = 0; i<n; i++) {
-    if (ier[i] != 0) {
-      ret = ier[i];
-      break;
-    }
-  }
-
-  delete [] ier;
-
-  return ret;
 }
 
-int init_history_batch(SingleCrystalModel & model, size_t n, double * const hist)
+void init_history_batch(SingleCrystalModel & model, size_t n, double * const hist)
 {
   size_t nh = model.nstore();
   for (size_t i=0; i<n; i++) {
-    int ier = model.init_store(&hist[i*nh]);
-    if (ier !=0) return ier;
+    model.init_store(&hist[i*nh]);
   }
-  return 0;
 }
 
-int set_orientation_passive_batch(SingleCrystalModel & model, size_t n,
+void set_orientation_passive_batch(SingleCrystalModel & model, size_t n,
                                   double * const hist,
                                   std::vector<Orientation> orientations)
 {
@@ -71,11 +56,9 @@ int set_orientation_passive_batch(SingleCrystalModel & model, size_t n,
   for (size_t i=0; i<n; i++) {
     model.set_passive_orientation(&hist[i*nh], orientations[i]);
   }
-
-  return 0;
 }
 
-int get_orientation_passive_batch(SingleCrystalModel & model, size_t n,
+void get_orientation_passive_batch(SingleCrystalModel & model, size_t n,
                                   double * const hist,
                                   std::vector<Orientation> & orientations)
 {
@@ -85,8 +68,6 @@ int get_orientation_passive_batch(SingleCrystalModel & model, size_t n,
   for (size_t i=0; i<n; i++) {
     orientations[i] = model.get_passive_orientation(&hist[i*nh]);
   }
-
-  return 0;
 }
 
 } // namespace neml

--- a/src/cp/batch_wrap.cxx
+++ b/src/cp/batch_wrap.cxx
@@ -124,10 +124,9 @@ PYBIND11_MODULE(batch, m) {
           double * p_n_ptr = arr2ptr<double>(p_n);
 
           // bye bye GIL
-          int ier;
           {
             py::gil_scoped_release release;
-            ier = evaluate_crystal_batch(model, n,
+            evaluate_crystal_batch(model, n,
                                          d_np1_ptr, d_n_ptr, w_np1_ptr, w_n_ptr,
                                          T_np1_ptr, T_n_ptr, t_np1, t_n,
                                          s_np1_ptr, s_n_ptr,
@@ -136,8 +135,6 @@ PYBIND11_MODULE(batch, m) {
                                          u_np1_ptr, u_n_ptr,
                                          p_np1_ptr, p_n_ptr, nthreads);
           }
-
-          py_error(ier);
 
           return std::make_tuple(s_np1, h_np1, A_np1, B_np1, u_np1, p_np1);
 
@@ -153,8 +150,7 @@ PYBIND11_MODULE(batch, m) {
         {
           int nh = model.nstore();
           auto h = alloc_mat<double>(n,nh);
-          int ier = init_history_batch(model, n, arr2ptr<double>(h));
-          py_error(ier);
+          init_history_batch(model, n, arr2ptr<double>(h));
           return h;
         }, "Batch initialize history");
   m.def("set_orientation_passive_batch",
@@ -174,11 +170,9 @@ PYBIND11_MODULE(batch, m) {
             throw std::runtime_error("History and input orientations are not compatible!");
           }
 
-          int ier = set_orientation_passive_batch(model, n, 
+          set_orientation_passive_batch(model, n, 
                                                   arr2ptr<double>(h),
                                                   qs);
-          py_error(ier);
-
         }, "Set passive orientations from a big vector");
   m.def("get_orientation_passive_batch",
         [](SingleCrystalModel & model, py::array_t<double, py::array::c_style>
@@ -195,11 +189,9 @@ PYBIND11_MODULE(batch, m) {
             throw std::runtime_error("History input not compatible with model");
           }
 
-          int ier = get_orientation_passive_batch(model, n, 
+          get_orientation_passive_batch(model, n, 
                                                   arr2ptr<double>(h),
                                                   res);
-          py_error(ier);
-
           return res;
         }, "Get passive orientations from a polycrystal.");
 

--- a/src/cp/polycrystal.cxx
+++ b/src/cp/polycrystal.cxx
@@ -23,7 +23,7 @@ size_t PolycrystalModel::nhist() const
   return (model_->nstore() + 6 + 6 + 3) * n();
 }
 
-int PolycrystalModel::init_hist(double * const hist) const
+void PolycrystalModel::init_hist(double * const hist) const
 {
   for (size_t i = 0; i < n(); i++) {
     model_->init_store(history(hist, i));
@@ -33,8 +33,6 @@ int PolycrystalModel::init_hist(double * const hist) const
     std::fill(d(hist, i), d(hist, i) + 6, 0);
     std::fill(w(hist, i), w(hist, i) + 3, 0);
   }
-
-  return 0;
 }
 
 double * PolycrystalModel::history(double * const store, size_t i) const 
@@ -123,7 +121,7 @@ void TaylorModel::init_store(double * const store) const
   init_hist(store);
 }
 
-int TaylorModel::update_ld_inc(
+void TaylorModel::update_ld_inc(
    const double * const d_np1, const double * const d_n,
    const double * const w_np1, const double * const w_n,
    double T_np1, double T_n,
@@ -195,8 +193,6 @@ int TaylorModel::update_ld_inc(
 
   u_np1 += u_n;
   p_np1 += p_n;
-
-  return 0;
 }
 
 double TaylorModel::alpha(double T) const
@@ -204,7 +200,7 @@ double TaylorModel::alpha(double T) const
   return model_->alpha(T);
 }
 
-int TaylorModel::elastic_strains(const double * const s_np1, 
+void TaylorModel::elastic_strains(const double * const s_np1, 
                                  double T_np1, const double * const h_np1, 
                                  double * const e_np1) const
 {
@@ -218,8 +214,6 @@ int TaylorModel::elastic_strains(const double * const s_np1,
   }
 
   for (size_t j = 0; j < n(); j++) e_np1[j] /= n();
-
-  return 0;
 }
 
 }

--- a/src/cp/polycrystal.cxx
+++ b/src/cp/polycrystal.cxx
@@ -118,9 +118,9 @@ size_t TaylorModel::nstore() const
   return nhist();
 }
 
-int TaylorModel::init_store(double * const store) const
+void TaylorModel::init_store(double * const store) const
 {
-  return init_hist(store);
+  init_hist(store);
 }
 
 int TaylorModel::update_ld_inc(
@@ -158,7 +158,7 @@ int TaylorModel::update_ld_inc(
     std::copy(w_np1, w_np1+3, w(h_np1, i));
   }
 
-  int ier = evaluate_crystal_batch(*model_, n(), 
+  evaluate_crystal_batch(*model_, n(), 
                          d(h_np1, 0), d(h_n, 0),
                          w(h_np1, 0), w(h_n, 0),
                          Ts_np1, Ts_n,
@@ -196,7 +196,7 @@ int TaylorModel::update_ld_inc(
   u_np1 += u_n;
   p_np1 += p_n;
 
-  return ier;
+  return 0;
 }
 
 double TaylorModel::alpha(double T) const

--- a/src/cp/singlecrystal.cxx
+++ b/src/cp/singlecrystal.cxx
@@ -127,7 +127,7 @@ void SingleCrystalModel::Fe(double * const stress, double * const hist,
   FE = ((Symmetric::id() + estrain) * RR).inverse();
 }
 
-int SingleCrystalModel::update_ld_inc(
+void SingleCrystalModel::update_ld_inc(
    const double * const d_np1, const double * const d_n,
    const double * const w_np1, const double * const w_n,
    double T_np1, double T_n,
@@ -145,7 +145,7 @@ int SingleCrystalModel::update_ld_inc(
                                     s_np1, s_n, h_np1, h_n, 
                                     A_np1, B_np1, u_np1, u_n,
                                     p_np1, p_n, 1);
-    return 0;
+    return;
   }
 
   // Try with a predictor
@@ -177,11 +177,9 @@ int SingleCrystalModel::update_ld_inc(
         throw e;
     }
   }
-  
-  return 0;
 }
 
-int SingleCrystalModel::attempt_update_ld_inc_(
+void SingleCrystalModel::attempt_update_ld_inc_(
    const double * const d_np1, const double * const d_n,
    const double * const w_np1, const double * const w_n,
    double T_np1, double T_n,
@@ -330,8 +328,6 @@ int SingleCrystalModel::attempt_update_ld_inc_(
   // Update model based on any post-processors
   for (auto pp : postprocessors_)
     pp->act(*this, local_lattice, T_np1, D, W, HF_np1, HF_n);
-
-  return 0;
 }
 
 size_t SingleCrystalModel::nhist() const
@@ -339,12 +335,11 @@ size_t SingleCrystalModel::nhist() const
   return stored_hist_.size();
 }
 
-int SingleCrystalModel::init_hist(double * const hist) const
+void SingleCrystalModel::init_hist(double * const hist) const
 {
   std::fill(hist, hist+nhist(), 0.0); // Shuts it up about initialized memory
   History h = gather_history_(hist);
   init_history(h);
-  return 0;
 }
 
 double SingleCrystalModel::alpha(double T) const
@@ -352,7 +347,7 @@ double SingleCrystalModel::alpha(double T) const
   return alpha_->value(T);
 }
 
-int SingleCrystalModel::elastic_strains(
+void SingleCrystalModel::elastic_strains(
     const double * const s_np1,
     double T_np1, const double * const h_np1,
     double * const e_np1) const
@@ -365,8 +360,6 @@ int SingleCrystalModel::elastic_strains(
                                                    h.get<Orientation>("rotation"), 
                                                    h, T_np1);
   std::copy(estrain.data(), estrain.data()+6, e_np1);
-
-  return 0;
 }
 
 size_t SingleCrystalModel::nparams() const
@@ -759,7 +752,7 @@ double SingleCrystalModel::calc_work_inc_(
   return dU - dE;
 }
 
-int SingleCrystalModel::solve_substep_(SCTrialState * ts,
+void SingleCrystalModel::solve_substep_(SCTrialState * ts,
                                        Symmetric & stress,
                                        History & hist)
 {
@@ -770,8 +763,6 @@ int SingleCrystalModel::solve_substep_(SCTrialState * ts,
   // Dump the results
   stress.copy_data(x);
   hist.copy_data(&x[6]);
-
-  return 0;
 }
 
 std::vector<std::string> SingleCrystalModel::not_updated_() const

--- a/src/cp/singlecrystal.cxx
+++ b/src/cp/singlecrystal.cxx
@@ -374,15 +374,14 @@ size_t SingleCrystalModel::nparams() const
   return 6 + nhist() - static_size_;
 }
 
-int SingleCrystalModel::init_x(double * const x, TrialState * ts)
+void SingleCrystalModel::init_x(double * const x, TrialState * ts)
 {
   SCTrialState * ats = static_cast<SCTrialState*>(ts);
   std::copy(ats->S.data(), ats->S.data()+6, x);
   std::copy(ats->history.rawptr(), ats->history.rawptr()+ats->history.size(), &x[6]);
-  return 0;
 }
 
-int SingleCrystalModel::RJ(const double * const x, TrialState * ts,
+void SingleCrystalModel::RJ(const double * const x, TrialState * ts,
                            double * const R, double * const J)
 {
   // Cast trial state
@@ -452,8 +451,6 @@ int SingleCrystalModel::RJ(const double * const x, TrialState * ts,
   for (size_t i = 0; i<nparams(); i++) {
     J[CINDEX(i,i,nparams())] += 1.0;
   }
-
-  return 0;
 }
 
 Orientation SingleCrystalModel::get_active_orientation(

--- a/src/creep.cxx
+++ b/src/creep.cxx
@@ -681,13 +681,13 @@ int CreepModel::update(const double * const s_np1,
   // Setup the trial state
   CreepModelTrialState ts;
   int ier = make_trial_state(s_np1, e_n, T_np1, T_n, t_np1, t_n, ts);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Solve for the new creep strain
   std::vector<double> xv(nparams());
   double * x = &xv[0];
   ier = solve(this, x, &ts, {rtol_, atol_, miter_, verbose_, linesearch_});
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   
   // Extract
   std::copy(x, x+6, e_np1);
@@ -733,12 +733,12 @@ int CreepModel::RJ(const double * const x, TrialState * ts,
   
   // Residual
   int ier = f(tss->s_np1, x, tss->t, tss->T, R);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<6; i++) R[i] = x[i] - tss->e_n[i] - R[i] * tss->dt;
 
   // Jacobian
   ier = df_de(tss->s_np1, x, tss->t, tss->T, J);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<36; i++) J[i] = -J[i] * tss->dt;
   for (int i=0; i<6; i++) J[CINDEX(i,i,6)] += 1.0;
 
@@ -754,16 +754,16 @@ int CreepModel::calc_tangent_(const double * const e_np1,
   double J[36];
 
   ier = RJ(e_np1, &ts, R, J);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   ier = invert_mat(J, 6);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   for (int i=0; i<36; i++) J[i] = J[i] * ts.dt;
 
   double B[36];
   ier = df_ds(ts.s_np1, e_np1, ts.t, ts.T, B);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   mat_mat(6, 6, 6, J, B, A_np1);
 
@@ -909,12 +909,12 @@ int J2CreepModel::f(const double * const s, const double * const e, double t,
   // Get the direction
   std::copy(s, s+6, f);
   ier = sdir(f);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Get the rate
   double rate;
   ier = rule_->g(se, ee, t, T, rate);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Multiply the two together
   for (int i=0; i<6; i++) f[i] *= 3.0/2.0 * rate;
@@ -939,12 +939,12 @@ int J2CreepModel::df_ds(const double * const s, const double * const e,
   // Get the rate
   double rate;
   ier = rule_->g(se, ee, t, T, rate);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Get the rate derivative
   double drate;
   ier = rule_->dg_ds(se, ee, t, T, drate);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Get our usual funny identity tensor
   double ID[36];
@@ -990,25 +990,25 @@ int J2CreepModel::df_de(const double * const s, const double * const e, double t
   double s_dir[6];
   std::copy(s, s+6, s_dir);
   ier = sdir(s_dir);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Get the strain direction
   double e_dir[6];
   std::copy(e, e+6, e_dir);
   ier = edir(e_dir);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Get the derivative
   double drate;
   ier = rule_->dg_de(se, ee, t, T, drate);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Tack onto the direction
   for (int i=0; i<6; i++) e_dir[i] *= drate;
 
   // Form the final outer product
   ier = outer_vec(s_dir, 6, e_dir, 6, df);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   return 0;
 }
@@ -1025,12 +1025,12 @@ int J2CreepModel::df_dt(const double * const s, const double * const e,
   // Get the stress direction
   std::copy(s, s+6, df);
   ier = sdir(df);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Get the derivative
   double drate;
   ier = rule_->dg_dt(se, ee, t, T, drate);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Multiply
   for (int i=0; i<6; i++) df[i] *= 3.0/2.0 * drate;
@@ -1050,12 +1050,12 @@ int J2CreepModel::df_dT(const double * const s, const double * const e,
   // Get the stress direction
   std::copy(s, s+6, df);
   ier = sdir(df);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Get the derivative
   double drate;
   ier = rule_->dg_dT(se, ee, t, T, drate);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   // Multiply
   for (int i=0; i<6; i++) df[i] *= 3.0/2.0 * drate;

--- a/src/creep.cxx
+++ b/src/creep.cxx
@@ -16,20 +16,18 @@ ScalarCreepRule::ScalarCreepRule(ParameterSet & params) :
 }
 
 // Scalar creep default derivatives for time and temperature
-int ScalarCreepRule::dg_dt(double seq, double eeq, double t, double T,
+void ScalarCreepRule::dg_dt(double seq, double eeq, double t, double T,
                            double & dg) const
 {
   dg = 0.0;
 
-  return 0;
 }
 
-int ScalarCreepRule::dg_dT(double seq, double eeq, double t, double T,
+void ScalarCreepRule::dg_dT(double seq, double eeq, double t, double T,
                            double & dg) const
 {
   dg = 0.0;
 
-  return 0;
 }
 
 // Implementation of power law creep
@@ -62,24 +60,21 @@ std::unique_ptr<NEMLObject> PowerLawCreep::initialize(ParameterSet & params)
 }
 
 
-int PowerLawCreep::g(double seq, double eeq, double t, double T, double & g) const
+void PowerLawCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   g = A_->value(T) * pow(seq, n_->value(T));
-  return 0;
 }
 
-int PowerLawCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void PowerLawCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
   double nv = n_->value(T);
 
   dg = A_->value(T) * nv * pow(seq, nv - 1.0);
-  return 0;
 }
 
-int PowerLawCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void PowerLawCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
 double PowerLawCreep::A(double T) const
@@ -122,25 +117,22 @@ std::unique_ptr<NEMLObject> NormalizedPowerLawCreep::initialize(ParameterSet & p
 }
 
 
-int NormalizedPowerLawCreep::g(double seq, double eeq, double t, double T, double & g) const
+void NormalizedPowerLawCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   g = pow(seq / s0_->value(T), n_->value(T));
-  return 0;
 }
 
-int NormalizedPowerLawCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void NormalizedPowerLawCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
   double nv = n_->value(T);
   double s0v = s0_->value(T);
 
   dg = nv / s0v * pow(seq / s0v, nv - 1.0);
-  return 0;
 }
 
-int NormalizedPowerLawCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void NormalizedPowerLawCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
 // Implementation of the Blackburn minimum creep rate equation
@@ -179,7 +171,7 @@ std::unique_ptr<NEMLObject> BlackburnMinimumCreep::initialize(ParameterSet & par
 }
 
 
-int BlackburnMinimumCreep::g(double seq, double eeq, double t, double T, double & g) const
+void BlackburnMinimumCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   double A = A_->value(T);
   double n = n_->value(T);
@@ -187,10 +179,9 @@ int BlackburnMinimumCreep::g(double seq, double eeq, double t, double T, double 
 
   g = A * pow(sinh(beta * seq / n), n) * exp(-Q_ / (R_ * T));
 
-  return 0;
 }
 
-int BlackburnMinimumCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void BlackburnMinimumCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
   double A = A_->value(T);
   double n = n_->value(T);
@@ -199,23 +190,20 @@ int BlackburnMinimumCreep::dg_ds(double seq, double eeq, double t, double T, dou
   dg = A * beta * exp(-Q_ / (R_ * T)) * cosh(beta * seq / n) * 
       pow(sinh(beta * seq / n), n - 1.0);
 
-  return 0;
 }
 
-int BlackburnMinimumCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void BlackburnMinimumCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
-int BlackburnMinimumCreep::dg_dT(double seq, double eeq, double t, double T, double & dg) const
+void BlackburnMinimumCreep::dg_dT(double seq, double eeq, double t, double T, double & dg) const
 {
   double A = A_->value(T);
   double n = n_->value(T);
   double beta = beta_->value(T);
 
   dg = A * pow(sinh(beta * seq / n), n) * exp(-Q_ / (R_ * T)) * Q_ / (R_ * T * T);
-  return 0;
 }
 
 // Implementation of the Swindeman minimum creep rate equation
@@ -255,32 +243,28 @@ std::unique_ptr<NEMLObject> SwindemanMinimumCreep::initialize(ParameterSet & par
 }
 
 
-int SwindemanMinimumCreep::g(double seq, double eeq, double t, double T, double & g) const
+void SwindemanMinimumCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   g = C_ * pow(seq, n_) * exp(V_ * seq) * exp(-Q_/(T+shift_));
 
-  return 0;
 }
 
-int SwindemanMinimumCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void SwindemanMinimumCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
 
   dg = C_ * exp(-Q_/(T+shift_)) * (n_ + seq * V_) * exp(seq * V_) * pow(seq, n_ - 1.0);
 
-  return 0;
 }
 
-int SwindemanMinimumCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void SwindemanMinimumCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
-int SwindemanMinimumCreep::dg_dT(double seq, double eeq, double t, double T, double & dg) const
+void SwindemanMinimumCreep::dg_dT(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = C_ * pow(seq, n_) * exp(V_ * seq) * exp(-Q_/(T+shift_)) * Q_ /
       ((T+shift_) * (T+shift_)); 
-  return 0;
 }
 
 // Implementation of the mechanism switching model
@@ -326,7 +310,7 @@ std::unique_ptr<NEMLObject> RegionKMCreep::initialize(ParameterSet & params)
   return neml::make_unique<RegionKMCreep>(params); 
 }
 
-int RegionKMCreep::g(double seq, double eeq, double t, double T, double & g) const
+void RegionKMCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   double A, B;
   select_region_(seq, T, A, B);
@@ -335,10 +319,9 @@ int RegionKMCreep::g(double seq, double eeq, double t, double T, double & g) con
 
   g = eps0_ * exp(C1*B) * pow(seq / G, C1 * A);
 
-  return 0;
 }
 
-int RegionKMCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void RegionKMCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
   double A, B;
   select_region_(seq, T, A, B);
@@ -347,13 +330,11 @@ int RegionKMCreep::dg_ds(double seq, double eeq, double t, double T, double & dg
   
   dg = eps0_ * exp(C1*B) * C1 * A / G * pow(seq / G, C1 * A - 1.0);
 
-  return 0;
 }
 
-int RegionKMCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void RegionKMCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
 void RegionKMCreep::select_region_(double seq, double T, double & Ai, double & Bi) const
@@ -417,7 +398,7 @@ std::unique_ptr<NEMLObject> NortonBaileyCreep::initialize(ParameterSet & params)
   return neml::make_unique<NortonBaileyCreep>(params); 
 }
 
-int NortonBaileyCreep::g(double seq, double eeq, double t, double T, double & g) const
+void NortonBaileyCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   double A = A_->value(T);
   double m = m_->value(T);
@@ -433,10 +414,9 @@ int NortonBaileyCreep::g(double seq, double eeq, double t, double T, double & g)
 
   g = m * pow(A, 1.0 / m) * pow(seq, n / m) * pow(eeq, (m - 1.0) / m); 
 
-  return 0;
 }
 
-int NortonBaileyCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void NortonBaileyCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
   double A = A_->value(T);
   double m = m_->value(T);
@@ -452,10 +432,9 @@ int NortonBaileyCreep::dg_ds(double seq, double eeq, double t, double T, double 
 
   dg = n * pow(A, 1.0 / m) * pow(seq, n / m - 1.0) * pow(eeq, (m - 1.0) / m);
 
-  return 0;
 }
 
-int NortonBaileyCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void NortonBaileyCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   double A = A_->value(T);
   double m = m_->value(T);
@@ -471,7 +450,6 @@ int NortonBaileyCreep::dg_de(double seq, double eeq, double t, double T, double 
 
   dg = (m - 1) * pow(A, 1.0 / m) * pow(seq, n / m) * pow(eeq, -1.0 / m);
 
-  return 0;
 }
 
 double NortonBaileyCreep::A(double T) const
@@ -530,29 +508,26 @@ std::unique_ptr<NEMLObject> MukherjeeCreep::initialize(ParameterSet & params)
   return neml::make_unique<MukherjeeCreep>(params); 
 }
 
-int MukherjeeCreep::g(double seq, double eeq, double t, double T, 
+void MukherjeeCreep::g(double seq, double eeq, double t, double T, 
                       double & g) const
 {
   double mu = emodel_->G(T);
   double Dv = D0_ * exp(-Q_ / (R_ * T));
   g = A_ * Dv * mu * b_ / (k_ * T) * pow(seq / mu, n_);
-  return 0;
 }
 
-int MukherjeeCreep::dg_ds(double seq, double eeq, double t, double T,
+void MukherjeeCreep::dg_ds(double seq, double eeq, double t, double T,
                           double & dg) const
 {
   double mu = emodel_->G(T);
   double Dv = D0_ * exp(-Q_ / (R_ * T));
   dg = n_ * A_ * Dv * mu * b_ / (k_ * T) * pow(seq / mu, n_ - 1.0) / mu;
-  return 0;
 }
 
-int MukherjeeCreep::dg_de(double seq, double eeq, double t, double T,
+void MukherjeeCreep::dg_de(double seq, double eeq, double t, double T,
                           double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
 double MukherjeeCreep::A() const
@@ -616,13 +591,12 @@ ParameterSet GenericCreep::parameters()
   return pset;
 }
 
-int GenericCreep::g(double seq, double eeq, double t, double T, double & g) const
+void GenericCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   g = exp(cfn_->value(log(seq)));
-  return 0;
 }
 
-int GenericCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void GenericCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
   double f = cfn_->value(log(seq));
   double df = cfn_->derivative(log(seq));
@@ -633,13 +607,11 @@ int GenericCreep::dg_ds(double seq, double eeq, double t, double T, double & dg)
   else {
     dg = 0.0;
   }
-  return 0;
 }
 
-int GenericCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void GenericCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
 // Setup for solve
@@ -655,24 +627,22 @@ CreepModel::CreepModel(ParameterSet & params) :
 }
 
 // Creep model default derivatives for time and temperature
-int CreepModel::df_dt(const double * const s, const double * const e, double t,
+void CreepModel::df_dt(const double * const s, const double * const e, double t,
                       double T, double * const df) const
 {
   std::fill(df, df+6, 0.0);
 
-  return 0;
 }
 
-int CreepModel::df_dT(const double * const s, const double * const e, double t,
+void CreepModel::df_dT(const double * const s, const double * const e, double t,
                       double T, double * const df) const
 {
   std::fill(df, df+6, 0.0);
 
-  return 0;
 }
 
 // Implementation of creep model update
-int CreepModel::update(const double * const s_np1, 
+void CreepModel::update(const double * const s_np1, 
                        double * const e_np1, const double * const e_n,
                        double T_np1, double T_n,
                        double t_np1, double t_n,
@@ -691,10 +661,10 @@ int CreepModel::update(const double * const s_np1,
   std::copy(x, x+6, e_np1);
 
   // Get the tangent
-  return calc_tangent_(e_np1, ts, A_np1);
+  calc_tangent_(e_np1, ts, A_np1);
 }
 
-int CreepModel::make_trial_state(const double * const s_np1, 
+void CreepModel::make_trial_state(const double * const s_np1, 
                                  const double * const e_n,
                                  double T_np1, double T_n,
                                  double t_np1, double t_n,
@@ -705,8 +675,6 @@ int CreepModel::make_trial_state(const double * const s_np1,
   ts.t = t_np1;
   std::copy(e_n, e_n+6, ts.e_n);
   std::copy(s_np1, s_np1+6, ts.s_np1);
-  
-  return 0;
 }
 
 // Implement the solve
@@ -715,16 +683,15 @@ size_t CreepModel::nparams() const
   return 6; // the creep strain
 }
 
-int CreepModel::init_x(double * const x, TrialState * ts)
+void CreepModel::init_x(double * const x, TrialState * ts)
 {
   CreepModelTrialState * tss = static_cast<CreepModelTrialState *>(ts);
 
   // Just make it the previous value
   std::copy(tss->e_n, tss->e_n+6, x);
-  return 0;
 }
 
-int CreepModel::RJ(const double * const x, TrialState * ts, 
+void CreepModel::RJ(const double * const x, TrialState * ts, 
                      double * const R, double * const J)
 {
   CreepModelTrialState * tss = static_cast<CreepModelTrialState *>(ts);
@@ -737,12 +704,10 @@ int CreepModel::RJ(const double * const x, TrialState * ts,
   df_de(tss->s_np1, x, tss->t, tss->T, J);
   for (int i=0; i<36; i++) J[i] = -J[i] * tss->dt;
   for (int i=0; i<6; i++) J[CINDEX(i,i,6)] += 1.0;
-
-  return 0;
 }
 
 // Helper for tangent
-int CreepModel::calc_tangent_(const double * const e_np1, 
+void CreepModel::calc_tangent_(const double * const e_np1, 
                               CreepModelTrialState & ts, double * const A_np1)
 {
   double R[6];
@@ -757,8 +722,6 @@ int CreepModel::calc_tangent_(const double * const e_np1,
   df_ds(ts.s_np1, e_np1, ts.t, ts.T, B);
 
   mat_mat(6, 6, 6, J, B, A_np1);
-
-  return 0;
 }
 
 // Implementation of 2.25Cr-1Mo rule
@@ -786,7 +749,7 @@ std::unique_ptr<NEMLObject> MinCreep225Cr1MoCreep::initialize(ParameterSet & par
 }
 
 
-int MinCreep225Cr1MoCreep::g(double seq, double eeq, double t, double T, double & g) const
+void MinCreep225Cr1MoCreep::g(double seq, double eeq, double t, double T, double & g) const
 {
   if (seq < 60.0) {
     g = e1_(seq, T);
@@ -800,10 +763,9 @@ int MinCreep225Cr1MoCreep::g(double seq, double eeq, double t, double T, double 
     }
   }
 
-  return 0;
 }
 
-int MinCreep225Cr1MoCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+void MinCreep225Cr1MoCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
 {
   if (seq < 60.0) {
     dg = de1_(seq, T);
@@ -817,13 +779,11 @@ int MinCreep225Cr1MoCreep::dg_ds(double seq, double eeq, double t, double T, dou
     }
   }
 
-  return 0;
 }
 
-int MinCreep225Cr1MoCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+void MinCreep225Cr1MoCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
 {
   dg = 0.0;
-  return 0;
 }
 
 double MinCreep225Cr1MoCreep::e1_(double seq, double T) const
@@ -888,7 +848,7 @@ std::unique_ptr<NEMLObject> J2CreepModel::initialize(ParameterSet & params)
   return neml::make_unique<J2CreepModel>(params); 
 }
 
-int J2CreepModel::f(const double * const s, const double * const e, double t,
+void J2CreepModel::f(const double * const s, const double * const e, double t,
                     double T, double * const f) const
 {
   // Gather the effective stresses
@@ -906,10 +866,9 @@ int J2CreepModel::f(const double * const s, const double * const e, double t,
   // Multiply the two together
   for (int i=0; i<6; i++) f[i] *= 3.0/2.0 * rate;
 
-  return 0;
 }
 
-int J2CreepModel::df_ds(const double * const s, const double * const e, 
+void J2CreepModel::df_ds(const double * const s, const double * const e, 
                         double t, double T, double * const df) const
 {
   // Gather the effective stresses
@@ -957,10 +916,9 @@ int J2CreepModel::df_ds(const double * const s, const double * const e,
   // Do the final multiplication
   mat_mat(6, 6, 6, A, ID, df);
 
-  return 0;
 }
 
-int J2CreepModel::df_de(const double * const s, const double * const e, double t, double T, 
+void J2CreepModel::df_de(const double * const s, const double * const e, double t, double T, 
               double * const df) const
 {
   // Gather the effective stresses
@@ -987,10 +945,9 @@ int J2CreepModel::df_de(const double * const s, const double * const e, double t
   // Form the final outer product
   outer_vec(s_dir, 6, e_dir, 6, df);
 
-  return 0;
 }
 
-int J2CreepModel::df_dt(const double * const s, const double * const e, 
+void J2CreepModel::df_dt(const double * const s, const double * const e, 
                         double t, double T, double * const df) const 
 {
   // Gather the effective quantities
@@ -1008,10 +965,9 @@ int J2CreepModel::df_dt(const double * const s, const double * const e,
   // Multiply
   for (int i=0; i<6; i++) df[i] *= 3.0/2.0 * drate;
   
-  return 0;
 }
 
-int J2CreepModel::df_dT(const double * const s, const double * const e,
+void J2CreepModel::df_dT(const double * const s, const double * const e,
                         double t, double T, double * const df) const
 {
   // Gather the effective quantities
@@ -1029,7 +985,6 @@ int J2CreepModel::df_dT(const double * const s, const double * const e,
   // Multiply
   for (int i=0; i<6; i++) df[i] *= 3.0/2.0 * drate;
   
-  return 0;
 }
 
 // Helpers for J2 plasticity
@@ -1047,7 +1002,7 @@ double J2CreepModel::eeq(const double * const e) const
   return sqrt(2.0 / 3.0) * norm2_vec(e, 6);
 }
 
-int J2CreepModel::sdir(double * const s) const
+void J2CreepModel::sdir(double * const s) const
 {
   double se = seq(s);
   if (se < std::numeric_limits<double>::epsilon()) {
@@ -1057,10 +1012,9 @@ int J2CreepModel::sdir(double * const s) const
     dev_vec(s);
     for (int i=0; i<6; i++) s[i] /= se;
   }
-  return 0;
 }
 
-int J2CreepModel::edir(double * const e) const
+void J2CreepModel::edir(double * const e) const
 {
   double ee = eeq(e);
   if (ee < std::numeric_limits<double>::epsilon()) {
@@ -1069,7 +1023,6 @@ int J2CreepModel::edir(double * const e) const
   else {
     for (int i=0; i<6; i++) e[i] /= ee;
   }
-  return 0;
 }
 
 } // namespace neml

--- a/src/creep_wrap.cxx
+++ b/src/creep_wrap.cxx
@@ -26,8 +26,7 @@ PYBIND11_MODULE(creep, m) {
             auto e_np1 = alloc_vec<double>(6);
             auto A_np1 = alloc_mat<double>(6,6);
 
-            int ier = m.update(arr2ptr<double>(s_np1), arr2ptr<double>(e_np1), arr2ptr<double>(e_n), T_np1, T_n, t_np1, t_n, arr2ptr<double>(A_np1));
-            py_error(ier);
+            m.update(arr2ptr<double>(s_np1), arr2ptr<double>(e_np1), arr2ptr<double>(e_n), T_np1, T_n, t_np1, t_n, arr2ptr<double>(A_np1));
 
             return std::make_tuple(e_np1, A_np1);
 
@@ -37,8 +36,7 @@ PYBIND11_MODULE(creep, m) {
            [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
            {
             auto fv = alloc_vec<double>(6);
-            int ier = m.f(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(fv));
-            py_error(ier);
+            m.f(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(fv));
             return fv;
            }, "Evaluate creep rate.")
 
@@ -46,8 +44,7 @@ PYBIND11_MODULE(creep, m) {
            [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
            {
             auto dfv = alloc_mat<double>(6,6);
-            int ier = m.df_ds(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            py_error(ier);
+            m.df_ds(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
             return dfv;
            }, "Evaluate creep rate derivative wrt stress.")
 
@@ -55,8 +52,7 @@ PYBIND11_MODULE(creep, m) {
            [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
            {
             auto dfv = alloc_mat<double>(6,6);
-            int ier = m.df_de(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            py_error(ier);
+            m.df_de(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
             return dfv;
            }, "Evaluate creep rate derivative wrt strain.")
 
@@ -64,8 +60,7 @@ PYBIND11_MODULE(creep, m) {
            [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
            {
             auto dfv = alloc_vec<double>(6);
-            int ier = m.df_dt(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            py_error(ier);
+            m.df_dt(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
             return dfv;
            }, "Evaluate creep rate derivative wrt time.")
 
@@ -73,8 +68,7 @@ PYBIND11_MODULE(creep, m) {
            [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
            {
             auto dfv = alloc_vec<double>(6);
-            int ier = m.df_dT(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            py_error(ier);
+            m.df_dT(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
             return dfv;
            }, "Evaluate creep rate derivative wrt temperature.")
 
@@ -83,10 +77,9 @@ PYBIND11_MODULE(creep, m) {
            [](CreepModel & m, py::array_t<double, py::array::c_style> s_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n) -> std::unique_ptr<CreepModelTrialState>
            {
             std::unique_ptr<CreepModelTrialState> ts(new CreepModelTrialState);
-            int ier = m.make_trial_state(arr2ptr<double>(s_np1),
+            m.make_trial_state(arr2ptr<double>(s_np1),
                                          arr2ptr<double>(e_n),
                                          T_np1, T_n, t_np1, t_n, *ts);
-            py_error(ier);
 
             return ts;
 
@@ -105,8 +98,7 @@ PYBIND11_MODULE(creep, m) {
            [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
            {
             double gv;
-            int ier = m.g(seq, eeq, t, T, gv);
-            py_error(ier);
+            m.g(seq, eeq, t, T, gv);
             return gv;
            }, "Evaluate creep rate.")
 
@@ -114,8 +106,7 @@ PYBIND11_MODULE(creep, m) {
            [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
            {
             double gv;
-            int ier = m.dg_ds(seq, eeq, t, T, gv);
-            py_error(ier);
+            m.dg_ds(seq, eeq, t, T, gv);
             return gv;
            }, "Evaluate creep rate derivative wrt stress.")
 
@@ -123,8 +114,7 @@ PYBIND11_MODULE(creep, m) {
            [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
            {
             double gv;
-            int ier = m.dg_de(seq, eeq, t, T, gv);
-            py_error(ier);
+            m.dg_de(seq, eeq, t, T, gv);
             return gv;
            }, "Evaluate creep rate derivative wrt strain.")
 
@@ -132,8 +122,7 @@ PYBIND11_MODULE(creep, m) {
            [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
            {
             double gv;
-            int ier = m.dg_dt(seq, eeq, t, T, gv);
-            py_error(ier);
+            m.dg_dt(seq, eeq, t, T, gv);
             return gv;
            }, "Evaluate creep rate wrt time.")
 
@@ -141,8 +130,7 @@ PYBIND11_MODULE(creep, m) {
            [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
            {
             double gv;
-            int ier = m.dg_dT(seq, eeq, t, T, gv);
-            py_error(ier);
+            m.dg_dT(seq, eeq, t, T, gv);
             return gv;
            }, "Evaluate creep rate wrt temperature.")
       ;

--- a/src/damage_wrap.cxx
+++ b/src/damage_wrap.cxx
@@ -25,8 +25,7 @@ PYBIND11_MODULE(damage, m) {
            [](NEMLDamagedModel_sd & m) -> py::array_t<double>
            {
             auto h = alloc_vec<double>(m.ndamage());
-            int ier = m.init_damage(arr2ptr<double>(h));
-            py_error(ier);
+            m.init_damage(arr2ptr<double>(h));
             return h;
            }, "Initialize damage variables.")
       ;
@@ -39,57 +38,52 @@ PYBIND11_MODULE(damage, m) {
            [](NEMLScalarDamagedModel_sd & m, double d_np1, double d_n, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, py::array_t<double, py::array::c_style> s_np1, py::array_t<double, py::array::c_style> s_n, double T_np1, double T_n, double t_np1, double t_n) -> double
            {
             double damage;
-            int ier = m.damage(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
+            m.damage(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
                      arr2ptr<double>(s_np1), arr2ptr<double>(s_n),
                      T_np1, T_n,
                      t_np1, t_n, &damage);
-            py_error(ier);
             return damage;
            }, "The damage evolution equation.")
       .def("ddamage_dd",
            [](NEMLScalarDamagedModel_sd & m, double d_np1, double d_n, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, py::array_t<double, py::array::c_style> s_np1, py::array_t<double, py::array::c_style> s_n, double T_np1, double T_n, double t_np1, double t_n) -> double
            {
             double ddamage;
-            int ier = m.ddamage_dd(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
+            m.ddamage_dd(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
                      arr2ptr<double>(s_np1), arr2ptr<double>(s_n),
                      T_np1, T_n,
                      t_np1, t_n, &ddamage);
-            py_error(ier);
             return ddamage;
            }, "The derivative of the damage evolution equation wrt. damage.")
       .def("ddamage_de",
            [](NEMLScalarDamagedModel_sd & m, double d_np1, double d_n, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, py::array_t<double, py::array::c_style> s_np1, py::array_t<double, py::array::c_style> s_n, double T_np1, double T_n, double t_np1, double t_n) -> py::array_t<double>
            {
             auto ddamage = alloc_vec<double>(6);
-            int ier = m.ddamage_de(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
+            m.ddamage_de(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
                      arr2ptr<double>(s_np1), arr2ptr<double>(s_n),
                      T_np1, T_n,
                      t_np1, t_n, arr2ptr<double>(ddamage));
-            py_error(ier);
             return ddamage;
            }, "The derivative of the damage evolution equation wrt. strain.") 
       .def("ddamage_ds",
            [](NEMLScalarDamagedModel_sd & m, double d_np1, double d_n, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, py::array_t<double, py::array::c_style> s_np1, py::array_t<double, py::array::c_style> s_n, double T_np1, double T_n, double t_np1, double t_n) -> py::array_t<double>
            {
             auto ddamage = alloc_vec<double>(6);
-            int ier = m.ddamage_ds(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
+            m.ddamage_ds(d_np1, d_n, arr2ptr<double>(e_np1), arr2ptr<double>(e_n),
                      arr2ptr<double>(s_np1), arr2ptr<double>(s_n),
                      T_np1, T_n,
                      t_np1, t_n, arr2ptr<double>(ddamage));
-            py_error(ier);
             return ddamage;
            }, "The derivative of the damage evolution equation wrt. stress.") 
       .def("make_trial_state",
            [](NEMLScalarDamagedModel_sd & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n, double u_n, double p_n) -> std::unique_ptr<SDTrialState>
            {
             std::unique_ptr<SDTrialState> ts(new SDTrialState);
-            int ier = m.make_trial_state(arr2ptr<double>(e_np1),
+            m.make_trial_state(arr2ptr<double>(e_np1),
                                          arr2ptr<double>(e_n),
                                          T_np1, T_n, t_np1, t_n,
                                          arr2ptr<double>(s_n),
                                          arr2ptr<double>(h_n),
                                          u_n, p_n, *ts);
-            py_error(ier);
 
             return ts;
            }, "Make a trial state, mostly for testing.")
@@ -135,16 +129,14 @@ PYBIND11_MODULE(damage, m) {
            [](EffectiveStress & m, py::array_t<double, py::array::c_style> s) -> double
            {
             double res;
-            int ier = m.effective(arr2ptr<double>(s), res);
-            py_error(ier);
+            m.effective(arr2ptr<double>(s), res);
             return res;
            }, "The effective stress measure.")
       .def("deffective",
            [](EffectiveStress & m, py::array_t<double, py::array::c_style> s) -> py::array_t<double>
            {
             auto res = alloc_vec<double>(6);
-            int ier = m.deffective(arr2ptr<double>(s), arr2ptr<double>(res));
-            py_error(ier);
+            m.deffective(arr2ptr<double>(s), arr2ptr<double>(res));
             return res;
            }, "The derivative of the effective stress measure wrt stress.")
       ;
@@ -220,8 +212,7 @@ PYBIND11_MODULE(damage, m) {
            [](NEMLStandardScalarDamagedModel_sd & m, py::array_t<double, py::array::c_style> s_np1, double d_np1, double T_np1) -> double
            {
             double fv;
-            int ier = m.f(arr2ptr<double>(s_np1), d_np1, T_np1, fv);
-            py_error(ier);
+            m.f(arr2ptr<double>(s_np1), d_np1, T_np1, fv);
             
             return fv;
            }, "The damage evolution function.")
@@ -229,8 +220,7 @@ PYBIND11_MODULE(damage, m) {
            [](NEMLStandardScalarDamagedModel_sd & m, py::array_t<double, py::array::c_style> s_np1, double d_np1, double T_np1) -> py::array_t<double>
            {
             auto dfv = alloc_vec<double>(6);
-            int ier = m.df_ds(arr2ptr<double>(s_np1), d_np1, T_np1, arr2ptr<double>(dfv));
-            py_error(ier);
+            m.df_ds(arr2ptr<double>(s_np1), d_np1, T_np1, arr2ptr<double>(dfv));
 
             return dfv;
            }, "The derivative of the damage function wrt. stress.")
@@ -238,8 +228,7 @@ PYBIND11_MODULE(damage, m) {
            [](NEMLStandardScalarDamagedModel_sd & m, py::array_t<double, py::array::c_style> s_np1, double d_np1, double T_np1) -> double
            {
             double dfv;
-            int ier = m.df_dd(arr2ptr<double>(s_np1), d_np1, T_np1, dfv);
-            py_error(ier);
+            m.df_dd(arr2ptr<double>(s_np1), d_np1, T_np1, dfv);
             
             return dfv;
            }, "The derivative of the damage function wrt. damage")

--- a/src/elasticity.cxx
+++ b/src/elasticity.cxx
@@ -92,20 +92,20 @@ std::unique_ptr<NEMLObject> IsotropicLinearElasticModel::initialize(ParameterSet
   return neml::make_unique<IsotropicLinearElasticModel>(params); 
 }
 
-int IsotropicLinearElasticModel::C(double T, double * const Cv) const
+void IsotropicLinearElasticModel::C(double T, double * const Cv) const
 {
   double G, K;
   get_GK_(T, G, K);
 
-  return C_calc_(G, K, Cv);
+  C_calc_(G, K, Cv);
 }
 
-int IsotropicLinearElasticModel::S(double T, double * const Sv) const
+void IsotropicLinearElasticModel::S(double T, double * const Sv) const
 {
   double G, K;
   get_GK_(T, G, K);
 
-  return S_calc_(G, K, Sv);
+  S_calc_(G, K, Sv);
 }
 
 double IsotropicLinearElasticModel::E(double T) const
@@ -132,7 +132,7 @@ double IsotropicLinearElasticModel::K(double T) const
   return K;
 }
 
-int IsotropicLinearElasticModel::C_calc_(double G, double K, double * const Cv) const
+void IsotropicLinearElasticModel::C_calc_(double G, double K, double * const Cv) const
 {
   double l = K - 2.0/3.0 * G;
 
@@ -153,11 +153,9 @@ int IsotropicLinearElasticModel::C_calc_(double G, double K, double * const Cv) 
   Cv[21] = 2.0 * G;
   Cv[28] = 2.0 * G;
   Cv[35] = 2.0 * G;
-
-  return 0;
 }
 
-int IsotropicLinearElasticModel::S_calc_(double G, double K, double * const Sv) const
+void IsotropicLinearElasticModel::S_calc_(double G, double K, double * const Sv) const
 {
   double l = K - 2.0/3.0 * G;
   
@@ -182,8 +180,6 @@ int IsotropicLinearElasticModel::S_calc_(double G, double K, double * const Sv) 
   Sv[21] = c;
   Sv[28] = c;
   Sv[35] = c;
-
-  return 0;
 }
 
 void IsotropicLinearElasticModel::get_GK_(double T, double & G, double & K) const
@@ -278,7 +274,7 @@ std::unique_ptr<NEMLObject> CubicLinearElasticModel::initialize(ParameterSet & p
   return neml::make_unique<CubicLinearElasticModel>(params); 
 }
 
-int CubicLinearElasticModel::C(double T, double * const Cv) const
+void CubicLinearElasticModel::C(double T, double * const Cv) const
 {
   double C1, C2, C3;
   get_components_(T, C1, C2, C3);
@@ -300,14 +296,12 @@ int CubicLinearElasticModel::C(double T, double * const Cv) const
   Cv[21] = C3;
   Cv[28] = C3;
   Cv[35] = C3;
-
-  return 0;
 }
 
-int CubicLinearElasticModel::S(double T, double * const Sv) const
+void CubicLinearElasticModel::S(double T, double * const Sv) const
 {
   C(T, Sv);
-  return invert_mat(Sv, 6);
+  invert_mat(Sv, 6);
 }
 
 void CubicLinearElasticModel::get_components_(double T, 
@@ -372,7 +366,7 @@ std::unique_ptr<NEMLObject> TransverseIsotropicLinearElasticModel::initialize(Pa
   return neml::make_unique<TransverseIsotropicLinearElasticModel>(params); 
 }
 
-int TransverseIsotropicLinearElasticModel::C(double T, double * const Cv) const
+void TransverseIsotropicLinearElasticModel::C(double T, double * const Cv) const
 {
   double C11, C33, C12, C13, C44;
   get_components_(T, C11, C33, C12, C13, C44);
@@ -393,14 +387,12 @@ int TransverseIsotropicLinearElasticModel::C(double T, double * const Cv) const
   Cv[21] = C44;
   Cv[28] = C44;
   Cv[35] = (C11-C12)/2;
-
-  return 0;
 }
 
-int TransverseIsotropicLinearElasticModel::S(double T, double * const Sv) const
+void TransverseIsotropicLinearElasticModel::S(double T, double * const Sv) const
 {
   C(T, Sv);
-  return invert_mat(Sv, 6);
+  invert_mat(Sv, 6);
 }
 
 void TransverseIsotropicLinearElasticModel::get_components_(double T, 

--- a/src/elasticity_wrap.cxx
+++ b/src/elasticity_wrap.cxx
@@ -20,8 +20,7 @@ PYBIND11_MODULE(elasticity, m) {
            [](const LinearElasticModel & m, double T) -> py::array_t<double>
            {
             auto C = alloc_mat<double>(6,6);
-            int ier = m.C(T, arr2ptr<double>(C));
-            py_error(ier);
+            m.C(T, arr2ptr<double>(C));
             return C;
            }, "Return stiffness elasticity matrix.")
 
@@ -29,8 +28,7 @@ PYBIND11_MODULE(elasticity, m) {
            [](const LinearElasticModel & m, double T) -> py::array_t<double>
            {
             auto S = alloc_mat<double>(6,6);
-            int ier = m.S(T, arr2ptr<double>(S));
-            py_error(ier);
+            m.S(T, arr2ptr<double>(S));
             return S;
            }, "Return compliance elasticity matrix.")
       .def("C_tensor",

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -84,10 +84,8 @@ int TVPFlowRule::s(const double * const s, const double * const alpha,
 
   double temp[6];
   double yv;
-  int ier = flow_->g(s, alpha, T, temp);
-  if (ier != 0) return ier;
-  ier = flow_->y(s, alpha, T, yv);
-  if (ier != 0) return ier;
+  flow_->g(s, alpha, T, temp);
+  flow_->y(s, alpha, T, yv);
   if (yv > NEML_STRAIN_RATE_LIMIT) 
     throw NEMLError("Strain rate exceeds rate limit");
   
@@ -95,14 +93,12 @@ int TVPFlowRule::s(const double * const s, const double * const alpha,
     erate[i] -= yv * temp[i];
   }
 
-  ier = flow_->g_temp(s, alpha, T, temp);
-  if (ier != 0) return ier;
+  flow_->g_temp(s, alpha, T, temp);
   for (int i=0; i<6; i++) {
     erate[i] -= Tdot * temp[i];
   }
 
-  ier = flow_->g_time(s, alpha, T, temp);
-  if (ier != 0) return ier;
+  flow_->g_time(s, alpha, T, temp);
   for (int i=0; i<6; i++) {
     erate[i] -= temp[i];
   }
@@ -122,33 +118,27 @@ int TVPFlowRule::ds_ds(const double * const s, const double * const alpha,
               double * const d_sdot)
 {
   double yv;
-  int ier = flow_->y(s, alpha, T, yv);
-  if (ier != 0) return ier;
+  flow_->y(s, alpha, T, yv);
 
   double work[36];
-  ier = flow_->dg_ds(s, alpha, T, work);
-  if (ier != 0) return ier;
+  flow_->dg_ds(s, alpha, T, work);
   for (int i=0; i<36; i++) {
     work[i] *= -yv;
   }
 
   double t1[6];
-  ier = flow_->g(s, alpha, T, t1);
-  if (ier != 0) return ier;
+  flow_->g(s, alpha, T, t1);
   double t2[6];
-  ier = flow_->dy_ds(s, alpha, T, t2);
-  if (ier != 0) return ier;
+  flow_->dy_ds(s, alpha, T, t2);
   outer_update_minus(t1, 6, t2, 6, work);
   
   double t3[36];
-  ier = flow_->dg_ds_temp(s, alpha, T, t3);
-  if (ier != 0) return ier;
+  flow_->dg_ds_temp(s, alpha, T, t3);
   for (int i=0; i<36; i++) {
     work[i] -= t3[i] * Tdot;
   }
 
-  ier = flow_->dg_ds_time(s, alpha, T, t3);
-  if (ier != 0) return ier;
+  flow_->dg_ds_time(s, alpha, T, t3);
   for (int i=0; i<36; i++) {
     work[i] -= t3[i];
   }
@@ -167,38 +157,32 @@ int TVPFlowRule::ds_da(const double * const s, const double * const alpha,
               double * const d_sdot)
 {
   double yv;
-  int ier = flow_->y(s, alpha, T, yv);
-  if (ier != 0) return ier;
+  flow_->y(s, alpha, T, yv);
   
   int sz = 6 * nhist();
   
   std::vector<double> workv(sz);
   double * work = &workv[0];
-  ier = flow_->dg_da(s, alpha, T, work);
-  if (ier != 0) return ier;
+  flow_->dg_da(s, alpha, T, work);
   for (int i=0; i<sz; i++) {
     work[i] *= -yv;
   }
 
   double t1[6];
-  ier = flow_->g(s, alpha, T, t1);
-  if (ier != 0) return ier;
+  flow_->g(s, alpha, T, t1);
   std::vector<double> t2v(nhist());
   double * t2 = &t2v[0];
-  ier = flow_->dy_da(s, alpha, T, t2);
-  if (ier != 0) return ier;
+  flow_->dy_da(s, alpha, T, t2);
   outer_update_minus(t1, 6, t2, nhist(), work);
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
-  ier = flow_->dg_da_temp(s, alpha, T, t3);
-  if (ier != 0) return ier; 
+  flow_->dg_da_temp(s, alpha, T, t3);
   for (int i=0; i<sz; i++) {
     work[i] -= t3[i] * Tdot;
   }
 
-  ier = flow_->dg_da_time(s, alpha, T, t3);
-  if (ier != 0) return ier;
+  flow_->dg_da_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) {
     work[i] -= t3[i];
   }
@@ -226,21 +210,17 @@ int TVPFlowRule::a(const double * const s, const double * const alpha,
               double * const adot)
 {
   double dg;
-  int ier = flow_->y(s, alpha, T, dg);
-  if (ier != 0) return 0;
+  flow_->y(s, alpha, T, dg);
 
-  ier = flow_->h(s, alpha, T, adot);
-  if (ier != 0) return 0;
+  flow_->h(s, alpha, T, adot);
   for (size_t i=0; i<nhist(); i++) adot[i] *= dg;
   
   std::vector<double> tempv(nhist());
   double * temp = &tempv[0];
-  ier = flow_->h_temp(s, alpha, T, temp);
-  if (ier != 0) return ier;
+  flow_->h_temp(s, alpha, T, temp);
   for (size_t i=0; i<nhist(); i++) adot[i] += temp[i] * Tdot;
 
-  ier = flow_->h_time(s, alpha, T, temp);
-  if (ier != 0) return ier;
+  flow_->h_time(s, alpha, T, temp);
   for (size_t i=0; i<nhist(); i++) adot[i] += temp[i];
 
   return 0;
@@ -253,34 +233,28 @@ int TVPFlowRule::da_ds(const double * const s, const double * const alpha,
               double * const d_adot)
 {
   double dg;
-  int ier = flow_->y(s, alpha, T, dg);
-  if (ier != 0) return ier;
+  flow_->y(s, alpha, T, dg);
 
   int sz = nhist() * 6;
 
-  ier = flow_->dh_ds(s, alpha, T, d_adot);
-  if (ier != 0) return ier;
+  flow_->dh_ds(s, alpha, T, d_adot);
   for (int i=0; i<sz; i++) d_adot[i] *= dg;
 
   std::vector<double> t1v(nhist());
   double * t1 = &t1v[0];
-  ier = flow_->h(s, alpha, T, t1);
-  if (ier != 0) return ier;
+  flow_->h(s, alpha, T, t1);
 
   double t2[6];
-  ier = flow_->dy_ds(s, alpha, T, t2);
-  if (ier != 0) return ier;
+  flow_->dy_ds(s, alpha, T, t2);
 
   outer_update(t1, nhist(), t2, 6, d_adot);
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
-  ier = flow_->dh_ds_temp(s, alpha, T, t3);
-  if (ier != 0) return ier;
+  flow_->dh_ds_temp(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * Tdot;
 
-  ier = flow_->dh_ds_time(s, alpha, T, t3);
-  if (ier != 0) return ier;
+  flow_->dh_ds_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i];
 
   return 0;
@@ -293,36 +267,30 @@ int TVPFlowRule::da_da(const double * const s, const double * const alpha,
               double * const d_adot)
 {
   double dg;
-  int ier = flow_->y(s, alpha, T, dg);
-  if (ier != 0) return ier;
+  flow_->y(s, alpha, T, dg);
 
   int nh = nhist();
   int sz = nh * nh;
 
-  ier = flow_->dh_da(s, alpha, T, d_adot);
-  if (ier != 0) return ier;
+  flow_->dh_da(s, alpha, T, d_adot);
   for (int i=0; i<sz; i++) d_adot[i] *= dg;
   
   std::vector<double> t1v(nh);
   double * t1 = &t1v[0];
-  ier = flow_->h(s, alpha, T, t1);
-  if (ier != 0) return ier;
+  flow_->h(s, alpha, T, t1);
   
   std::vector<double> t2v(nh);
   double * t2 = &t2v[0];
-  ier = flow_->dy_da(s, alpha, T, t2);
-  if (ier != 0) return ier;
+  flow_->dy_da(s, alpha, T, t2);
 
   outer_update(t1, nh, t2, nh, d_adot);
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
-  ier = flow_->dh_da_temp(s, alpha, T, t3);
-  if (ier != 0) return ier;
+  flow_->dh_da_temp(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * Tdot;
 
-  ier = flow_->dh_da_time(s, alpha, T, t3);
-  if (ier != 0) return ier;
+  flow_->dh_da_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i];
 
   return 0;
@@ -348,23 +316,19 @@ int TVPFlowRule::work_rate(const double * const s,
 
   double temp[6];
   double yv;
-  int ier = flow_->g(s, alpha, T, temp);
-  if (ier != 0) return ier;
-  ier = flow_->y(s, alpha, T, yv);
-  if (ier != 0) return ier;
+  flow_->g(s, alpha, T, temp);
+  flow_->y(s, alpha, T, yv);
 
   for (int i=0; i<6; i++) {
     erate[i] += yv * temp[i];
   }
 
-  ier = flow_->g_temp(s, alpha, T, temp);
-  if (ier != 0) return ier;
+  flow_->g_temp(s, alpha, T, temp);
   for (int i=0; i<6; i++) {
     erate[i] += Tdot * temp[i];
   }
 
-  ier = flow_->g_time(s, alpha, T, temp);
-  if (ier != 0) return ier;
+  flow_->g_time(s, alpha, T, temp);
   for (int i=0; i<6; i++) {
     erate[i] += temp[i];
   }

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -14,20 +14,18 @@ GeneralFlowRule::GeneralFlowRule(ParameterSet & params) :
 {
 }
 
-int GeneralFlowRule::work_rate(const double * const s,
+void GeneralFlowRule::work_rate(const double * const s,
                                             const double * const alpha,
                                             const double * const edot, double T,
                                             double Tdot, double & p_dot)
 {
   // By default don't calculate plastic work
   p_dot = 0.0;
-  return 0;
 }
 
-int GeneralFlowRule::set_elastic_model(std::shared_ptr<LinearElasticModel>
+void GeneralFlowRule::set_elastic_model(std::shared_ptr<LinearElasticModel>
                                        emodel)
 {
-  return 0;
 }
 
 void GeneralFlowRule::override_guess(double * const x)
@@ -69,12 +67,13 @@ size_t TVPFlowRule::nhist() const
   return flow_->nhist();
 }
 
-int TVPFlowRule::init_hist(double * const h)
+void TVPFlowRule::init_hist(double * const h)
 {
-  return flow_->init_hist(h);
+  flow_->init_hist(h);
+
 }
 
-int TVPFlowRule::s(const double * const s, const double * const alpha,
+void TVPFlowRule::s(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const sdot)
@@ -108,11 +107,10 @@ int TVPFlowRule::s(const double * const s, const double * const alpha,
 
   mat_vec(C, 6, erate, 6, sdot);
 
-  return 0;
 
 }
 
-int TVPFlowRule::ds_ds(const double * const s, const double * const alpha,
+void TVPFlowRule::ds_ds(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_sdot)
@@ -147,11 +145,10 @@ int TVPFlowRule::ds_ds(const double * const s, const double * const alpha,
 
   mat_mat(6,6,6, t3, work, d_sdot);
 
-  return 0;
 
 }
 
-int TVPFlowRule::ds_da(const double * const s, const double * const alpha,
+void TVPFlowRule::ds_da(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_sdot)
@@ -192,19 +189,18 @@ int TVPFlowRule::ds_da(const double * const s, const double * const alpha,
 
   mat_mat(6, nhist(), 6, C, work, d_sdot);
 
-  return 0;
 
 }
 
-int TVPFlowRule::ds_de(const double * const s, const double * const alpha,
+void TVPFlowRule::ds_de(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_sdot)
 {
-  return elastic_->C(T, d_sdot);
+  elastic_->C(T, d_sdot);
 }
 
-int TVPFlowRule::a(const double * const s, const double * const alpha,
+void TVPFlowRule::a(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const adot)
@@ -223,11 +219,10 @@ int TVPFlowRule::a(const double * const s, const double * const alpha,
   flow_->h_time(s, alpha, T, temp);
   for (size_t i=0; i<nhist(); i++) adot[i] += temp[i];
 
-  return 0;
 
 }
 
-int TVPFlowRule::da_ds(const double * const s, const double * const alpha,
+void TVPFlowRule::da_ds(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_adot)
@@ -257,11 +252,10 @@ int TVPFlowRule::da_ds(const double * const s, const double * const alpha,
   flow_->dh_ds_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i];
 
-  return 0;
   
 }
 
-int TVPFlowRule::da_da(const double * const s, const double * const alpha,
+void TVPFlowRule::da_da(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_adot)
@@ -293,20 +287,18 @@ int TVPFlowRule::da_da(const double * const s, const double * const alpha,
   flow_->dh_da_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i];
 
-  return 0;
 }
 
-int TVPFlowRule::da_de(const double * const s, const double * const alpha,
+void TVPFlowRule::da_de(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_adot)
 {
   std::fill(d_adot, d_adot+(nhist()*6), 0.0);
 
-  return 0;
 }
 
-int TVPFlowRule::work_rate(const double * const s,
+void TVPFlowRule::work_rate(const double * const s,
                                     const double * const alpha,
                                     const double * const edot, double T,
                                     double Tdot, double & p_dot)
@@ -334,24 +326,20 @@ int TVPFlowRule::work_rate(const double * const s,
   }
 
   p_dot = dot_vec(s, erate, 6);
-  
-  return 0;
 }
 
-int TVPFlowRule::elastic_strains(const double * const s_np1, double T_np1,
+void TVPFlowRule::elastic_strains(const double * const s_np1, double T_np1,
                                  double * const e_np1) const
 {
   double S[36];
   elastic_->S(T_np1, S);
   mat_vec(S, 6, s_np1, 6, e_np1);
 
-  return 0;
 }
 
-int TVPFlowRule::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
+void TVPFlowRule::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
 {
   elastic_ = emodel;
-  return 0;
 }
 
 void TVPFlowRule::override_guess(double * const x)

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -85,23 +85,24 @@ int TVPFlowRule::s(const double * const s, const double * const alpha,
   double temp[6];
   double yv;
   int ier = flow_->g(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
-  if (yv > NEML_STRAIN_RATE_LIMIT) return EXCEEDS_STRAIN_RATE_LIMIT;
+  if (ier != 0) return ier;
+  if (yv > NEML_STRAIN_RATE_LIMIT) 
+    throw NEMLError("Strain rate exceeds rate limit");
   
   for (int i=0; i<6; i++) {
     erate[i] -= yv * temp[i];
   }
 
   ier = flow_->g_temp(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<6; i++) {
     erate[i] -= Tdot * temp[i];
   }
 
   ier = flow_->g_time(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<6; i++) {
     erate[i] -= temp[i];
   }
@@ -122,32 +123,32 @@ int TVPFlowRule::ds_ds(const double * const s, const double * const alpha,
 {
   double yv;
   int ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   double work[36];
   ier = flow_->dg_ds(s, alpha, T, work);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<36; i++) {
     work[i] *= -yv;
   }
 
   double t1[6];
   ier = flow_->g(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   double t2[6];
   ier = flow_->dy_ds(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   outer_update_minus(t1, 6, t2, 6, work);
   
   double t3[36];
   ier = flow_->dg_ds_temp(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<36; i++) {
     work[i] -= t3[i] * Tdot;
   }
 
   ier = flow_->dg_ds_time(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<36; i++) {
     work[i] -= t3[i];
   }
@@ -167,37 +168,37 @@ int TVPFlowRule::ds_da(const double * const s, const double * const alpha,
 {
   double yv;
   int ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   
   int sz = 6 * nhist();
   
   std::vector<double> workv(sz);
   double * work = &workv[0];
   ier = flow_->dg_da(s, alpha, T, work);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) {
     work[i] *= -yv;
   }
 
   double t1[6];
   ier = flow_->g(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   std::vector<double> t2v(nhist());
   double * t2 = &t2v[0];
   ier = flow_->dy_da(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   outer_update_minus(t1, 6, t2, nhist(), work);
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
   ier = flow_->dg_da_temp(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier; 
+  if (ier != 0) return ier; 
   for (int i=0; i<sz; i++) {
     work[i] -= t3[i] * Tdot;
   }
 
   ier = flow_->dg_da_time(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) {
     work[i] -= t3[i];
   }
@@ -226,20 +227,20 @@ int TVPFlowRule::a(const double * const s, const double * const alpha,
 {
   double dg;
   int ier = flow_->y(s, alpha, T, dg);
-  if (ier != SUCCESS) return 0;
+  if (ier != 0) return 0;
 
   ier = flow_->h(s, alpha, T, adot);
-  if (ier != SUCCESS) return 0;
+  if (ier != 0) return 0;
   for (size_t i=0; i<nhist(); i++) adot[i] *= dg;
   
   std::vector<double> tempv(nhist());
   double * temp = &tempv[0];
   ier = flow_->h_temp(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (size_t i=0; i<nhist(); i++) adot[i] += temp[i] * Tdot;
 
   ier = flow_->h_time(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (size_t i=0; i<nhist(); i++) adot[i] += temp[i];
 
   return 0;
@@ -253,33 +254,33 @@ int TVPFlowRule::da_ds(const double * const s, const double * const alpha,
 {
   double dg;
   int ier = flow_->y(s, alpha, T, dg);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   int sz = nhist() * 6;
 
   ier = flow_->dh_ds(s, alpha, T, d_adot);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) d_adot[i] *= dg;
 
   std::vector<double> t1v(nhist());
   double * t1 = &t1v[0];
   ier = flow_->h(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   double t2[6];
   ier = flow_->dy_ds(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   outer_update(t1, nhist(), t2, 6, d_adot);
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
   ier = flow_->dh_ds_temp(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * Tdot;
 
   ier = flow_->dh_ds_time(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) d_adot[i] += t3[i];
 
   return 0;
@@ -293,35 +294,35 @@ int TVPFlowRule::da_da(const double * const s, const double * const alpha,
 {
   double dg;
   int ier = flow_->y(s, alpha, T, dg);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   int nh = nhist();
   int sz = nh * nh;
 
   ier = flow_->dh_da(s, alpha, T, d_adot);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) d_adot[i] *= dg;
   
   std::vector<double> t1v(nh);
   double * t1 = &t1v[0];
   ier = flow_->h(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   
   std::vector<double> t2v(nh);
   double * t2 = &t2v[0];
   ier = flow_->dy_da(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   outer_update(t1, nh, t2, nh, d_adot);
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
   ier = flow_->dh_da_temp(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * Tdot;
 
   ier = flow_->dh_da_time(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<sz; i++) d_adot[i] += t3[i];
 
   return 0;
@@ -348,22 +349,22 @@ int TVPFlowRule::work_rate(const double * const s,
   double temp[6];
   double yv;
   int ier = flow_->g(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   for (int i=0; i<6; i++) {
     erate[i] += yv * temp[i];
   }
 
   ier = flow_->g_temp(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<6; i++) {
     erate[i] += Tdot * temp[i];
   }
 
   ier = flow_->g_time(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   for (int i=0; i<6; i++) {
     erate[i] += temp[i];
   }

--- a/src/general_flow_wrap.cxx
+++ b/src/general_flow_wrap.cxx
@@ -20,8 +20,7 @@ PYBIND11_MODULE(general_flow, m) {
            [](GeneralFlowRule & m) -> py::array_t<double>
            {
             auto h = alloc_vec<double>(m.nhist());
-            int ier = m.init_hist(arr2ptr<double>(h));
-            py_error(ier);
+            m.init_hist(arr2ptr<double>(h));
             return h;
            }, "Initialize history variables.")
 
@@ -29,41 +28,37 @@ PYBIND11_MODULE(general_flow, m) {
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.s(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.s(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot, 
                           arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "Stress rate.")
       .def("ds_ds",
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,6);
-            int ier = m.ds_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.ds_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot, arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "Stress rate derivative with respect to stress.")
       .def("ds_da",
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,m.nhist());
-            int ier = m.ds_da(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.ds_da(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot,  arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "Stress rate derivative with respect to history.")
       .def("ds_de",
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,6);
-            int ier = m.ds_de(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.ds_de(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot,  arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "Stress rate derivative with respect to strain.")
 
@@ -72,41 +67,37 @@ PYBIND11_MODULE(general_flow, m) {
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.a(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.a(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot, 
                           arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "History rate.")
       .def("da_ds",
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.da_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.da_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot, arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "History rate derivative with respect to stress.")
       .def("da_da",
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.da_da(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.da_da(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot,  arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "History rate derivative with respect to history.")
       .def("da_de",
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.da_de(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.da_de(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot,  arr2ptr<double>(f));
-            py_error(ier);
             return f;
            }, "History rate derivative with respect to strain.")
       
@@ -114,10 +105,9 @@ PYBIND11_MODULE(general_flow, m) {
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> double
            {
             double pi;
-            int ier = m.work_rate(arr2ptr<double>(s), arr2ptr<double>(alpha), 
+            m.work_rate(arr2ptr<double>(s), arr2ptr<double>(alpha), 
                           arr2ptr<double>(edot), T,
                           Tdot,  pi);
-            py_error(ier);
             return pi;
            }, "Plastic work rate.")
       .def("set_elastic_model", &GeneralFlowRule::set_elastic_model)

--- a/src/hardening.cxx
+++ b/src/hardening.cxx
@@ -421,7 +421,7 @@ size_t CombinedHardeningRule::nhist() const
 int CombinedHardeningRule::init_hist(double * const alpha) const
 {
   int ier = iso_->init_hist(alpha);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   return kin_->init_hist(&alpha[iso_->nhist()]);
 }
 
@@ -439,12 +439,12 @@ int CombinedHardeningRule::dq_da(const double * const alpha, double T,
   std::vector<double> idv(iso_->nhist() * iso_->nhist());
   double * id = &idv[0];
   int ier = iso_->dq_da(alpha, T, id);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
   
   std::vector<double> kdv(kin_->nhist() * kin_->nhist());
   double * kd = &kdv[0];
   ier = kin_->dq_da(&alpha[iso_->nhist()], T, kd);
-  if (ier != SUCCESS) return ier;
+  if (ier != 0) return ier;
 
   std::fill(dqv, dqv + nhist()*nhist(), 0.0);
 

--- a/src/hardening.cxx
+++ b/src/hardening.cxx
@@ -420,8 +420,7 @@ size_t CombinedHardeningRule::nhist() const
 
 int CombinedHardeningRule::init_hist(double * const alpha) const
 {
-  int ier = iso_->init_hist(alpha);
-  if (ier != 0) return ier;
+  iso_->init_hist(alpha);
   return kin_->init_hist(&alpha[iso_->nhist()]);
 }
 
@@ -438,13 +437,11 @@ int CombinedHardeningRule::dq_da(const double * const alpha, double T,
   // Annoying this doesn't work nicely...
   std::vector<double> idv(iso_->nhist() * iso_->nhist());
   double * id = &idv[0];
-  int ier = iso_->dq_da(alpha, T, id);
-  if (ier != 0) return ier;
+  iso_->dq_da(alpha, T, id);
   
   std::vector<double> kdv(kin_->nhist() * kin_->nhist());
   double * kd = &kdv[0];
-  ier = kin_->dq_da(&alpha[iso_->nhist()], T, kd);
-  if (ier != 0) return ier;
+  kin_->dq_da(&alpha[iso_->nhist()], T, kd);
 
   std::fill(dqv, dqv + nhist()*nhist(), 0.0);
 

--- a/src/hardening.cxx
+++ b/src/hardening.cxx
@@ -26,11 +26,10 @@ size_t IsotropicHardeningRule::nhist() const
   return 1;
 }
 
-int IsotropicHardeningRule::init_hist(double * const alpha) const
+void IsotropicHardeningRule::init_hist(double * const alpha) const
 {
   alpha[0] = 0.0;
 
-  return 0;
 }
 
 // Implementation of linear hardening
@@ -62,20 +61,18 @@ std::unique_ptr<NEMLObject> LinearIsotropicHardeningRule::initialize(ParameterSe
   return neml::make_unique<LinearIsotropicHardeningRule>(params); 
 }
 
-int LinearIsotropicHardeningRule::q(const double * const alpha, 
+void LinearIsotropicHardeningRule::q(const double * const alpha, 
                                     double T, double * const qv) const
 {
   qv[0] = -s0_->value(T) - K_->value(T) * alpha[0];
 
-  return 0;
 }
 
-int LinearIsotropicHardeningRule::dq_da(const double * const alpha, 
+void LinearIsotropicHardeningRule::dq_da(const double * const alpha, 
                                     double T, double * const dqv) const
 {
   dqv[0] = -K_->value(T);
 
-  return 0;
 }
 
 double LinearIsotropicHardeningRule::s0(double T) const
@@ -117,19 +114,17 @@ std::unique_ptr<NEMLObject> InterpolatedIsotropicHardeningRule::initialize(Param
       ); 
 }
 
-int InterpolatedIsotropicHardeningRule::q(const double * const alpha,
+void InterpolatedIsotropicHardeningRule::q(const double * const alpha,
                                           double T, double * const qv) const
 {
   qv[0] = -flow_->value(alpha[0]);
-  return 0;
 }
 
-int InterpolatedIsotropicHardeningRule::dq_da(const double * const alpha,
+void InterpolatedIsotropicHardeningRule::dq_da(const double * const alpha,
                                               double T,
                                               double * const dqv) const
 {
   dqv[0] = -flow_->derivative(alpha[0]);
-  return 0;
 }
 
 // Implementation of voce hardening
@@ -164,20 +159,18 @@ std::unique_ptr<NEMLObject> VoceIsotropicHardeningRule::initialize(ParameterSet 
   return neml::make_unique<VoceIsotropicHardeningRule>(params); 
 }
 
-int VoceIsotropicHardeningRule::q(const double * const alpha, 
+void VoceIsotropicHardeningRule::q(const double * const alpha, 
                                     double T, double * const qv) const
 {
   qv[0] = -s0_->value(T) - R_->value(T) * (1.0 - exp(-d_->value(T) * alpha[0]));
 
-  return 0;
 }
 
-int VoceIsotropicHardeningRule::dq_da(const double * const alpha, 
+void VoceIsotropicHardeningRule::dq_da(const double * const alpha, 
                                     double T, double * const dqv) const
 {
   dqv[0] = -d_->value(T) * R_->value(T) * exp(-d_->value(T) * alpha[0]);
 
-  return 0;
 }
 
 double VoceIsotropicHardeningRule::s0(double T) const
@@ -227,15 +220,14 @@ std::unique_ptr<NEMLObject> PowerLawIsotropicHardeningRule::initialize(Parameter
   return neml::make_unique<PowerLawIsotropicHardeningRule>(params); 
 }
 
-int PowerLawIsotropicHardeningRule::q(const double * const alpha, 
+void PowerLawIsotropicHardeningRule::q(const double * const alpha, 
                                     double T, double * const qv) const
 {
   qv[0] = -s0_->value(T) - A_->value(T) * pow(alpha[0], n_->value(T));
 
-  return 0;
 }
 
-int PowerLawIsotropicHardeningRule::dq_da(const double * const alpha, 
+void PowerLawIsotropicHardeningRule::dq_da(const double * const alpha, 
                                     double T, double * const dqv) const
 {
   if (alpha[0] == 0.0) {
@@ -245,7 +237,6 @@ int PowerLawIsotropicHardeningRule::dq_da(const double * const alpha,
     dqv[0] = -A_->value(T) * n_->value(T) * pow(alpha[0], n_->value(T) - 1);
   }
 
-  return 0;
 }
 
 // Implementation of combined isotropic class
@@ -278,34 +269,26 @@ std::unique_ptr<NEMLObject> CombinedIsotropicHardeningRule::initialize(Parameter
       ); 
 }
 
-int CombinedIsotropicHardeningRule::q(const double * const alpha, 
+void CombinedIsotropicHardeningRule::q(const double * const alpha, 
                                     double T, double * const qv) const
 {
   double qi;
-  int err = 0;
   qv[0] = 0.0;
   for (auto it = rules_.begin(); it != rules_.end(); ++it) {
-    err = (*it)->q(alpha, T, &qi);
+    (*it)->q(alpha, T, &qi);
     qv[0] += qi;
-    if (err != 0) return err;
   }
-
-  return err;
 }
 
-int CombinedIsotropicHardeningRule::dq_da(const double * const alpha, 
+void CombinedIsotropicHardeningRule::dq_da(const double * const alpha, 
                                     double T, double * const dqv) const
 {
   double dqi;
-  int err = 0;
   dqv[0] = 0.0;
   for (auto it = rules_.begin(); it != rules_.end(); ++it) {
-    err = (*it)->dq_da(alpha, T, &dqi);
+    (*it)->dq_da(alpha, T, &dqi);
     dqv[0] += dqi;
-    if (err != 0) return err;
   }
-
-  return err;
 }
 
 size_t CombinedIsotropicHardeningRule::nrules() const 
@@ -325,11 +308,10 @@ size_t KinematicHardeningRule::nhist() const
   return 6;
 }
 
-int KinematicHardeningRule::init_hist(double * const alpha) const
+void KinematicHardeningRule::init_hist(double * const alpha) const
 {
   for (int i=0; i<6; i++) alpha[i] = 0.0;
 
-  return 0;
 }
 
 // Implementation of linear kinematic hardening
@@ -359,17 +341,16 @@ std::unique_ptr<NEMLObject> LinearKinematicHardeningRule::initialize(ParameterSe
   return neml::make_unique<LinearKinematicHardeningRule>(params); 
 }
 
-int LinearKinematicHardeningRule::q(const double * const alpha, 
+void LinearKinematicHardeningRule::q(const double * const alpha, 
                                     double T, double * const qv) const
 {
   for (int i=0; i<6; i++) {
     qv[i] = -H_->value(T) * alpha[i];
   }
 
-  return 0;
 }
 
-int LinearKinematicHardeningRule::dq_da(const double * const alpha, 
+void LinearKinematicHardeningRule::dq_da(const double * const alpha, 
                                     double T, double * const dqv) const
 {
   std::fill(dqv, dqv+36, 0.0);
@@ -377,7 +358,6 @@ int LinearKinematicHardeningRule::dq_da(const double * const alpha,
     dqv[CINDEX(i,i,6)] = -H_->value(T);
   }
 
-  return 0;
 }
 
 double LinearKinematicHardeningRule::H(double T) const
@@ -418,20 +398,20 @@ size_t CombinedHardeningRule::nhist() const
   return iso_->nhist() + kin_->nhist();
 }
 
-int CombinedHardeningRule::init_hist(double * const alpha) const
+void CombinedHardeningRule::init_hist(double * const alpha) const
 {
   iso_->init_hist(alpha);
   return kin_->init_hist(&alpha[iso_->nhist()]);
 }
 
-int CombinedHardeningRule::q(const double * const alpha, double T, 
+void CombinedHardeningRule::q(const double * const alpha, double T, 
                              double * const qv) const
 {
   iso_->q(alpha, T, qv);
   return kin_->q(&alpha[iso_->nhist()], T, &qv[iso_->nhist()]);
 }
 
-int CombinedHardeningRule::dq_da(const double * const alpha, double T, 
+void CombinedHardeningRule::dq_da(const double * const alpha, double T, 
                                  double * const dqv) const
 {
   // Annoying this doesn't work nicely...
@@ -458,7 +438,6 @@ int CombinedHardeningRule::dq_da(const double * const alpha, double T,
     }
   }
 
-  return 0;
 }
 
 NonAssociativeHardening::NonAssociativeHardening(ParameterSet & params) :
@@ -468,53 +447,47 @@ NonAssociativeHardening::NonAssociativeHardening(ParameterSet & params) :
 }
 
 // Provide zeros for these
-int NonAssociativeHardening::h_time(const double * const s, 
+void NonAssociativeHardening::h_time(const double * const s, 
                                     const double * const alpha, double T,
                                     double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
-  return 0;
 }
 
-int NonAssociativeHardening::dh_ds_time(const double * const s,
+void NonAssociativeHardening::dh_ds_time(const double * const s,
                                         const double * const alpha, double T,
                                         double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*6, 0.0);
-  return 0;
 }
 
-int NonAssociativeHardening::dh_da_time(const double * const s,
+void NonAssociativeHardening::dh_da_time(const double * const s,
                                         const double * const alpha, double T,
                                         double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
-  return 0;
 }
 
 // Provide zeros for these
-int NonAssociativeHardening::h_temp(const double * const s,
+void NonAssociativeHardening::h_temp(const double * const s,
                                     const double * const alpha, double T,
                                     double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
-  return 0;
 }
 
-int NonAssociativeHardening::dh_ds_temp(const double * const s,
+void NonAssociativeHardening::dh_ds_temp(const double * const s,
                                         const double * const alpha, double T,
                                         double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*6, 0.0);
-  return 0;
 }
 
-int NonAssociativeHardening::dh_da_temp(const double * const s,
+void NonAssociativeHardening::dh_da_temp(const double * const s,
                                         const double * const alpha, double T,
                                         double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
-  return 0;
 }
 
 // Begin non-associative hardening rules
@@ -561,7 +534,7 @@ double ConstantGamma::gamma(double ep, double T) const {
 }
 
 double ConstantGamma::dgamma(double ep, double T) const {
-  return 0;
+  return 0.0;
 }
 
 double ConstantGamma::g(double T) const {
@@ -673,13 +646,12 @@ size_t Chaboche::nhist() const
   return 1 + 6 * n_;
 }
 
-int Chaboche::init_hist(double * const alpha) const
+void Chaboche::init_hist(double * const alpha) const
 {
   std::fill(alpha, alpha+nhist(), 0.0);
-  return 0;
 }
 
-int Chaboche::q(const double * const alpha, double T, double * const qv) const
+void Chaboche::q(const double * const alpha, double T, double * const qv) const
 {
   iso_->q(alpha, T, qv);
   std::fill(qv+1, qv+7, 0.0);
@@ -692,10 +664,9 @@ int Chaboche::q(const double * const alpha, double T, double * const qv) const
       qv[j+1] += alpha[1+i*6+j];
     }
   }
-  return 0;
 }
 
-int Chaboche::dq_da(const double * const alpha, double T, double * const qv) const
+void Chaboche::dq_da(const double * const alpha, double T, double * const qv) const
 {
   std::fill(qv, qv+(ninter()*nhist()), 0.0);
   iso_->dq_da(alpha, T, qv); // fills in (0,0)
@@ -708,10 +679,9 @@ int Chaboche::dq_da(const double * const alpha, double T, double * const qv) con
       qv[CINDEX((j+1),(1+i*6+j), nhist())] = 1.0;
     }
   }
-  return 0;
 }
 
-int Chaboche::h(const double * const s, const double * const alpha, double T,
+void Chaboche::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   hv[0] = sqrt(2.0/3.0); // Isotropic part
@@ -734,10 +704,9 @@ int Chaboche::h(const double * const s, const double * const alpha, double T,
     }
   }
 
-  return 0;
 }
 
-int Chaboche::dh_ds(const double * const s, const double * const alpha, double T,
+void Chaboche::dh_ds(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::fill(dhv, dhv + nhist()*6, 0.0);
@@ -790,10 +759,9 @@ int Chaboche::dh_ds(const double * const s, const double * const alpha, double T
     }
   }
   
-  return 0;
 }
 
-int Chaboche::dh_da(const double * const s, const double * const alpha, double T,
+void Chaboche::dh_da(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   // Again, there should be no earthly reason the compiler can't do this
@@ -853,14 +821,12 @@ int Chaboche::dh_da(const double * const s, const double * const alpha, double T
     }
   }
 
-  return 0;
 }
 
-int Chaboche::h_time(const double * const s, const double * const alpha, 
+void Chaboche::h_time(const double * const s, const double * const alpha, 
                      double T, double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
-  if (not relax_) return 0;
  
   std::vector<double> A = eval_vector(A_, T);
   std::vector<double> a = eval_vector(a_, T);
@@ -876,25 +842,21 @@ int Chaboche::h_time(const double * const s, const double * const alpha,
     }
   }
 
-  return 0;
 }
 
-int Chaboche::dh_ds_time(const double * const s, const double * const alpha, 
+void Chaboche::dh_ds_time(const double * const s, const double * const alpha, 
                          double T, double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*6, 0.0);
-  if (not relax_) return 0;
 
   // Also return if relax
 
-  return 0;
 }
 
-int Chaboche::dh_da_time(const double * const s, const double * const alpha,
+void Chaboche::dh_da_time(const double * const s, const double * const alpha,
                          double T, double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
-  if (not relax_) return 0;
 
   std::vector<double> A = eval_vector(A_, T);
   std::vector<double> a = eval_vector(a_, T);
@@ -928,14 +890,12 @@ int Chaboche::dh_da_time(const double * const s, const double * const alpha,
     }
   }
 
-  return 0;
 }
 
-int Chaboche::h_temp(const double * const s, const double * const alpha, double T,
+void Chaboche::h_temp(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
-  if (not noniso_) return 0;
 
   std::vector<double> c = eval_vector(c_, T);
   std::vector<double> dc = eval_deriv_vector(c_, T);
@@ -946,21 +906,18 @@ int Chaboche::h_temp(const double * const s, const double * const alpha, double 
       hv[1+i*6+j] = -sqrt(2.0/3.0) * dc[i] / c[i] * alpha[1+i*6+j];
     }
   }
-  return 0;
 }
 
-int Chaboche::dh_ds_temp(const double * const s, const double * const alpha, double T,
+void Chaboche::dh_ds_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*6, 0.0);
-  return 0;
 }
 
-int Chaboche::dh_da_temp(const double * const s, const double * const alpha, double T,
+void Chaboche::dh_da_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
-  if (not noniso_) return 0;
 
   std::vector<double> c = eval_vector(c_, T);
   std::vector<double> dc = eval_deriv_vector(c_, T);
@@ -973,7 +930,6 @@ int Chaboche::dh_da_temp(const double * const s, const double * const alpha, dou
     }
   }
 
-  return 0;
 }
 
 int Chaboche::n() const
@@ -1058,13 +1014,12 @@ size_t ChabocheVoceRecovery::nhist() const
   return 1 + 6 * n_;
 }
 
-int ChabocheVoceRecovery::init_hist(double * const alpha) const
+void ChabocheVoceRecovery::init_hist(double * const alpha) const
 {
   std::fill(alpha, alpha+nhist(), 0.0);
-  return 0;
 }
 
-int ChabocheVoceRecovery::q(const double * const alpha, double T, double * const qv) const
+void ChabocheVoceRecovery::q(const double * const alpha, double T, double * const qv) const
 {
   // Isotropic part
   qv[0] = -(s0_->value(T) + alpha[0]);
@@ -1079,10 +1034,9 @@ int ChabocheVoceRecovery::q(const double * const alpha, double T, double * const
       qv[j+1] += alpha[1+i*6+j];
     }
   }
-  return 0;
 }
 
-int ChabocheVoceRecovery::dq_da(const double * const alpha, double T, double * const qv) const
+void ChabocheVoceRecovery::dq_da(const double * const alpha, double T, double * const qv) const
 {
   std::fill(qv, qv+(ninter()*nhist()), 0.0);
 
@@ -1097,10 +1051,9 @@ int ChabocheVoceRecovery::dq_da(const double * const alpha, double T, double * c
       qv[CINDEX((j+1),(1+i*6+j), nhist())] = 1.0;
     }
   }
-  return 0;
 }
 
-int ChabocheVoceRecovery::h(const double * const s, const double * const alpha, double T,
+void ChabocheVoceRecovery::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   // Isotropic
@@ -1125,10 +1078,9 @@ int ChabocheVoceRecovery::h(const double * const s, const double * const alpha, 
     }
   }
 
-  return 0;
 }
 
-int ChabocheVoceRecovery::dh_ds(const double * const s, const double * const alpha, double T,
+void ChabocheVoceRecovery::dh_ds(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::fill(dhv, dhv + nhist()*6, 0.0);
@@ -1181,10 +1133,9 @@ int ChabocheVoceRecovery::dh_ds(const double * const s, const double * const alp
     }
   }
   
-  return 0;
 }
 
-int ChabocheVoceRecovery::dh_da(const double * const s, const double * const alpha, double T,
+void ChabocheVoceRecovery::dh_da(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   // Again, there should be no earthly reason the compiler can't do this
@@ -1246,10 +1197,9 @@ int ChabocheVoceRecovery::dh_da(const double * const s, const double * const alp
     }
   }
 
-  return 0;
 }
 
-int ChabocheVoceRecovery::h_time(const double * const s, const double * const alpha, 
+void ChabocheVoceRecovery::h_time(const double * const s, const double * const alpha, 
                      double T, double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
@@ -1273,20 +1223,18 @@ int ChabocheVoceRecovery::h_time(const double * const s, const double * const al
     }
   }
 
-  return 0;
 }
 
-int ChabocheVoceRecovery::dh_ds_time(const double * const s, const double * const alpha, 
+void ChabocheVoceRecovery::dh_ds_time(const double * const s, const double * const alpha, 
                          double T, double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*6, 0.0);
 
   // Also return if relax
 
-  return 0;
 }
 
-int ChabocheVoceRecovery::dh_da_time(const double * const s, const double * const alpha,
+void ChabocheVoceRecovery::dh_da_time(const double * const s, const double * const alpha,
                          double T, double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
@@ -1327,14 +1275,12 @@ int ChabocheVoceRecovery::dh_da_time(const double * const s, const double * cons
     }
   }
 
-  return 0;
 }
 
-int ChabocheVoceRecovery::h_temp(const double * const s, const double * const alpha, double T,
+void ChabocheVoceRecovery::h_temp(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
-  if (not noniso_) return 0;
 
   std::vector<double> c = eval_vector(c_, T);
   std::vector<double> dc = eval_deriv_vector(c_, T);
@@ -1345,21 +1291,18 @@ int ChabocheVoceRecovery::h_temp(const double * const s, const double * const al
       hv[1+i*6+j] = -sqrt(2.0/3.0) * dc[i] / c[i] * alpha[1+i*6+j];
     }
   }
-  return 0;
 }
 
-int ChabocheVoceRecovery::dh_ds_temp(const double * const s, const double * const alpha, double T,
+void ChabocheVoceRecovery::dh_ds_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*6, 0.0);
-  return 0;
 }
 
-int ChabocheVoceRecovery::dh_da_temp(const double * const s, const double * const alpha, double T,
+void ChabocheVoceRecovery::dh_da_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
-  if (not noniso_) return 0;
 
   std::vector<double> c = eval_vector(c_, T);
   std::vector<double> dc = eval_deriv_vector(c_, T);
@@ -1371,8 +1314,6 @@ int ChabocheVoceRecovery::dh_da_temp(const double * const s, const double * cons
       dhv[CINDEX(ci,ci,nhist())] = - sqrt(2.0/3.0) * dc[i] / c[i];
     }
   }
-
-  return 0;
 }
 
 int ChabocheVoceRecovery::n() const

--- a/src/hardening_wrap.cxx
+++ b/src/hardening_wrap.cxx
@@ -134,8 +134,7 @@ PYBIND11_MODULE(hardening, m) {
            [](const NonAssociativeHardening & m) -> py::array_t<double>
            {
             auto v = alloc_vec<double>(m.nhist());
-            int ier = m.init_hist(arr2ptr<double>(v));
-            py_error(ier);
+            m.init_hist(arr2ptr<double>(v));
             return v;
            }, "Initialize history.")
         
@@ -143,8 +142,7 @@ PYBIND11_MODULE(hardening, m) {
            [](const NonAssociativeHardening & m, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto q = alloc_vec<double>(m.ninter());
-            int ier = m.q(arr2ptr<double>(alpha), T, arr2ptr<double>(q));
-            py_error(ier);
+            m.q(arr2ptr<double>(alpha), T, arr2ptr<double>(q));
             return q;
            }, "Map alpha to q.")
 
@@ -152,8 +150,7 @@ PYBIND11_MODULE(hardening, m) {
            [](const NonAssociativeHardening & m, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto D = alloc_mat<double>(m.ninter(), m.nhist());
-            int ier = m.dq_da(arr2ptr<double>(alpha), T, arr2ptr<double>(D));
-            py_error(ier);
+            m.dq_da(arr2ptr<double>(alpha), T, arr2ptr<double>(D));
             return D;
            }, "Gradient of map")
 
@@ -161,24 +158,21 @@ PYBIND11_MODULE(hardening, m) {
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.h(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.h(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule.")
       .def("dh_ds",
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.dh_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule derivative with respect to stress.")
       .def("dh_da",
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.dh_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule derivative with respect to history.")
 
@@ -187,24 +181,21 @@ PYBIND11_MODULE(hardening, m) {
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.h_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.h_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule, time part.")
       .def("dh_ds_time",
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.dh_ds_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_ds_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (time) derivative with respect to stress.")
       .def("dh_da_time",
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.dh_da_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_da_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (time) derivative with respect to history.")
 
@@ -212,24 +203,21 @@ PYBIND11_MODULE(hardening, m) {
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.h_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.h_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule, temperature part.")
       .def("dh_ds_temp",
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.dh_ds_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_ds_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (temperature) derivative with respect to stress.")
       .def("dh_da_temp",
            [](NonAssociativeHardening & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.dh_da_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_da_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (temperature) derivative with respect to history.")
       ;

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <sstream>
-#include <exception>
 
 namespace neml {
 

--- a/src/larsonmiller.cxx
+++ b/src/larsonmiller.cxx
@@ -43,14 +43,13 @@ std::unique_ptr<NEMLObject> LarsonMillerRelation::initialize(
   return neml::make_unique<LarsonMillerRelation>(params); 
 }
 
-int LarsonMillerRelation::sR(double t, double T, double & s) const
+void LarsonMillerRelation::sR(double t, double T, double & s) const
 {
   double LMP = T * (C_ + log10(t));
   s = pow(10.0,fn_->value(LMP));
-  return 0;
 }
 
-int LarsonMillerRelation::tR(double s, double T, double & t)
+void LarsonMillerRelation::tR(double s, double T, double & t)
 {
   LMTrialState ts;
   ts.stress = s;
@@ -60,11 +59,9 @@ int LarsonMillerRelation::tR(double s, double T, double & t)
 
   // x has LMP
   t = pow(10.0, x[0] / T - C_);
-
-  return 0;
 }
 
-int LarsonMillerRelation::dtR_ds(double s, double T, double & dt)
+void LarsonMillerRelation::dtR_ds(double s, double T, double & dt)
 {
   LMTrialState ts;
   ts.stress = s;
@@ -75,8 +72,6 @@ int LarsonMillerRelation::dtR_ds(double s, double T, double & dt)
   double LMP = x[0];
   
   dt = pow(10.0, LMP/T-C_)/(T * s * fn_->derivative(LMP));
-
-  return 0;
 }
 
 size_t LarsonMillerRelation::nparams() const
@@ -84,22 +79,18 @@ size_t LarsonMillerRelation::nparams() const
   return 1;
 }
 
-int LarsonMillerRelation::init_x(double * const x, TrialState * ts)
+void LarsonMillerRelation::init_x(double * const x, TrialState * ts)
 {
   x[0] = 50000.0; // A reasonable LMP...
-
-  return 0;
 }
 
-int LarsonMillerRelation::RJ(const double * const x, TrialState * ts, 
+void LarsonMillerRelation::RJ(const double * const x, TrialState * ts, 
                              double * const R, double * const J)
 {
   LMTrialState * tss = static_cast<LMTrialState*>(ts);
 
   R[0] = log10(tss->stress) - fn_->value(x[0]);
   J[0] = -fn_->derivative(x[0]);
-
-  return 0;
 }
 
 }

--- a/src/larsonmiller.cxx
+++ b/src/larsonmiller.cxx
@@ -55,9 +55,8 @@ int LarsonMillerRelation::tR(double s, double T, double & t)
   LMTrialState ts;
   ts.stress = s;
   double x[1];
-  int ier = solve(this, x, &ts, {rtol_, atol_, miter_, verbose_, 
+  solve(this, x, &ts, {rtol_, atol_, miter_, verbose_, 
                   linesearch_});
-  if (ier != 0) return ier;
 
   // x has LMP
   t = pow(10.0, x[0] / T - C_);
@@ -70,9 +69,8 @@ int LarsonMillerRelation::dtR_ds(double s, double T, double & dt)
   LMTrialState ts;
   ts.stress = s;
   double x[1];
-  int ier = solve(this, x, &ts, {rtol_, atol_, miter_, verbose_, 
+  solve(this, x, &ts, {rtol_, atol_, miter_, verbose_, 
                   linesearch_});
-  if (ier != 0) return ier;
   
   double LMP = x[0];
   

--- a/src/larsonmiller_wrap.cxx
+++ b/src/larsonmiller_wrap.cxx
@@ -28,24 +28,21 @@ PYBIND11_MODULE(larsonmiller, m) {
            [](LarsonMillerRelation & m, double t, double T) -> double
            {
             double s;
-            int ier = m.sR(t, T, s);
-            py_error(ier);
+            m.sR(t, T, s);
             return s;
            }, "The rupture stress as a function of time and temperature.")
       .def("tR", 
            [](LarsonMillerRelation & m, double s, double T) -> double
            {
             double t;
-            int ier = m.tR(s, T, t);
-            py_error(ier);
+            m.tR(s, T, t);
             return t;
            }, "The rupture time as a function of stress and temperature.")
       .def("dtR_ds", 
            [](LarsonMillerRelation & m, double s, double T) -> double
            {
             double dt;
-            int ier = m.dtR_ds(s, T, dt);
-            py_error(ier);
+            m.dtR_ds(s, T, dt);
             return dt;
            }, "The derivative of the time to rupture with respect to stress.")
     ;

--- a/src/math/nemlmath.cxx
+++ b/src/math/nemlmath.cxx
@@ -934,7 +934,7 @@ int invert_mat(double * const A, int n)
   if (info > 0) {
     delete [] ipiv;
     delete [] work;
-    return LINALG_FAILURE;
+    throw LinalgError("Matrix could not be inverted!");
   }
 
   dgetri_(n, A, n, ipiv, work, lwork, info);
@@ -942,7 +942,7 @@ int invert_mat(double * const A, int n)
   delete [] ipiv;
   delete [] work;
 
-  if (info > 0) return LINALG_FAILURE;
+  if (info > 0) throw LinalgError("Matrix could not be inverted!");
 
   return 0;
 }
@@ -980,7 +980,7 @@ int solve_mat(const double * const A, int n, double * const x)
   delete [] ipiv;
   delete [] B;
 
-  if (info > 0) return LINALG_FAILURE;
+  if (info > 0) throw LinalgError("Matrix could not be inverted!");
   
   return 0;
 }

--- a/src/math/nemlmath.cxx
+++ b/src/math/nemlmath.cxx
@@ -9,7 +9,7 @@
 
 namespace neml {
 
-int SymSymR4SkewmSkewSymR4SymR4(const double * const M, const double * const W, double * const SS)
+void SymSymR4SkewmSkewSymR4SymR4(const double * const M, const double * const W, double * const SS)
 {
 	SS[0] = sqrt(2)*(-M[24]*W[1] + M[30]*W[2]);
 	SS[1] = sqrt(2)*(-M[25]*W[1] + M[31]*W[2]);
@@ -47,11 +47,9 @@ int SymSymR4SkewmSkewSymR4SymR4(const double * const M, const double * const W, 
 	SS[33] = -M[21]*W[1] + M[27]*W[0] - sqrt(2)*M[3]*W[2] + sqrt(2)*M[9]*W[2];
 	SS[34] = sqrt(2)*M[10]*W[2] - M[22]*W[1] + M[28]*W[0] - sqrt(2)*M[4]*W[2];
 	SS[35] = sqrt(2)*M[11]*W[2] - M[23]*W[1] + M[29]*W[0] - sqrt(2)*M[5]*W[2];
- 
-  return 0;
 }
 
-int SymSkewR4SymmSkewSymR4SymR4(const double * const D, const double * const M, double * const SS)
+void SymSkewR4SymmSkewSymR4SymR4(const double * const D, const double * const M, double * const SS)
 {
 	SS[0] = sqrt(2)*(-D[4]*M[6] + D[5]*M[12]);
 	SS[1] = sqrt(2)*(-D[4]*M[7] + D[5]*M[13]);
@@ -89,11 +87,9 @@ int SymSkewR4SymmSkewSymR4SymR4(const double * const D, const double * const M, 
 	SS[33] = -sqrt(2)*D[0]*M[15] + sqrt(2)*D[1]*M[15] - D[3]*M[9] + D[4]*M[3];
 	SS[34] = -sqrt(2)*D[0]*M[16] + sqrt(2)*D[1]*M[16] - D[3]*M[10] + D[4]*M[4];
 	SS[35] = -sqrt(2)*D[0]*M[17] + sqrt(2)*D[1]*M[17] - D[3]*M[11] + D[4]*M[5];
-
-  return 0;
 }
 
-int SpecialSymSymR4Sym(const double * const D, const double * const M, double * const SW)
+void SpecialSymSymR4Sym(const double * const D, const double * const M, double * const SW)
 {
 	SW[0] = -sqrt(2)*D[1]*M[3]/2 + sqrt(2)*D[2]*M[3]/2 + sqrt(2)*D[3]*M[1]/2 - sqrt(2)*D[3]*M[2]/2 + D[4]*M[5]/2 - D[5]*M[4]/2;
 	SW[1] = sqrt(2)*D[0]*M[4]/2 - sqrt(2)*D[2]*M[4]/2 - D[3]*M[5]/2 - sqrt(2)*D[4]*M[0]/2 + sqrt(2)*D[4]*M[2]/2 + D[5]*M[3]/2;
@@ -113,11 +109,9 @@ int SpecialSymSymR4Sym(const double * const D, const double * const M, double * 
 	SW[15] = -sqrt(2)*D[1]*M[33]/2 + sqrt(2)*D[2]*M[33]/2 + sqrt(2)*D[3]*M[31]/2 - sqrt(2)*D[3]*M[32]/2 + D[4]*M[35]/2 - D[5]*M[34]/2;
 	SW[16] = sqrt(2)*D[0]*M[34]/2 - sqrt(2)*D[2]*M[34]/2 - D[3]*M[35]/2 - sqrt(2)*D[4]*M[30]/2 + sqrt(2)*D[4]*M[32]/2 + D[5]*M[33]/2;
 	SW[17] = -sqrt(2)*D[0]*M[35]/2 + sqrt(2)*D[1]*M[35]/2 + D[3]*M[34]/2 - D[4]*M[33]/2 + sqrt(2)*D[5]*M[30]/2 - sqrt(2)*D[5]*M[31]/2;
-
-  return 0;
 }
 
-int transform_fourth(const double * const D, const double * const W, double * const M)
+void transform_fourth(const double * const D, const double * const W, double * const M)
 {
 	M[0] = D[0];
 	M[1] = sqrt(2)*D[5]/2 - W[2]/2;
@@ -200,11 +194,9 @@ int transform_fourth(const double * const D, const double * const W, double * co
 	M[78] = sqrt(2)*D[16]/2 - W[7]/2;
 	M[79] = sqrt(2)*D[15]/2 + W[6]/2;
 	M[80] = D[14];
-
-  return 0;
 }
 
-int truesdell_tangent_outer(const double * const S, double * const M)
+void truesdell_tangent_outer(const double * const S, double * const M)
 {
 	M[0] = S[0];
 	M[1] = sqrt(2)*S[5];
@@ -287,11 +279,9 @@ int truesdell_tangent_outer(const double * const S, double * const M)
 	M[78] = sqrt(2)*S[4];
 	M[79] = sqrt(2)*S[3];
 	M[80] = S[2];
-  
-  return 0;
 }
 
-int full2skew(const double * const A, double * const M)
+void full2skew(const double * const A, double * const M)
 {
 	M[0] = -A[5];
 	M[1] = A[2];
@@ -311,11 +301,9 @@ int full2skew(const double * const A, double * const M)
 	M[15] = -sqrt(2)*A[14];
 	M[16] = sqrt(2)*A[11];
 	M[17] = -sqrt(2)*A[10];
-
-  return 0;
 }
 
-int skew2full(const double * const M, double * const A)
+void skew2full(const double * const M, double * const A)
 {
 	A[0] = 0;
 	A[1] = -M[2];
@@ -398,11 +386,9 @@ int skew2full(const double * const M, double * const A)
 	A[78] = -M[7];
 	A[79] = M[6];
 	A[80] = 0;
-
-  return 0;
 }
 
-int full2wws(const double * const A, double * const M)
+void full2wws(const double * const A, double * const M)
 {
 	M[0] = -A[45];
 	M[1] = -A[49];
@@ -422,11 +408,9 @@ int full2wws(const double * const A, double * const M)
 	M[15] = -sqrt(2)*A[14];
 	M[16] = -sqrt(2)*A[11];
 	M[17] = -sqrt(2)*A[10];
-
-  return 0;
 }
 
-int wws2full(const double * const M, double * const A)
+void wws2full(const double * const M, double * const A)
 {
 	A[0] = 0;
 	A[1] = 0;
@@ -509,11 +493,9 @@ int wws2full(const double * const M, double * const A)
 	A[78] = 0;
 	A[79] = 0;
 	A[80] = 0;
-  
-  return 0;
 }
 
-int full2mandel(const double * const A, double * const M)
+void full2mandel(const double * const A, double * const M)
 {
 	M[0] = A[0];
 	M[1] = A[4];
@@ -551,11 +533,9 @@ int full2mandel(const double * const A, double * const M)
 	M[33] = 2*A[14];
 	M[34] = 2*A[11];
 	M[35] = 2*A[10];
-
-  return 0;
 }
 
-int mandel2full(const double * const M, double * const A)
+void mandel2full(const double * const M, double * const A)
 {
 	A[0] = M[0];
 	A[1] = sqrt(2)*M[5]/2;
@@ -638,11 +618,9 @@ int mandel2full(const double * const M, double * const A)
 	A[78] = sqrt(2)*M[16]/2;
 	A[79] = sqrt(2)*M[15]/2;
 	A[80] = M[14];
-  
-  return 0;
 }
 
-int truesdell_update_sym(const double * const D, const double * const W,
+void truesdell_update_sym(const double * const D, const double * const W,
                          const double * const Sn, const double * const So,
                          double * const Snp1)
 {
@@ -655,15 +633,13 @@ int truesdell_update_sym(const double * const D, const double * const W,
 
   truesdell_mat(D, W, mat);
 
-  int ier = solve_mat(mat, 9, rhs_full);
+  solve_mat(mat, 9, rhs_full);
   sym(rhs_full, rhs_mandel);
 
   add_vec(Sn, rhs_mandel, 6, Snp1);
-
-  return ier;
 }
 
-int truesdell_mat(const double * const D, const double * const W,
+void truesdell_mat(const double * const D, const double * const W,
                   double * const M)
 {
 	M[0] = -D[0] + D[1] + D[2] + 1;
@@ -747,11 +723,9 @@ int truesdell_mat(const double * const D, const double * const W,
 	M[78] = -sqrt(2)*D[4]/2 + W[1];
 	M[79] = -sqrt(2)*D[3]/2 - W[0];
 	M[80] = D[0] + D[1] - D[2] + 1;
-
-  return 0;
 }
 
-int truesdell_rhs(const double * const D, const double * const W,
+void truesdell_rhs(const double * const D, const double * const W,
                   const double * const Sn, const double * const So,
                   double * const St)
 {
@@ -761,11 +735,9 @@ int truesdell_rhs(const double * const D, const double * const W,
 	St[3] = sqrt(2)*(-sqrt(2)*D[0]*Sn[3]/2 + sqrt(2)*D[3]*Sn[1]/2 + sqrt(2)*D[3]*Sn[2]/2 + D[4]*Sn[5]/2 + D[5]*Sn[4]/2 + Sn[1]*W[0] - Sn[2]*W[0] + sqrt(2)*Sn[4]*W[2]/2 - sqrt(2)*Sn[5]*W[1]/2 + sqrt(2)*So[3]/2);
 	St[4] = sqrt(2)*(-sqrt(2)*D[1]*Sn[4]/2 + D[3]*Sn[5]/2 + sqrt(2)*D[4]*Sn[0]/2 + sqrt(2)*D[4]*Sn[2]/2 + D[5]*Sn[3]/2 - Sn[0]*W[1] + Sn[2]*W[1] - sqrt(2)*Sn[3]*W[2]/2 + sqrt(2)*Sn[5]*W[0]/2 + sqrt(2)*So[4]/2);
 	St[5] = sqrt(2)*(-sqrt(2)*D[2]*Sn[5]/2 + D[3]*Sn[4]/2 + D[4]*Sn[3]/2 + sqrt(2)*D[5]*Sn[0]/2 + sqrt(2)*D[5]*Sn[1]/2 + Sn[0]*W[2] - Sn[1]*W[2] + sqrt(2)*Sn[3]*W[1]/2 - sqrt(2)*Sn[4]*W[0]/2 + sqrt(2)*So[5]/2);
-
-  return 0;
 }
 
-int sym(const double * const A, double * const v)
+void sym(const double * const A, double * const v)
 {
   v[0] = A[0];
   v[1] = A[4];
@@ -773,11 +745,9 @@ int sym(const double * const A, double * const v)
   v[3] = sqrt(2.0) * A[5];
   v[4] = sqrt(2.0) * A[2];
   v[5] = sqrt(2.0) * A[1];
-
-  return 0;
 }
 
-int usym(const double * const v, double * const A)
+void usym(const double * const v, double * const A)
 {
   A[0] = v[0];
   A[1] = v[5] / sqrt(2.0);
@@ -788,19 +758,16 @@ int usym(const double * const v, double * const A)
   A[6] = v[4] / sqrt(2.0);
   A[7] = v[3] / sqrt(2.0);
   A[8] = v[2];
-
-  return 0;
 }
 
-int skew(const double * const A, double * const v)
+void skew(const double * const A, double * const v)
 {
   v[0] = -A[5];
   v[1] = A[2];
   v[2] = -A[1];
-  return 0;
 }
 
-int uskew(const double * const v, double * const A)
+void uskew(const double * const v, double * const A)
 {
   A[0] = 0;
   A[1] = -v[2];
@@ -811,35 +778,27 @@ int uskew(const double * const v, double * const A)
   A[6] = -v[1];
   A[7] = v[0];
   A[8] = 0;
-
-  return 0;
 }
 
-int minus_vec(double * const a, int n)
+void minus_vec(double * const a, int n)
 {
   for (int i=0; i<n; i++) {
     a[i] = -a[i];
   }
-
-  return 0;
 }
 
-int add_vec(const double * const a, const double * const b, int n, double * const c)
+void add_vec(const double * const a, const double * const b, int n, double * const c)
 {
   for (int i=0; i<n; i++) {
     c[i] = a[i] + b[i];
   }
-
-  return 0;
 }
 
-int sub_vec(const double * const a, const double * const b, int n, double * const c)
+void sub_vec(const double * const a, const double * const b, int n, double * const c)
 {
   for (int i=0; i<n; i++) {
     c[i] = a[i] - b[i];
   }
-  
-  return 0;
 }
 
 double dot_vec(const double * const a, const double * const b, int n)
@@ -856,74 +815,61 @@ double norm2_vec(const double * const a, int n)
   return sqrt(dot_vec(a, a, n));
 }
 
-int normalize_vec(double * const a, int n)
+void normalize_vec(double * const a, int n)
 {
   double nv = norm2_vec(a, n);
   if (fabs(nv) < std::numeric_limits<double>::epsilon()) {
     std::fill(a, a+n, 0.0);
-    return 0;
+    return;
   }
   for (int i=0; i<n; i++) {
     a[i] /= nv;
   }
-  return 0;
 }
 
-int dev_vec(double * const a)
+void dev_vec(double * const a)
 {
   double tr = (a[0] + a[1] + a[2]) / 3.0;
   for (int i=0; i<3; i++) {
     a[i] -= tr;
   }
-
-  return 0;
 }
 
-int outer_vec(const double * const a, int na, const double * const b, int nb, double * const C)
+void outer_vec(const double * const a, int na, const double * const b, int nb, double * const C)
 {
   for (int i=0; i < na; i++) {
     for (int j=0; j < nb; j++) {
       C[CINDEX(i,j,nb)] = a[i] * b[j];
     }
   }
-
-  return 0;
 }
 
 // Problem?
-int outer_update(const double * const a, int na, const double * const b, 
+void outer_update(const double * const a, int na, const double * const b, 
                  int nb, double * const C)
 {
   dger_(nb, na, 1.0, b, 1, a, 1, C, nb);
-
-  return 0;
 }
 
-int outer_update_minus(const double * const a, int na, const double * const b, 
+void outer_update_minus(const double * const a, int na, const double * const b, 
                        int nb, double * const C)
 {
   dger_(nb, na, -1.0, b, 1, a, 1, C, nb);
-
-  return 0;
 }
 
-int mat_vec(const double * const A, int m, const double * const b, int n, 
+void mat_vec(const double * const A, int m, const double * const b, int n, 
             double * const c)
 {
   dgemv_("T", n, m, 1.0, A, n, b, 1, 0.0, c, 1);
-
-  return 0;
 }
 
-int mat_vec_trans(const double * const A, int m, const double * const b, int n, 
+void mat_vec_trans(const double * const A, int m, const double * const b, int n, 
             double * const c)
 {
   dgemv_("N", m, n, 1.0, A, m, b, 1, 0.0, c, 1);
-
-  return 0;
 }
 
-int invert_mat(double * const A, int n)
+void invert_mat(double * const A, int n)
 {
   int * ipiv = new int[n + 1];
   int lwork = n * n;
@@ -943,28 +889,22 @@ int invert_mat(double * const A, int n)
   delete [] work;
 
   if (info > 0) throw LinalgError("Matrix could not be inverted!");
-
-  return 0;
 }
 
-int mat_mat(int m, int n, int k, const double * const A,
+void mat_mat(int m, int n, int k, const double * const A,
             const double * const B, double * const C)
 {
   dgemm_("N", "N", n, m, k, 1.0, B, n, A, k, 0.0, C, n);
-
-  return 0;
 }
 
-int mat_mat_ABT(int m, int n, int k, const double * const A,
+void mat_mat_ABT(int m, int n, int k, const double * const A,
             const double * const B, double * const C)
 {
   // Provide as A_mk B_nk
   dgemm_("T", "N", n, m, k, 1.0, B, k, A, k, 0.0, C, n);
-
-  return 0;
 }
 
-int solve_mat(const double * const A, int n, double * const x)
+void solve_mat(const double * const A, int n, double * const x)
 {
   int info;
   int * ipiv = new int [n];
@@ -981,8 +921,6 @@ int solve_mat(const double * const A, int n, double * const x)
   delete [] B;
 
   if (info > 0) throw LinalgError("Matrix could not be inverted!");
-  
-  return 0;
 }
 
 /*
@@ -1170,7 +1108,7 @@ bool isclose(double a, double b)
   return fabs(a - b) <= (ATOL + RTOL * fabs(b));
 }
 
-int rotate_matrix(int m, int n, const double * const A,
+void rotate_matrix(int m, int n, const double * const A,
                   const double * const B, double * C)
 {
   double * temp = new double[m*n];
@@ -1184,8 +1122,6 @@ int rotate_matrix(int m, int n, const double * const A,
   dgemm_("N", "N", m, m, n, 1.0, temp, m, A, n, 0.0, C, m);
 
   delete [] temp;
-
-  return 0;
 }
 
 int fact(int n)
@@ -1198,7 +1134,7 @@ double factorial(int n)
   return (double) fact(n);
 }
 
-int eigenvalues_sym(const double * const s, double * values)
+void eigenvalues_sym(const double * const s, double * values)
 {
   double F[9];
   usym(s, F);
@@ -1209,10 +1145,10 @@ int eigenvalues_sym(const double * const s, double * values)
 
   dsyev_("N", "U", 3, F, 3, values, work, swork, info);
 
-  return info;
+  if (info != 0) throw LinalgError("Eigenvalue calculation failed");
 }
 
-int eigenvectors_sym(const double * const s, double * vectors)
+void eigenvectors_sym(const double * const s, double * vectors)
 {
   usym(s, vectors);
 
@@ -1223,7 +1159,7 @@ int eigenvectors_sym(const double * const s, double * vectors)
 
   dsyev_("V", "U", 3, vectors, 3, values, work, swork, info);
 
-  return info;
+  if (info != 0) throw LinalgError("Eigenvector calculation failed");
 }
 
 double I1(const double * const s)

--- a/src/math/nemlmath_wrap.cxx
+++ b/src/math/nemlmath_wrap.cxx
@@ -381,8 +381,7 @@ PYBIND11_MODULE(nemlmath, m) {
             throw LinalgError("a must be a 6-vector!");
           }
           
-          int ier = dev_vec(arr2ptr<double>(a));
-          py_error(ier);
+          dev_vec(arr2ptr<double>(a));
 
           return a;
 
@@ -529,8 +528,7 @@ PYBIND11_MODULE(nemlmath, m) {
           if (A.request().shape[0] != A.request().shape[1]) {
             throw LinalgError("Matrix is not square!");
           }
-          int ier = invert_mat(arr2ptr<double>(A), A.request().shape[0]);
-          py_error(ier);
+          invert_mat(arr2ptr<double>(A), A.request().shape[0]);
           // Should check non-singular
           return A;
         }, "Invert a matrix IN PLACE.");
@@ -583,8 +581,7 @@ PYBIND11_MODULE(nemlmath, m) {
          {
            double vals[3];
 
-           int ier = eigenvalues_sym(arr2ptr<double>(s), vals);
-           py_error(ier);
+           eigenvalues_sym(arr2ptr<double>(s), vals);
 
            return std::make_tuple(vals[0],vals[1],vals[2]);
          }, "Eigenvalues of a symmetric matrix.");
@@ -594,8 +591,7 @@ PYBIND11_MODULE(nemlmath, m) {
          {
            auto V = alloc_mat<double>(3,3);
            
-           int ier = eigenvectors_sym(arr2ptr<double>(s), arr2ptr<double>(V));
-           py_error(ier);
+           eigenvectors_sym(arr2ptr<double>(s), arr2ptr<double>(V));
 
            return V;
          }, "Eigenvectors of a symmetric matrix.");

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -77,12 +77,10 @@ size_t NEMLModel_sd::nstore() const
   return nhist() + 6;
 }
 
-int NEMLModel_sd::init_store(double * const store) const
+void NEMLModel_sd::init_store(double * const store) const
 {
   init_hist(&store[0]);
   std::fill(&store[nhist()], &store[nhist()]+6, 0.0);
-
-  return 0;
 }
 
 double NEMLModel_sd::alpha(double T) const
@@ -102,7 +100,9 @@ int NEMLModel_sd::elastic_strains(const double * const s_np1,
 {
   double S[36];
   elastic_->S(T_np1, S);
-  return mat_vec(S, 6, s_np1, 6, e_np1);
+  mat_vec(S, 6, s_np1, 6, e_np1);
+
+  return 0;
 }
 
 int NEMLModel_sd::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
@@ -178,10 +178,9 @@ size_t NEMLModel_ldi::nstore() const
   return nhist();
 }
 
-int NEMLModel_ldi::init_store(double * const store) const
+void NEMLModel_ldi::init_store(double * const store) const
 {
   init_hist(&store[0]);
-  return 0;
 }
 
 SubstepModel_sd::SubstepModel_sd(ParameterSet & params) :
@@ -602,16 +601,14 @@ size_t SmallStrainPerfectPlasticity::nparams() const
   return 7;
 }
 
-int SmallStrainPerfectPlasticity::init_x(double * const x, TrialState * ts)
+void SmallStrainPerfectPlasticity::init_x(double * const x, TrialState * ts)
 {
   SSPPTrialState * tss = static_cast<SSPPTrialState *>(ts);
   std::copy(tss->s_tr, tss->s_tr+6, x);
   x[6] = 0.0;
-
-  return 0;
 }
 
-int SmallStrainPerfectPlasticity::RJ(
+void SmallStrainPerfectPlasticity::RJ(
     const double * const x, TrialState * ts, double * const R,
     double * const J)
 {
@@ -658,8 +655,6 @@ int SmallStrainPerfectPlasticity::RJ(
 
   // J22
   J[CINDEX(6,6,7)] = 0.0;
-
-  return 0;
 }
 
 // Getter
@@ -746,7 +741,8 @@ size_t SmallStrainRateIndependentPlasticity::nhist() const
 
 int SmallStrainRateIndependentPlasticity::init_hist(double * const hist) const
 {
-  return flow_->init_hist(hist);
+  flow_->init_hist(hist);
+  return 0;
 }
 
 TrialState * SmallStrainRateIndependentPlasticity::setup(
@@ -850,16 +846,15 @@ size_t SmallStrainRateIndependentPlasticity::nparams() const
   return 6 + flow_->nhist() + 1;
 }
 
-int SmallStrainRateIndependentPlasticity::init_x(double * const x, TrialState * ts)
+void SmallStrainRateIndependentPlasticity::init_x(double * const x, TrialState * ts)
 {
   SSRIPTrialState * tss = static_cast<SSRIPTrialState *>(ts);
   std::copy(tss->s_tr, tss->s_tr+6, x);
   std::copy(&tss->h_tr[0], &tss->h_tr[0]+flow_->nhist(), &x[6]);
   x[6+flow_->nhist()] = 0.0; // consistency parameter
-  return 0;
 }
 
-int SmallStrainRateIndependentPlasticity::RJ(const double * const x, 
+void SmallStrainRateIndependentPlasticity::RJ(const double * const x, 
                                              TrialState * ts, 
                                              double * const R, double * const J)
 {
@@ -980,8 +975,6 @@ int SmallStrainRateIndependentPlasticity::RJ(const double * const x,
 
   // J33
   J[CINDEX((6+nh), (6+nh), n)] = 0.0;
-  
-  return 0;
 }
 
 const std::shared_ptr<const LinearElasticModel> SmallStrainRateIndependentPlasticity::elastic() const
@@ -1143,17 +1136,15 @@ size_t SmallStrainCreepPlasticity::nparams() const
   return 6;
 }
 
-int SmallStrainCreepPlasticity::init_x(double * const x, TrialState * ts)
+void SmallStrainCreepPlasticity::init_x(double * const x, TrialState * ts)
 {
   SSCPTrialState * tss = static_cast<SSCPTrialState*>(ts);
 
   // Start out at last step's value
   std::copy(tss->ep_strain, tss->ep_strain + 6, x);
-  
-  return 0;
 }
 
-int SmallStrainCreepPlasticity::RJ(const double * const x, TrialState * ts, 
+void SmallStrainCreepPlasticity::RJ(const double * const x, TrialState * ts, 
                                    double * const R, double * const J)
 {
   SSCPTrialState * tss = static_cast<SSCPTrialState*>(ts);
@@ -1195,8 +1186,6 @@ int SmallStrainCreepPlasticity::RJ(const double * const x, TrialState * ts,
   mat_mat(6, 6, 6, B, A_np1, J);
   for (int i=0; i<6; i++) J[CINDEX(i,i,6)] += 1.0;
   for (int i=0; i<36; i++) J[i] *= sf_;
-
-  return 0;
 }
 
 int SmallStrainCreepPlasticity::make_trial_state(
@@ -1427,7 +1416,9 @@ size_t GeneralIntegrator::nhist() const
 
 int GeneralIntegrator::init_hist(double * const hist) const
 {
-  return rule_->init_hist(hist);
+  rule_->init_hist(hist);
+
+  return 0;
 }
 
 size_t GeneralIntegrator::nparams() const
@@ -1435,18 +1426,16 @@ size_t GeneralIntegrator::nparams() const
   return 6 + nhist();
 }
 
-int GeneralIntegrator::init_x(double * const x, TrialState * ts)
+void GeneralIntegrator::init_x(double * const x, TrialState * ts)
 {
   GITrialState * tss = static_cast<GITrialState*>(ts);
   std::copy(tss->s_guess, tss->s_guess+6, x);
   std::copy(tss->h_n.begin(), tss->h_n.end(), &x[6]);
 
   rule_->override_guess(x);
-
-  return 0;
 }
 
-int GeneralIntegrator::RJ(const double * const x, TrialState * ts,
+void GeneralIntegrator::RJ(const double * const x, TrialState * ts,
                           double * const R, double * const J)
 {
   GITrialState * tss = static_cast<GITrialState*>(ts);
@@ -1514,8 +1503,6 @@ int GeneralIntegrator::RJ(const double * const x, TrialState * ts,
       J[CINDEX((i+6),(j+6),nparams)] = -J22[CINDEX(i,j,nhist)];
     }
   }
-  
-  return 0;
 }
 
 
@@ -1566,7 +1553,9 @@ int GeneralIntegrator::make_trial_state(
 int GeneralIntegrator::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
 {
   elastic_ = emodel;
-  return rule_->set_elastic_model(emodel);
+  rule_->set_elastic_model(emodel);
+
+  return 0;
 }
 
 // Start KMRegimeModel

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -35,7 +35,7 @@ NEMLModel_sd::NEMLModel_sd(ParameterSet & params) :
 
 }
 
-int NEMLModel_sd::update_ld_inc(
+void NEMLModel_sd::update_ld_inc(
     const double * const d_np1, const double * const d_n,
     const double * const w_np1, const double * const w_n,
     double T_np1, double T_n,
@@ -69,7 +69,6 @@ int NEMLModel_sd::update_ld_inc(
 
   calc_tangent_(D, W, base_A_np1, s_np1, A_np1, B_np1);
 
-  return 0;
 }
 
 size_t NEMLModel_sd::nstore() const
@@ -93,7 +92,7 @@ const std::shared_ptr<const LinearElasticModel> NEMLModel_sd::elastic() const
   return elastic_;
 }
 
-int NEMLModel_sd::elastic_strains(const double * const s_np1,
+void NEMLModel_sd::elastic_strains(const double * const s_np1,
                                            double T_np1, 
                                            const double * const h_np1,
                                            double * const e_np1) const
@@ -102,16 +101,14 @@ int NEMLModel_sd::elastic_strains(const double * const s_np1,
   elastic_->S(T_np1, S);
   mat_vec(S, 6, s_np1, 6, e_np1);
 
-  return 0;
 }
 
-int NEMLModel_sd::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
+void NEMLModel_sd::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
 {
   elastic_ = emodel;
-  return 0;
 }
 
-int NEMLModel_sd::calc_tangent_(const double * const D, const double * const W,
+void NEMLModel_sd::calc_tangent_(const double * const D, const double * const W,
                                 const double * const C, const double * const S,
                                 double * const A, double * const B)
 {
@@ -146,7 +143,6 @@ int NEMLModel_sd::calc_tangent_(const double * const D, const double * const W,
   // IMPORTANT TODO: go back and find where you dropped the factor of 2...
   for (int i=0; i<18; i++) B[i] *= 2.0;
 
-  return 0;
 }
 
 // NEMLModel_ldi implementation
@@ -156,7 +152,7 @@ NEMLModel_ldi::NEMLModel_ldi(ParameterSet & params) :
 
 }
 
-int NEMLModel_ldi::update_sd(
+void NEMLModel_ldi::update_sd(
    const double * const e_np1, const double * const e_n,
    double T_np1, double T_n,
    double t_np1, double t_n,
@@ -168,7 +164,7 @@ int NEMLModel_ldi::update_sd(
 {
   double W[3] = {0,0,0};
   double B[18];
-  return update_ld_inc(e_np1, e_n, W, W, T_np1, T_n, t_np1, t_n,
+  update_ld_inc(e_np1, e_n, W, W, T_np1, T_n, t_np1, t_n,
                        s_np1, s_n, h_np1, h_n, A_np1, B, u_np1, u_n,
                        p_np1, p_n);
 }
@@ -196,7 +192,7 @@ SubstepModel_sd::SubstepModel_sd(ParameterSet & params) :
 
 }
 
-int SubstepModel_sd::update_sd(
+void SubstepModel_sd::update_sd(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
     double t_np1, double t_n,
@@ -306,10 +302,9 @@ int SubstepModel_sd::update_sd(
   delete [] A_new;
   delete [] E_inc;
 
-  return 0;
 }
 
-int SubstepModel_sd::update_step(
+void SubstepModel_sd::update_step(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
     double t_np1, double t_n,
@@ -349,7 +344,8 @@ int SubstepModel_sd::update_step(
     work_and_energy(ts, e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
                     h_np1, h_n, u_np1, u_n, p_np1, p_n); 
     delete ts;
-    return 0;
+
+    return;
   }
   
   // Solve the system
@@ -381,8 +377,6 @@ int SubstepModel_sd::update_step(
 
   delete [] x;
   delete ts;
-
-  return 0;
 }
 
 // Implementation of small strain elasticity
@@ -420,12 +414,11 @@ size_t SmallStrainElasticity::nhist() const
   return 0;
 }
 
-int SmallStrainElasticity::init_hist(double * const hist) const
+void SmallStrainElasticity::init_hist(double * const hist) const
 {
-  return 0;
 }
 
-int SmallStrainElasticity::update_sd(
+void SmallStrainElasticity::update_sd(
        const double * const e_np1, const double * const e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
@@ -447,7 +440,6 @@ int SmallStrainElasticity::update_sd(
   u_np1 = u_n + dot_vec(ds, de, 6);
   p_np1 = p_n;
 
-  return 0;
 }
 
 // Implementation of perfect plasticity
@@ -497,9 +489,8 @@ size_t SmallStrainPerfectPlasticity::nhist() const
   return 0;
 }
 
-int SmallStrainPerfectPlasticity::init_hist(double * const hist) const
+void SmallStrainPerfectPlasticity::init_hist(double * const hist) const
 {
-  return 0;
 }
 
 TrialState * SmallStrainPerfectPlasticity::setup(
@@ -529,7 +520,7 @@ bool SmallStrainPerfectPlasticity::elastic_step(
   return fv <= 0.0;
 }
 
-int SmallStrainPerfectPlasticity::update_internal(
+void SmallStrainPerfectPlasticity::update_internal(
     const double * const x,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -538,10 +529,9 @@ int SmallStrainPerfectPlasticity::update_internal(
     double * const h_np1, const double * const h_n)
 {
   std::copy(x, x+6, s_np1);
-  return 0;
 }
 
-int SmallStrainPerfectPlasticity::strain_partial(
+void SmallStrainPerfectPlasticity::strain_partial(
     const TrialState * ts,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -559,10 +549,9 @@ int SmallStrainPerfectPlasticity::strain_partial(
     }
   }
 
-  return 0;
 }
 
-int SmallStrainPerfectPlasticity::work_and_energy(
+void SmallStrainPerfectPlasticity::work_and_energy(
     const TrialState * ts,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -593,7 +582,6 @@ int SmallStrainPerfectPlasticity::work_and_energy(
   sub_vec(e_np1, e_n, 6, de);
   u_np1 = u_n + dot_vec(ds, de, 6) / 2.0;
 
-  return 0;
 }
 
 size_t SmallStrainPerfectPlasticity::nparams() const
@@ -664,7 +652,7 @@ double SmallStrainPerfectPlasticity::ys(double T) const
 }
 
 // Make this public for ease of testing
-int SmallStrainPerfectPlasticity::make_trial_state(
+void SmallStrainPerfectPlasticity::make_trial_state(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n, double t_np1, double t_n,
     const double * const s_n, const double * const h_n,
@@ -687,7 +675,6 @@ int SmallStrainPerfectPlasticity::make_trial_state(
   mat_vec(ts.C, 6, de, 6, ts.s_tr);
   for (size_t i = 0; i < 6; i++) ts.s_tr[i] = s_n[i] + ts.s_tr[i];
 
-  return 0;
 }
 
 // Implementation of small strain rate independent plasticity
@@ -739,10 +726,9 @@ size_t SmallStrainRateIndependentPlasticity::nhist() const
   return flow_->nhist();
 }
 
-int SmallStrainRateIndependentPlasticity::init_hist(double * const hist) const
+void SmallStrainRateIndependentPlasticity::init_hist(double * const hist) const
 {
   flow_->init_hist(hist);
-  return 0;
 }
 
 TrialState * SmallStrainRateIndependentPlasticity::setup(
@@ -773,7 +759,7 @@ bool SmallStrainRateIndependentPlasticity::elastic_step(
   return fv <= 0.0;
 }
 
-int SmallStrainRateIndependentPlasticity::update_internal(
+void SmallStrainRateIndependentPlasticity::update_internal(
     const double * const x,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -783,10 +769,9 @@ int SmallStrainRateIndependentPlasticity::update_internal(
 {
   std::copy(x, x+6, s_np1);
   std::copy(x+6, x+6+nhist(), h_np1);
-  return 0;
 }
 
-int SmallStrainRateIndependentPlasticity::strain_partial(
+void SmallStrainRateIndependentPlasticity::strain_partial(
     const TrialState * ts,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -803,10 +788,9 @@ int SmallStrainRateIndependentPlasticity::strain_partial(
       de[CINDEX(i,j,6)] = tss->C[CINDEX(i,j,6)];
     }
   }
-  return 0;
 }
 
-int SmallStrainRateIndependentPlasticity::work_and_energy(
+void SmallStrainRateIndependentPlasticity::work_and_energy(
     const TrialState * ts,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -837,7 +821,6 @@ int SmallStrainRateIndependentPlasticity::work_and_energy(
   sub_vec(e_np1, e_n, 6, de);
   u_np1 = u_n + dot_vec(ds, de, 6) / 2.0;
 
-  return 0;
 }
 
 size_t SmallStrainRateIndependentPlasticity::nparams() const
@@ -982,7 +965,7 @@ const std::shared_ptr<const LinearElasticModel> SmallStrainRateIndependentPlasti
   return elastic_;
 }
 
-int SmallStrainRateIndependentPlasticity::make_trial_state(
+void SmallStrainRateIndependentPlasticity::make_trial_state(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n, double t_np1, double t_n,
     const double * const s_n, const double * const h_n,
@@ -1008,7 +991,6 @@ int SmallStrainRateIndependentPlasticity::make_trial_state(
   mat_vec(ts.C, 6, ee, 6, ts.s_tr);
   // Store temp
   ts.T = T_np1;
-  return 0;
 }
 
 // Implement creep + plasticity
@@ -1067,13 +1049,13 @@ size_t SmallStrainCreepPlasticity::nhist() const
   return plastic_->nhist() + 6;
 }
 
-int SmallStrainCreepPlasticity::init_hist(double * const hist) const
+void SmallStrainCreepPlasticity::init_hist(double * const hist) const
 {
   std::fill(hist, hist+6, 0.0);
-  return plastic_->init_hist(&hist[6]);
+  plastic_->init_hist(&hist[6]);
 }
 
-int SmallStrainCreepPlasticity::update_sd(
+void SmallStrainCreepPlasticity::update_sd(
        const double * const e_np1, const double * const e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
@@ -1127,7 +1109,6 @@ int SmallStrainCreepPlasticity::update_sd(
   sub_vec(creep_new, creep_old, 6, dec);
   p_np1 += dot_vec(ds, dec, 6) / 2.0;
   
-  return 0;
 }
 
 size_t SmallStrainCreepPlasticity::nparams() const
@@ -1188,7 +1169,7 @@ void SmallStrainCreepPlasticity::RJ(const double * const x, TrialState * ts,
   for (int i=0; i<36; i++) J[i] *= sf_;
 }
 
-int SmallStrainCreepPlasticity::make_trial_state(
+void SmallStrainCreepPlasticity::make_trial_state(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n, double t_np1, double t_n,
     const double * const s_n, const double * const h_n,
@@ -1208,10 +1189,9 @@ int SmallStrainCreepPlasticity::make_trial_state(
 
   std::copy(h_n, h_n+6, ts.ep_strain);
 
-  return 0;
 }
 
-int SmallStrainCreepPlasticity::form_tangent_(
+void SmallStrainCreepPlasticity::form_tangent_(
     double * const A, double * const B, double * const A_np1)
 {
   // Okay, what we really want to do is
@@ -1244,13 +1224,12 @@ int SmallStrainCreepPlasticity::form_tangent_(
   std::copy(A,A+36,A_np1);
   for (int i=0; i<36; i++) A_np1[i] -= D[i];
 
-  return 0;
 }
 
-int SmallStrainCreepPlasticity::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
+void SmallStrainCreepPlasticity::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
 {
   elastic_ = emodel;
-  return plastic_->set_elastic_model(emodel);
+  plastic_->set_elastic_model(emodel);
 }
 
 // Start general integrator implementation
@@ -1328,7 +1307,7 @@ bool GeneralIntegrator::elastic_step(
   return false;
 }
 
-int GeneralIntegrator::update_internal(
+void GeneralIntegrator::update_internal(
     const double * const x,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -1339,10 +1318,9 @@ int GeneralIntegrator::update_internal(
   std::copy(x, x+6, s_np1);
   std::copy(x+6, x+6+nhist(), h_np1);
 
-  return 0;
 }
 
-int GeneralIntegrator::strain_partial(
+void GeneralIntegrator::strain_partial(
     const TrialState * ts,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -1376,10 +1354,9 @@ int GeneralIntegrator::strain_partial(
 
   delete [] ehist;
 
-  return 0;
 }
 
-int GeneralIntegrator::work_and_energy(
+void GeneralIntegrator::work_and_energy(
     const TrialState * ts,
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
@@ -1406,7 +1383,6 @@ int GeneralIntegrator::work_and_energy(
   rule_->work_rate(s_n, h_n, tss->e_dot, T_n, tss->Tdot, p_dot_n);
   p_np1 = p_n + (p_dot_np1 + p_dot_n)/2.0 * tss->dt;
 
-  return 0;
 }
 
 size_t GeneralIntegrator::nhist() const
@@ -1414,11 +1390,9 @@ size_t GeneralIntegrator::nhist() const
   return rule_->nhist();
 }
 
-int GeneralIntegrator::init_hist(double * const hist) const
+void GeneralIntegrator::init_hist(double * const hist) const
 {
   rule_->init_hist(hist);
-
-  return 0;
 }
 
 size_t GeneralIntegrator::nparams() const
@@ -1506,7 +1480,7 @@ void GeneralIntegrator::RJ(const double * const x, TrialState * ts,
 }
 
 
-int GeneralIntegrator::make_trial_state(
+void GeneralIntegrator::make_trial_state(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n, double t_np1, double t_n,
     const double * const s_n, const double * const h_n,
@@ -1547,15 +1521,13 @@ int GeneralIntegrator::make_trial_state(
   if ((t_n == 0.0) && (skip_first_))
     std::copy(s_n, s_n+6, ts.s_guess);
 
-  return 0;
 }
 
-int GeneralIntegrator::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
+void GeneralIntegrator::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
 {
   elastic_ = emodel;
   rule_->set_elastic_model(emodel);
 
-  return 0;
 }
 
 // Start KMRegimeModel
@@ -1599,7 +1571,7 @@ std::unique_ptr<NEMLObject> KMRegimeModel::initialize(ParameterSet & params)
   return neml::make_unique<KMRegimeModel>(params); 
 }
 
-int KMRegimeModel::update_sd(
+void KMRegimeModel::update_sd(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
     double t_np1, double t_n,
@@ -1631,7 +1603,7 @@ size_t KMRegimeModel::nhist() const
   return models_[0]->nhist();
 }
 
-int KMRegimeModel::init_hist(double * const hist) const
+void KMRegimeModel::init_hist(double * const hist) const
 {
   return models_[0]->init_hist(hist);
 }
@@ -1652,13 +1624,12 @@ double KMRegimeModel::activation_energy_(const double * const e_np1,
   return kboltz_ * T_np1 / (mu* pow(b_, 3.0)) * log(eps0_ / rate);
 }
 
-int KMRegimeModel::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
+void KMRegimeModel::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
 {
   elastic_ = emodel;
   for (auto it = models_.begin(); it != models_.end(); ++it) {
     (*it)->set_elastic_model(emodel);
   }
-  return 0;
 }
 
 } // namespace neml

--- a/src/models_wrap.cxx
+++ b/src/models_wrap.cxx
@@ -24,8 +24,7 @@ PYBIND11_MODULE(models, m) {
            [](NEMLModel & m) -> py::array_t<double>
            {
             auto h = alloc_vec<double>(m.nstore());
-            int ier = m.init_store(arr2ptr<double>(h));
-            py_error(ier);
+            m.init_store(arr2ptr<double>(h));
             return h;
            }, "Initialize stored variables.")
 
@@ -34,8 +33,7 @@ PYBIND11_MODULE(models, m) {
            [](NEMLModel & m) -> py::array_t<double>
            {
             auto h = alloc_vec<double>(m.nhist());
-            int ier = m.init_hist(arr2ptr<double>(h));
-            py_error(ier);
+            m.init_hist(arr2ptr<double>(h));
             return h;
            }, "Initialize history variables.")
       .def("update_sd",
@@ -46,8 +44,7 @@ PYBIND11_MODULE(models, m) {
             auto A_np1 = alloc_mat<double>(6,6);
             double u_np1, p_np1;
 
-            int ier = m.update_sd(arr2ptr<double>(e_np1), arr2ptr<double>(e_n), T_np1, T_n, t_np1, t_n, arr2ptr<double>(s_np1), arr2ptr<double>(s_n), arr2ptr<double>(h_np1), arr2ptr<double>(h_n), arr2ptr<double>(A_np1), u_np1, u_n, p_np1, p_n);
-            py_error(ier);
+            m.update_sd(arr2ptr<double>(e_np1), arr2ptr<double>(e_n), T_np1, T_n, t_np1, t_n, arr2ptr<double>(s_np1), arr2ptr<double>(s_n), arr2ptr<double>(h_np1), arr2ptr<double>(h_n), arr2ptr<double>(A_np1), u_np1, u_n, p_np1, p_n);
 
             return std::make_tuple(s_np1, h_np1, A_np1, u_np1, p_np1);
 
@@ -61,8 +58,7 @@ PYBIND11_MODULE(models, m) {
             auto B_np1 = alloc_mat<double>(6,3);
             double u_np1, p_np1;
 
-            int ier = m.update_ld_inc(arr2ptr<double>(d_np1), arr2ptr<double>(d_n), arr2ptr<double>(w_np1), arr2ptr<double>(w_n), T_np1, T_n, t_np1, t_n, arr2ptr<double>(s_np1), arr2ptr<double>(s_n), arr2ptr<double>(h_np1), arr2ptr<double>(h_n), arr2ptr<double>(A_np1), arr2ptr<double>(B_np1), u_np1, u_n, p_np1, p_n);
-            py_error(ier);
+            m.update_ld_inc(arr2ptr<double>(d_np1), arr2ptr<double>(d_n), arr2ptr<double>(w_np1), arr2ptr<double>(w_n), T_np1, T_n, t_np1, t_n, arr2ptr<double>(s_np1), arr2ptr<double>(s_n), arr2ptr<double>(h_np1), arr2ptr<double>(h_n), arr2ptr<double>(A_np1), arr2ptr<double>(B_np1), u_np1, u_n, p_np1, p_n);
 
             return std::make_tuple(s_np1, h_np1, A_np1, B_np1, u_np1, p_np1);
 
@@ -74,10 +70,9 @@ PYBIND11_MODULE(models, m) {
            {
             auto e_np1 = alloc_vec<double>(6);
 
-            int ier = m.elastic_strains(
+            m.elastic_strains(
                 arr2ptr<double>(s_np1), T_np1,
                 arr2ptr<double>(h_np1), arr2ptr<double>(e_np1));
-            py_error(ier);
 
             return e_np1;
 
@@ -132,15 +127,13 @@ PYBIND11_MODULE(models, m) {
            [](SmallStrainPerfectPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<SSPPTrialState>
            {
               std::unique_ptr<SSPPTrialState> ts(new SSPPTrialState);
-              int ier = m.make_trial_state(arr2ptr<double>(e_np1),
+              m.make_trial_state(arr2ptr<double>(e_np1),
                                           arr2ptr<double>(e_n),
                                           T_np1, T_n,
                                           t_np1, t_n,
                                           arr2ptr<double>(s_n),
                                           arr2ptr<double>(h_n),
                                           *ts);
-              py_error(ier);
-
               return ts;
            }, "Setup trial state for solve.")
       ;
@@ -157,15 +150,13 @@ PYBIND11_MODULE(models, m) {
            [](SmallStrainRateIndependentPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<SSRIPTrialState>
            {
               std::unique_ptr<SSRIPTrialState> ts(new SSRIPTrialState);
-              int ier = m.make_trial_state(arr2ptr<double>(e_np1),
+              m.make_trial_state(arr2ptr<double>(e_np1),
                                           arr2ptr<double>(e_n),
                                           T_np1, T_n,
                                           t_np1, t_n,
                                           arr2ptr<double>(s_n),
                                           arr2ptr<double>(h_n),
                                           *ts);
-              py_error(ier);
-
               return ts;
            }, "Setup trial state for solve.")
       ;
@@ -183,15 +174,13 @@ PYBIND11_MODULE(models, m) {
            [](SmallStrainCreepPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<SSCPTrialState>
            {
               std::unique_ptr<SSCPTrialState> ts(new SSCPTrialState);
-              int ier = m.make_trial_state(arr2ptr<double>(e_np1),
+              m.make_trial_state(arr2ptr<double>(e_np1),
                                           arr2ptr<double>(e_n),
                                           T_np1, T_n,
                                           t_np1, t_n,
                                           arr2ptr<double>(s_n),
                                           arr2ptr<double>(h_n),
                                           *ts);
-              py_error(ier);
-
               return ts;
            }, "Setup trial state for solve.")
       ;
@@ -210,14 +199,13 @@ PYBIND11_MODULE(models, m) {
            [](GeneralIntegrator & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<GITrialState>
            {
               std::unique_ptr<GITrialState> ts(new GITrialState);
-              int ier = m.make_trial_state(arr2ptr<double>(e_np1),
+              m.make_trial_state(arr2ptr<double>(e_np1),
                                           arr2ptr<double>(e_n),
                                           T_np1, T_n,
                                           t_np1, t_n,
                                           arr2ptr<double>(s_n),
                                           arr2ptr<double>(h_n),
                                           *ts);
-              py_error(ier);
               return ts;
            }, "Setup trial state for solve.")
       ;

--- a/src/nemlerror.cxx
+++ b/src/nemlerror.cxx
@@ -6,56 +6,29 @@ namespace neml {
 
 void py_error(int ier)
 {
-  switch(ier) {
-    case SUCCESS: return;
-    case INCOMPATIBLE_MODELS: throw std::runtime_error("Incompatible submodels");
-    case LINALG_FAILURE: throw LinalgError("Generic linear algebra failure");
-    case MAX_ITERATIONS: throw std::runtime_error("Maximum iteration count exceeded");
-    case KT_VIOLATION: throw std::runtime_error("Integration of rate-independent model resulted in a violation of the Kuhn-Tucker conditions");
-    case NODE_NOT_FOUND: throw std::runtime_error("XML node not found");
-    case TOO_MANY_NODES: throw std::runtime_error("More than one XML node found");
-    case ATTRIBUTE_NOT_FOUND: throw std::runtime_error("XML attribute not found");
-    case UNKNOWN_TYPE: throw std::runtime_error("Unknown model type");
-    case BAD_TEXT: throw std::runtime_error("Bad text data in XML node");
-    case INVALID_TYPE: throw std::runtime_error("Type described by XML node is invalid here");
-    case FILE_NOT_FOUND: throw std::runtime_error("File not found");
-    case CREEP_PLASTICITY: throw std::runtime_error("Creep models can only be combined with rate independent models");
-    case INCOMPATIBLE_KM: throw std::runtime_error("Incompatible lengths in Kocks-Mecking region model: number of models = number of splits + 1");
-    case DUMMY_ELASTIC: throw std::runtime_error("Calling for elastic constants from a dummy elastic model.");
-    case INCOMPATIBLE_VECTORS: throw std::runtime_error("Inputs do not have the same length.");
-    case UNKNOWN_ERROR: throw std::runtime_error("Unknown error");
-
-    default: throw std::runtime_error("Unknown error!");
-  }
+  if (ier != 0)
+    throw NEMLError("Unknown error!");
 }
 
 std::string string_error(int ier)
 {
-  switch(ier) {
-    case SUCCESS: return "Success";
-    case INCOMPATIBLE_MODELS: return "Incompatible submodels";
-    case LINALG_FAILURE: return "Linear algebra call failed";
-    case MAX_ITERATIONS: return "Maximum iteration count exceeded";
-    case KT_VIOLATION: return "Integration of rate-independent model resulted in a violation of the Kuhn-Tucker conditions";
-    case NODE_NOT_FOUND: return "XML node not found";
-    case TOO_MANY_NODES: return "More than  one XML node found";
-    case ATTRIBUTE_NOT_FOUND: return "XML attribute not found";
-    case UNKNOWN_TYPE: return "Unknown model type";
-    case BAD_TEXT: return "Bad text data in XML node";
-    case INVALID_TYPE: return "Type described by XML node is invalid here";
-    case FILE_NOT_FOUND: return "File not found";
-    case CREEP_PLASTICITY: return "Creep models can only be combined with rate independent plasticity models";
-    case INCOMPATIBLE_KM: return "Incompatible lengths in Kocks-Mecking region model: number of models = number of splits + 1";
-    case DUMMY_ELASTIC: return "Calling for elastic constants from a dummy elastic model";
-    case INCOMPATIBLE_VECTORS: return "Inputs do not have the same length.";
-    case UNKNOWN_ERROR: return "Unknown error";
-
-    default: return "Unknown error";
-  }
+  return "Unknown error";
 }
 
-LinalgError::LinalgError(const char * m) :
-    std::runtime_error(m)
+NEMLError::NEMLError(std::string msg) :
+    std::runtime_error(msg.c_str())
+{
+
+}
+
+LinalgError::LinalgError(std::string msg) :
+    NEMLError(msg)
+{
+
+}
+
+NonlinearSolverError::NonlinearSolverError(std::string msg) :
+    NEMLError(msg)
 {
 
 }

--- a/src/nemlerror.cxx
+++ b/src/nemlerror.cxx
@@ -4,11 +4,6 @@
 
 namespace neml {
 
-std::string string_error(int ier)
-{
-  return "Unknown error";
-}
-
 NEMLError::NEMLError(std::string msg) :
     std::runtime_error(msg.c_str())
 {

--- a/src/nemlerror.cxx
+++ b/src/nemlerror.cxx
@@ -4,12 +4,6 @@
 
 namespace neml {
 
-void py_error(int ier)
-{
-  if (ier != 0)
-    throw NEMLError("Unknown error!");
-}
-
 std::string string_error(int ier)
 {
   return "Unknown error";

--- a/src/parse_wrap.cxx
+++ b/src/parse_wrap.cxx
@@ -16,11 +16,10 @@ PYBIND11_MODULE(parse, m) {
 
   m.def("get_object_string", &get_object_string);
 
-  py::register_exception<NodeNotFound>(m, "NodeNotFound");
-  py::register_exception<DuplicateNode>(m, "DuplicateNode");
   py::register_exception<InvalidType>(m, "InvalidType");
   py::register_exception<UnknownParameterXML>(m, "UnknownParameterXML");
   py::register_exception<UnregisteredXML>(m, "UnregisteredXML");
+  py::register_exception<ModelNotFound>(m, "ModelNotFound");
 }
 
 } // namespace neml

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -47,7 +47,7 @@ size_t RateIndependentAssociativeFlow::nhist() const
 int RateIndependentAssociativeFlow::init_hist(double * const h) const
 {
   if (hardening_->nhist() != surface_->nhist()) {
-    return INCOMPATIBLE_MODELS;
+    throw NEMLError("Hardening model and flow surface are not compatible");
   }
 
   return hardening_->init_hist(h);
@@ -232,7 +232,7 @@ size_t RateIndependentNonAssociativeHardening::nhist() const
 int RateIndependentNonAssociativeHardening::init_hist(double * const h) const
 {
   if (hardening_->ninter() != surface_->nhist()) {
-    return INCOMPATIBLE_MODELS;
+    throw NEMLError("Hardening model and flow surface are not compatible");
   }
 
   return hardening_->init_hist(h);

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -60,8 +60,7 @@ int RateIndependentAssociativeFlow::f(const double* const s,
   std::vector<double> qv(nhist());
   double * q = &qv[0];
 
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->f(s, q, T, fv);
 }
@@ -73,8 +72,7 @@ int RateIndependentAssociativeFlow::df_ds(const double* const s,
   std::vector<double> qv(nhist());
   double * q = &qv[0];
   
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   return surface_->df_ds(s, q, T, dfv);
 }
@@ -85,18 +83,15 @@ int RateIndependentAssociativeFlow::df_da(const double* const s,
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   std::vector<double> jacv(nhist() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
   
   std::vector<double> dqv(nhist());
   double * dq = &dqv[0];
-  ier = surface_->df_dq(s, q, T, dq);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dq(s, q, T, dq);
 
   return mat_vec_trans(jac, nhist(), dq, nhist(), dfv);
 }
@@ -107,8 +102,7 @@ int RateIndependentAssociativeFlow::RateIndependentAssociativeFlow::g(const doub
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier; 
+  hardening_->q(alpha, T, q);
 
   return surface_->df_ds(s, q, T, gv);
 }
@@ -119,8 +113,7 @@ int RateIndependentAssociativeFlow::dg_ds(const double * const s,
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dsds(s, q, T, dgv);
 }
@@ -131,18 +124,15 @@ int RateIndependentAssociativeFlow::dg_da(const double * const s,
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   std::vector<double> jacv(nhist() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
   
   std::vector<double> ddv(6 * nhist());
   double * dd = &ddv[0];
-  ier = surface_->df_dsdq(s, q, T, dd);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dsdq(s, q, T, dd);
 
   return mat_mat(6, nhist(), nhist(), dd, jac, dgv);
 }
@@ -153,8 +143,7 @@ int RateIndependentAssociativeFlow::h(const double * const s,
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dq(s, q, T, hv);
 }
@@ -165,8 +154,7 @@ int RateIndependentAssociativeFlow::dh_ds(const double * const s,
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dqds(s, q, T, dhv);
 }
@@ -177,18 +165,15 @@ int RateIndependentAssociativeFlow::dh_da(const double * const s,
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   std::vector<double> jacv(nhist() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
 
   std::vector<double> ddv(nhist() * nhist());
   double * dd = &ddv[0];
-  ier = surface_->df_dqdq(s, q, T, dd);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dqdq(s, q, T, dd);
 
   return mat_mat(nhist(), nhist(), nhist(), dd, jac, dhv);
 }
@@ -244,8 +229,7 @@ int RateIndependentNonAssociativeHardening::f(const double* const s,
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->f(s, q, T, fv);
 }
@@ -256,8 +240,7 @@ int RateIndependentNonAssociativeHardening::df_ds(const double* const s,
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   return surface_->df_ds(s, q, T, dfv);
 }
@@ -268,18 +251,15 @@ int RateIndependentNonAssociativeHardening::df_da(const double* const s,
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
  
   std::vector<double> jacv(hardening_->ninter() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
   
   std::vector<double> dqv(hardening_->ninter());
   double * dq = &dqv[0];
-  ier = surface_->df_dq(s, q, T, dq);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dq(s, q, T, dq);
   
   return mat_vec_trans(jac, nhist(), dq, hardening_->ninter(), dfv);
 }
@@ -290,8 +270,7 @@ int RateIndependentNonAssociativeHardening::RateIndependentNonAssociativeHardeni
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_ds(s, q, T, gv);
 }
@@ -302,8 +281,7 @@ int RateIndependentNonAssociativeHardening::dg_ds(const double * const s,
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dsds(s, q, T, dgv);
 }
@@ -314,18 +292,15 @@ int RateIndependentNonAssociativeHardening::dg_da(const double * const s,
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return  ier; 
+  hardening_->q(alpha, T, q);
 
   std::vector<double> jacv(hardening_->ninter() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
   
   std::vector<double> ddv(6 * hardening_->ninter());
   double * dd = &ddv[0];
-  ier = surface_->df_dsdq(s, q, T, dd);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dsdq(s, q, T, dd);
 
   return mat_mat(6, nhist(), hardening_->ninter(), dd, jac, dgv);
 }

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -44,17 +44,16 @@ size_t RateIndependentAssociativeFlow::nhist() const
   return hardening_->nhist();
 }
 
-int RateIndependentAssociativeFlow::init_hist(double * const h) const
+void RateIndependentAssociativeFlow::init_hist(double * const h) const
 {
   if (hardening_->nhist() != surface_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
 
   hardening_->init_hist(h);
-  return 0;
 }
 
-int RateIndependentAssociativeFlow::f(const double* const s, 
+void RateIndependentAssociativeFlow::f(const double* const s, 
                                       const double* const alpha, double T,
                                       double & fv) const
 {
@@ -63,10 +62,10 @@ int RateIndependentAssociativeFlow::f(const double* const s,
 
   hardening_->q(alpha, T, q);
 
-  return surface_->f(s, q, T, fv);
+  surface_->f(s, q, T, fv);
 }
 
-int RateIndependentAssociativeFlow::df_ds(const double* const s, 
+void RateIndependentAssociativeFlow::df_ds(const double* const s, 
                                           const double* const alpha, double T,
                                           double * const dfv) const
 {
@@ -75,10 +74,10 @@ int RateIndependentAssociativeFlow::df_ds(const double* const s,
   
   hardening_->q(alpha, T, q);
   
-  return surface_->df_ds(s, q, T, dfv);
+  surface_->df_ds(s, q, T, dfv);
 }
 
-int RateIndependentAssociativeFlow::df_da(const double* const s, 
+void RateIndependentAssociativeFlow::df_da(const double* const s, 
                                           const double* const alpha, double T,
                                           double * const dfv) const
 {
@@ -94,10 +93,10 @@ int RateIndependentAssociativeFlow::df_da(const double* const s,
   double * dq = &dqv[0];
   surface_->df_dq(s, q, T, dq);
 
-  return mat_vec_trans(jac, nhist(), dq, nhist(), dfv);
+  mat_vec_trans(jac, nhist(), dq, nhist(), dfv);
 }
 
-int RateIndependentAssociativeFlow::RateIndependentAssociativeFlow::g(const double * const s, 
+void RateIndependentAssociativeFlow::RateIndependentAssociativeFlow::g(const double * const s, 
                                       const double * const alpha, double T,
                                       double * const gv) const
 {
@@ -105,10 +104,10 @@ int RateIndependentAssociativeFlow::RateIndependentAssociativeFlow::g(const doub
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_ds(s, q, T, gv);
+  surface_->df_ds(s, q, T, gv);
 }
 
-int RateIndependentAssociativeFlow::dg_ds(const double * const s, 
+void RateIndependentAssociativeFlow::dg_ds(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dgv) const
 {
@@ -116,10 +115,10 @@ int RateIndependentAssociativeFlow::dg_ds(const double * const s,
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dsds(s, q, T, dgv);
+  surface_->df_dsds(s, q, T, dgv);
 }
 
-int RateIndependentAssociativeFlow::dg_da(const double * const s, 
+void RateIndependentAssociativeFlow::dg_da(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dgv) const
 {
@@ -135,10 +134,10 @@ int RateIndependentAssociativeFlow::dg_da(const double * const s,
   double * dd = &ddv[0];
   surface_->df_dsdq(s, q, T, dd);
 
-  return mat_mat(6, nhist(), nhist(), dd, jac, dgv);
+  mat_mat(6, nhist(), nhist(), dd, jac, dgv);
 }
 
-int RateIndependentAssociativeFlow::h(const double * const s,
+void RateIndependentAssociativeFlow::h(const double * const s,
                                       const double * const alpha, double T,
                                       double * const hv) const
 {
@@ -146,10 +145,10 @@ int RateIndependentAssociativeFlow::h(const double * const s,
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dq(s, q, T, hv);
+  surface_->df_dq(s, q, T, hv);
 }
 
-int RateIndependentAssociativeFlow::dh_ds(const double * const s, 
+void RateIndependentAssociativeFlow::dh_ds(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dhv) const
 {
@@ -157,10 +156,10 @@ int RateIndependentAssociativeFlow::dh_ds(const double * const s,
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dqds(s, q, T, dhv);
+  surface_->df_dqds(s, q, T, dhv);
 }
 
-int RateIndependentAssociativeFlow::dh_da(const double * const s, 
+void RateIndependentAssociativeFlow::dh_da(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dhv) const
 {
@@ -176,7 +175,7 @@ int RateIndependentAssociativeFlow::dh_da(const double * const s,
   double * dd = &ddv[0];
   surface_->df_dqdq(s, q, T, dd);
 
-  return mat_mat(nhist(), nhist(), nhist(), dd, jac, dhv);
+  mat_mat(nhist(), nhist(), nhist(), dd, jac, dhv);
 }
 
 
@@ -215,7 +214,7 @@ size_t RateIndependentNonAssociativeHardening::nhist() const
   return hardening_->nhist();
 }
 
-int RateIndependentNonAssociativeHardening::init_hist(double * const h) const
+void RateIndependentNonAssociativeHardening::init_hist(double * const h) const
 {
   if (hardening_->ninter() != surface_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
@@ -223,10 +222,9 @@ int RateIndependentNonAssociativeHardening::init_hist(double * const h) const
 
   hardening_->init_hist(h);
 
-  return 0;
 }
 
-int RateIndependentNonAssociativeHardening::f(const double* const s, 
+void RateIndependentNonAssociativeHardening::f(const double* const s, 
                                       const double* const alpha, double T,
                                       double & fv) const
 {
@@ -234,10 +232,10 @@ int RateIndependentNonAssociativeHardening::f(const double* const s,
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->f(s, q, T, fv);
+  surface_->f(s, q, T, fv);
 }
 
-int RateIndependentNonAssociativeHardening::df_ds(const double* const s, 
+void RateIndependentNonAssociativeHardening::df_ds(const double* const s, 
                                           const double* const alpha, double T,
                                           double * const dfv) const
 {
@@ -245,10 +243,10 @@ int RateIndependentNonAssociativeHardening::df_ds(const double* const s,
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
   
-  return surface_->df_ds(s, q, T, dfv);
+  surface_->df_ds(s, q, T, dfv);
 }
 
-int RateIndependentNonAssociativeHardening::df_da(const double* const s, 
+void RateIndependentNonAssociativeHardening::df_da(const double* const s, 
                                           const double* const alpha, double T,
                                           double * const dfv) const
 {
@@ -264,10 +262,10 @@ int RateIndependentNonAssociativeHardening::df_da(const double* const s,
   double * dq = &dqv[0];
   surface_->df_dq(s, q, T, dq);
   
-  return mat_vec_trans(jac, nhist(), dq, hardening_->ninter(), dfv);
+  mat_vec_trans(jac, nhist(), dq, hardening_->ninter(), dfv);
 }
 
-int RateIndependentNonAssociativeHardening::RateIndependentNonAssociativeHardening::g(const double * const s, 
+void RateIndependentNonAssociativeHardening::RateIndependentNonAssociativeHardening::g(const double * const s, 
                                       const double * const alpha, double T,
                                       double * const gv) const
 {
@@ -275,10 +273,10 @@ int RateIndependentNonAssociativeHardening::RateIndependentNonAssociativeHardeni
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_ds(s, q, T, gv);
+  surface_->df_ds(s, q, T, gv);
 }
 
-int RateIndependentNonAssociativeHardening::dg_ds(const double * const s, 
+void RateIndependentNonAssociativeHardening::dg_ds(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dgv) const
 {
@@ -286,10 +284,10 @@ int RateIndependentNonAssociativeHardening::dg_ds(const double * const s,
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dsds(s, q, T, dgv);
+  surface_->df_dsds(s, q, T, dgv);
 }
 
-int RateIndependentNonAssociativeHardening::dg_da(const double * const s, 
+void RateIndependentNonAssociativeHardening::dg_da(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dgv) const
 {
@@ -305,31 +303,28 @@ int RateIndependentNonAssociativeHardening::dg_da(const double * const s,
   double * dd = &ddv[0];
   surface_->df_dsdq(s, q, T, dd);
 
-  return mat_mat(6, nhist(), hardening_->ninter(), dd, jac, dgv);
+  mat_mat(6, nhist(), hardening_->ninter(), dd, jac, dgv);
 }
 
-int RateIndependentNonAssociativeHardening::h(const double * const s,
+void RateIndependentNonAssociativeHardening::h(const double * const s,
                                       const double * const alpha, double T,
                                       double * const hv) const
 {
   hardening_->h(s, alpha, T, hv);
-  return 0;
 }
 
-int RateIndependentNonAssociativeHardening::dh_ds(const double * const s, 
+void RateIndependentNonAssociativeHardening::dh_ds(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dhv) const
 {
   hardening_->dh_ds(s, alpha, T, dhv);
-  return 0;
 }
 
-int RateIndependentNonAssociativeHardening::dh_da(const double * const s, 
+void RateIndependentNonAssociativeHardening::dh_da(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dhv) const
 {
   hardening_->dh_da(s, alpha, T, dhv);
-  return 0;
 }
 
 } // namespace neml

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -50,7 +50,8 @@ int RateIndependentAssociativeFlow::init_hist(double * const h) const
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
 
-  return hardening_->init_hist(h);
+  hardening_->init_hist(h);
+  return 0;
 }
 
 int RateIndependentAssociativeFlow::f(const double* const s, 
@@ -220,7 +221,9 @@ int RateIndependentNonAssociativeHardening::init_hist(double * const h) const
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
 
-  return hardening_->init_hist(h);
+  hardening_->init_hist(h);
+
+  return 0;
 }
 
 int RateIndependentNonAssociativeHardening::f(const double* const s, 
@@ -309,21 +312,24 @@ int RateIndependentNonAssociativeHardening::h(const double * const s,
                                       const double * const alpha, double T,
                                       double * const hv) const
 {
-  return hardening_->h(s, alpha, T, hv);
+  hardening_->h(s, alpha, T, hv);
+  return 0;
 }
 
 int RateIndependentNonAssociativeHardening::dh_ds(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dhv) const
 {
-  return hardening_->dh_ds(s, alpha, T, dhv);
+  hardening_->dh_ds(s, alpha, T, dhv);
+  return 0;
 }
 
 int RateIndependentNonAssociativeHardening::dh_da(const double * const s, 
                                           const double * const alpha, double T,
                                           double * const dhv) const
 {
-  return hardening_->dh_da(s, alpha, T, dhv);
+  hardening_->dh_da(s, alpha, T, dhv);
+  return 0;
 }
 
 } // namespace neml

--- a/src/ri_flow_wrap.cxx
+++ b/src/ri_flow_wrap.cxx
@@ -21,8 +21,7 @@ PYBIND11_MODULE(ri_flow, m) {
            [](RateIndependentFlowRule & m) -> py::array_t<double>
            {
             auto h = alloc_vec<double>(m.nhist());
-            int ier = m.init_hist(arr2ptr<double>(h));
-            py_error(ier);
+            m.init_hist(arr2ptr<double>(h));
             return h;
            }, "Initialize history variables.")
 
@@ -30,24 +29,21 @@ PYBIND11_MODULE(ri_flow, m) {
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> double
            {
             double fv;
-            int ier = m.f(arr2ptr<double>(s), arr2ptr<double>(alpha), T, fv);
-            py_error(ier);
+            m.f(arr2ptr<double>(s), arr2ptr<double>(alpha), T, fv);
             return fv;
            }, "Yield surface value.")
       .def("df_ds",
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.df_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.df_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Yield surface derivative with respect to stress.")
       .def("df_da",
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.df_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.df_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Yield surface derivative with respect to history.")
 
@@ -55,24 +51,21 @@ PYBIND11_MODULE(ri_flow, m) {
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.g(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.g(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule.")
       .def("dg_ds",
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,6);
-            int ier = m.dg_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule derivative with respect to stress.")
       .def("dg_da",
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,m.nhist());
-            int ier = m.dg_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule derivative with respect to history.")
 
@@ -80,24 +73,21 @@ PYBIND11_MODULE(ri_flow, m) {
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.h(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.h(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule.")
       .def("dh_ds",
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.dh_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule derivative with respect to stress.")
       .def("dh_da",
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.dh_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule derivative with respect to history.")
       ;

--- a/src/solvers.cxx
+++ b/src/solvers.cxx
@@ -104,9 +104,9 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
       }
       nR = nRt;
       if (nsearch == mline) {
-        // Arguably it's better to let it fall through
-        // ier = MAX_ITERATIONS;
-        // break;
+        // Arguably it's better to let it fall through, but we could
+        // raise a NonlinearSolverError right now with a line search
+        // failed message
       }
     }
     else {
@@ -142,7 +142,8 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
 
   if (ier != SUCCESS) return ier;
 
-  if (i == p.miter) return MAX_ITERATIONS;
+  if (i == p.miter) 
+    throw NonlinearSolverError("Nonlinear solver exceeded maximum allowed iterations!");
 
   return SUCCESS;
 }
@@ -319,7 +320,7 @@ int nox(Solvable * system, double * x, TrialState * ts,
 
   // Check if we actually succeeded
   if (result != NOX::StatusTest::Converged) {
-    return MAX_ITERATIONS; 
+    throw NonlinearSolverError("Nonlinear solver exceeded maximum allowed iterations!");
   }
 
   // Get the solution

--- a/src/solvers.cxx
+++ b/src/solvers.cxx
@@ -44,10 +44,7 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
     J = new double [n*n];
   }
 
-  int ier = 0;
-
-  ier = system->RJ(x, ts, R, J);
-  if (ier != SUCCESS) return ier;
+  system->RJ(x, ts, R, J);
 
   double nR = norm2_vec(R, n);
   double nR0 = nR;
@@ -73,8 +70,7 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
   {
     if ((nR < p.atol) || ((nR / nR0) < p.rtol)) break;
 
-    ier = solve_mat(J, n, R);
-    if (ier != SUCCESS) break;
+    solve_mat(J, n, R);
 
     if (p.linesearch) {
       int nsearch = 0;
@@ -87,11 +83,7 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
       bool linesearch_error = false;
       while (nsearch < mline) {
         for (int j=0; j<n; j++) x[j] = x_orig[j] - alpha * dir[j];
-        ier = system->RJ(x, ts, R, J);
-        if (ier != SUCCESS) {
-          linesearch_error = true;
-          break;
-        }
+        system->RJ(x, ts, R, J);
         nRt = norm2_vec(R, n);
         if (nRt < nR) break;
         alpha /= 2.0;
@@ -111,8 +103,7 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
     }
     else {
       for (int j=0; j<n; j++) x[j] -= R[j];
-      ier = system->RJ(x, ts, R, J);
-      if (ier != SUCCESS) break;
+      system->RJ(x, ts, R, J);
       nR = norm2_vec(R, n);
     }
     i++;
@@ -140,12 +131,10 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
     delete [] J;
   }
 
-  if (ier != SUCCESS) return ier;
-
   if (i == p.miter) 
     throw NonlinearSolverError("Nonlinear solver exceeded maximum allowed iterations!");
 
-  return SUCCESS;
+  return 0;
 }
 
 /// Helper to get numerical jacobian

--- a/src/solvers.cxx
+++ b/src/solvers.cxx
@@ -12,21 +12,21 @@
 namespace neml {
 
 // This function is configured by the build
-int solve(Solvable * system, double * x, TrialState * ts,
+void solve(Solvable * system, double * x, TrialState * ts,
           SolverParameters p, double * R, double * J)
 {
 #ifdef SOLVER_NOX
-  return nox(system, x, ts, p.atol, p.miter, p.verbose, R, J);
+  nox(system, x, ts, p.atol, p.miter, p.verbose, R, J);
 #elif SOLVER_NEWTON
   // Actually selected the newton solver
-  return newton(system, x, ts, p, R, J);
+  newton(system, x, ts, p, R, J);
 #else
   // Default solver: plain NR
-  return newton(system, x, ts, p, R, J);
+  newton(system, x, ts, p, R, J);
 #endif
 }
 
-int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, double * R,
+void newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, double * R,
            double * J)
 {
   int mline = 10;
@@ -133,12 +133,10 @@ int newton(Solvable * system, double * x, TrialState * ts, SolverParameters p, d
 
   if (i == p.miter) 
     throw NonlinearSolverError("Nonlinear solver exceeded maximum allowed iterations!");
-
-  return 0;
 }
 
 /// Helper to get numerical jacobian
-int diff_jac(Solvable * system, const double * const x, TrialState * ts,
+void diff_jac(Solvable * system, const double * const x, TrialState * ts,
              double * const nJ, double eps)
 {
   std::vector<double> R0v(system->nparams());
@@ -163,8 +161,6 @@ int diff_jac(Solvable * system, const double * const x, TrialState * ts,
       nJ[CINDEX(j,i,system->nparams())] = (nR[j] - R0[j]) / dx;
     }
   }
-  
-  return 0;
 }
 
 /// Helper to get checksum
@@ -253,7 +249,7 @@ bool NOXSolver::computeJacobian(NOX::LAPACK::Matrix<double>& J,
 }
 
 
-int nox(Solvable * system, double * x, TrialState * ts,
+void nox(Solvable * system, double * x, TrialState * ts,
         double tol, int miter, bool verbose, double * R,
         double * J)
 {
@@ -340,9 +336,6 @@ int nox(Solvable * system, double * x, TrialState * ts,
       delete [] J;
     }
   }
-
-
-  return 0;
 }
 
 #endif
@@ -358,18 +351,16 @@ size_t TestPower::nparams() const
   return 1;
 }
 
-int TestPower::init_x(double * const x, TrialState * ts)
+void TestPower::init_x(double * const x, TrialState * ts)
 {
   x[0] = x0_;
-  return 0;
 }
 
-int TestPower::RJ(const double * const x, TrialState * ts, double * const R, 
+void TestPower::RJ(const double * const x, TrialState * ts, double * const R, 
        double * const J)
 {
   R[0] = A_ * std::pow(x[0], n_) + b_;
   J[0] = A_ * n_ * std::pow(x[0], n_-1.0);
-  return 0;
 }
 
 

--- a/src/solvers_wrap.cxx
+++ b/src/solvers_wrap.cxx
@@ -34,8 +34,7 @@ PYBIND11_MODULE(solvers, m) {
            [](Solvable & m, TrialState & ts) -> py::array_t<double>
            {
             auto x = alloc_vec<double>(m.nparams());
-            int ier = m.init_x(arr2ptr<double>(x), &ts);
-            py_error(ier);
+            m.init_x(arr2ptr<double>(x), &ts);
             return x;
            }, "Initialize guess.")
       .def("RJ",
@@ -44,8 +43,7 @@ PYBIND11_MODULE(solvers, m) {
             auto R = alloc_vec<double>(m.nparams());
             auto J = alloc_mat<double>(m.nparams(), m.nparams());
             
-            int ier = m.RJ(arr2ptr<double>(x), &ts, arr2ptr<double>(R), arr2ptr<double>(J));
-            py_error(ier);
+            m.RJ(arr2ptr<double>(x), &ts, arr2ptr<double>(R), arr2ptr<double>(J));
 
             return std::make_tuple(R, J);
            }, "Residual and jacobian.")
@@ -57,10 +55,8 @@ PYBIND11_MODULE(solvers, m) {
         {
           auto x = alloc_vec<double>(system->nparams());
           
-          int ier = solve(system.get(), arr2ptr<double>(x), &ts, 
+          solve(system.get(), arr2ptr<double>(x), &ts, 
                           {rtol, atol, miter, verbose, linesearch});
-          py_error(ier);
-
           return x;
         }, "Solve a nonlinear system", 
         py::arg("solvable"), py::arg("trial_state"), py::arg("rtol") = 1.0e-6, py::arg("atol") = 1.0e-8,

--- a/src/surfaces.cxx
+++ b/src/surfaces.cxx
@@ -207,8 +207,7 @@ int IsoKinJ2::df_dqds(const double* const s, const double* const q, double T,
   std::fill(ddf, ddf+nhist()*6, 0.0);
   
   double ss[36];
-  int ier = df_dsds(s, q, T, ss);
-  if (ier != SUCCESS) return ier;
+  df_dsds(s, q, T, ss);
 
   for (int i=0; i<6; i++) {
     for (int j=0; j<6; j++) {

--- a/src/surfaces.cxx
+++ b/src/surfaces.cxx
@@ -62,7 +62,7 @@ size_t IsoKinJ2::nhist() const
   return 7;
 }
 
-int IsoKinJ2::f(const double* const s, const double* const q, double T,
+void IsoKinJ2::f(const double* const s, const double* const q, double T,
               double & fv) const
 {
   double sdev[6];
@@ -70,29 +70,26 @@ int IsoKinJ2::f(const double* const s, const double* const q, double T,
   dev_vec(sdev);
   add_vec(sdev, &q[1], 6, sdev);
   fv = norm2_vec(sdev, 6) + sqrt(2.0/3.0) * q[0];
-  return 0;
 }
 
-int IsoKinJ2::df_ds(const double* const s, const double* const q, double T,
+void IsoKinJ2::df_ds(const double* const s, const double* const q, double T,
               double * const df) const
 {
   std::copy(s, s+6, df);
   dev_vec(df);
   add_vec(df, &q[1], 6, df);
   normalize_vec(df, 6);
-  return 0;
 }
 
-int IsoKinJ2::df_dq(const double* const s, const double* const q, double T,
+void IsoKinJ2::df_dq(const double* const s, const double* const q, double T,
               double * const df) const
 {
   df[0] = sqrt(2.0/3.0);
   df_ds(s, q, T, &df[1]);
 
-  return 0;
 }
 
-int IsoKinJ2::df_dsds(const double* const s, const double* const q, double T,
+void IsoKinJ2::df_dsds(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   double n[6];
@@ -129,10 +126,9 @@ int IsoKinJ2::df_dsds(const double* const s, const double* const q, double T,
     }
   }
 
-  return 0;
 }
 
-int IsoKinJ2::df_dqdq(const double* const s, const double* const q, double T,
+void IsoKinJ2::df_dqdq(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   std::fill(ddf, ddf+nhist()*nhist(), 0.0);
@@ -164,10 +160,9 @@ int IsoKinJ2::df_dqdq(const double* const s, const double* const q, double T,
     }
   }
 
-  return 0;
 }
 
-int IsoKinJ2::df_dsdq(const double* const s, const double* const q, double T,
+void IsoKinJ2::df_dsdq(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   std::fill(ddf, ddf+6*nhist(), 0.0);
@@ -198,10 +193,9 @@ int IsoKinJ2::df_dsdq(const double* const s, const double* const q, double T,
     }
   }
 
-  return 0;
 }
 
-int IsoKinJ2::df_dqds(const double* const s, const double* const q, double T,
+void IsoKinJ2::df_dqds(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   std::fill(ddf, ddf+nhist()*6, 0.0);
@@ -215,7 +209,6 @@ int IsoKinJ2::df_dqds(const double* const s, const double* const q, double T,
     }
   }
 
-  return 0;
 }
 
 // J2I1 implementation
@@ -253,7 +246,7 @@ size_t IsoKinJ2I1::nhist() const
   return 7;
 }
 
-int IsoKinJ2I1::f(const double* const s, const double* const q, double T,
+void IsoKinJ2I1::f(const double* const s, const double* const q, double T,
               double & fv) const
 {
   double sdev[6];
@@ -263,10 +256,9 @@ int IsoKinJ2I1::f(const double* const s, const double* const q, double T,
   fv = norm2_vec(sdev, 6) + sqrt(2.0/3.0) * q[0] + 
       copysign(h_->value(T) * pow( fabs(s[0] + s[1] + s[2]), l_->value(T) ),
                s[0] + s[1] + s[2]);
-  return 0;
 }
 
-int IsoKinJ2I1::df_ds(const double* const s, const double* const q, double T,
+void IsoKinJ2I1::df_ds(const double* const s, const double* const q, double T,
               double * const df) const
 {
   std::copy(s, s+6, df);
@@ -285,10 +277,9 @@ int IsoKinJ2I1::df_ds(const double* const s, const double* const q, double T,
   }
   add_vec(df, dsh, 6, df);
 
-  return 0;
 }
 
-int IsoKinJ2I1::df_dq(const double* const s, const double* const q, double T,
+void IsoKinJ2I1::df_dq(const double* const s, const double* const q, double T,
               double * const df) const
 {
   df[0] = sqrt(2.0/3.0);
@@ -297,10 +288,9 @@ int IsoKinJ2I1::df_dq(const double* const s, const double* const q, double T,
   add_vec(&df[1], &q[1], 6, &df[1]);
   normalize_vec(&df[1], 6);
 
-  return 0;
 }
 
-int IsoKinJ2I1::df_dsds(const double* const s, const double* const q, double T,
+void IsoKinJ2I1::df_dsds(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   double n[6];
@@ -345,10 +335,9 @@ int IsoKinJ2I1::df_dsds(const double* const s, const double* const q, double T,
   }
   outer_update(iv2, 6, jv, 6, ddf);
 
-  return 0;
 }
 
-int IsoKinJ2I1::df_dqdq(const double* const s, const double* const q, double T,
+void IsoKinJ2I1::df_dqdq(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   std::fill(ddf, ddf+nhist()*nhist(), 0.0);
@@ -377,10 +366,9 @@ int IsoKinJ2I1::df_dqdq(const double* const s, const double* const q, double T,
     }
   }
 
-  return 0;
 }
 
-int IsoKinJ2I1::df_dsdq(const double* const s, const double* const q, double T,
+void IsoKinJ2I1::df_dsdq(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   std::fill(ddf, ddf+6*nhist(), 0.0);
@@ -409,10 +397,9 @@ int IsoKinJ2I1::df_dsdq(const double* const s, const double* const q, double T,
     }
   }
 
-  return 0;
 }
 
-int IsoKinJ2I1::df_dqds(const double* const s, const double* const q, double T,
+void IsoKinJ2I1::df_dqds(const double* const s, const double* const q, double T,
               double * const ddf) const
 {
   std::fill(ddf, ddf+nhist()*6, 0.0);
@@ -453,8 +440,6 @@ int IsoKinJ2I1::df_dqds(const double* const s, const double* const q, double T,
       ddf[CINDEX((i+1),j,6)] = ss[CINDEX(i,j,6)];
     }
   }
-
-  return 0;
 }
 
 std::string IsoJ2I1::type()

--- a/src/surfaces_wrap.cxx
+++ b/src/surfaces_wrap.cxx
@@ -21,8 +21,7 @@ PYBIND11_MODULE(surfaces, m) {
            {
             double fv;
 
-            int ier = m.f(arr2ptr<double>(s), arr2ptr<double>(h), T, fv);
-            py_error(ier);
+            m.f(arr2ptr<double>(s), arr2ptr<double>(h), T, fv);
 
             return fv;
            }, "Yield function")
@@ -32,8 +31,7 @@ PYBIND11_MODULE(surfaces, m) {
            {
             auto deriv = alloc_vec<double>(6);
             
-            int ier = m.df_ds(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
-            py_error(ier);
+            m.df_ds(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
 
             return deriv;
            }, "Yield function gradient wrt. deviatoric stress")
@@ -42,8 +40,7 @@ PYBIND11_MODULE(surfaces, m) {
            {
             auto deriv = alloc_vec<double>(m.nhist());
             
-            int ier = m.df_dq(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
-            py_error(ier);
+            m.df_dq(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
 
             return deriv;
            }, "Yield function gradient wrt. the history")
@@ -53,8 +50,7 @@ PYBIND11_MODULE(surfaces, m) {
            {
             auto deriv = alloc_mat<double>(6,6);
             
-            int ier = m.df_dsds(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
-            py_error(ier);
+            m.df_dsds(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
 
             return deriv;
            }, "Yield function Hessian: stress-stress")
@@ -64,8 +60,7 @@ PYBIND11_MODULE(surfaces, m) {
            {
             auto deriv = alloc_mat<double>(6,m.nhist());
             
-            int ier = m.df_dsdq(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
-            py_error(ier);
+            m.df_dsdq(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
 
             return deriv;
            }, "Yield function Hessian: stress-history")
@@ -75,8 +70,7 @@ PYBIND11_MODULE(surfaces, m) {
            {
             auto deriv = alloc_mat<double>(m.nhist(),6);
             
-            int ier = m.df_dqds(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
-            py_error(ier);
+            m.df_dqds(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
 
             return deriv;
            }, "Yield function Hessian: history-stress")
@@ -86,8 +80,7 @@ PYBIND11_MODULE(surfaces, m) {
            {
             auto deriv = alloc_mat<double>(m.nhist(),m.nhist());
             
-            int ier = m.df_dqdq(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
-            py_error(ier);
+            m.df_dqdq(arr2ptr<double>(s), arr2ptr<double>(h), T, arr2ptr<double>(deriv));
 
             return deriv;
            }, "Yield function Hessian: history-history")

--- a/src/visco_flow.cxx
+++ b/src/visco_flow.cxx
@@ -214,7 +214,9 @@ int PerzynaFlowRule::init_hist(double * const h) const
   if (surface_->nhist() != hardening_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
-  return hardening_->init_hist(h);
+  hardening_->init_hist(h);
+
+  return 0;
 }
 
 // Rate rule
@@ -509,7 +511,8 @@ int ChabocheFlowRule::init_hist(double * const h) const
   if (surface_->nhist() != hardening_->ninter()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
-  return hardening_->init_hist(h);
+  hardening_->init_hist(h);
+  return 0;
 }
 
 // Rate rule
@@ -640,57 +643,66 @@ int ChabocheFlowRule::dg_da(const double * const s, const double * const alpha, 
 int ChabocheFlowRule::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
-  return hardening_->h(s, alpha, T, hv);
+  hardening_->h(s, alpha, T, hv);
+  return 0;
 }
 
 int ChabocheFlowRule::dh_ds(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
-  return hardening_->dh_ds(s, alpha, T, dhv);
+  hardening_->dh_ds(s, alpha, T, dhv);
+  return 0;
 }
 
 int ChabocheFlowRule::dh_da(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
-  return hardening_->dh_da(s, alpha, T, dhv);
+  hardening_->dh_da(s, alpha, T, dhv);
+  return 0;
 }
 
 // Hardening rule wrt time
 int ChabocheFlowRule::h_time(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
-  return hardening_->h_time(s, alpha, T, hv);
+  hardening_->h_time(s, alpha, T, hv);
+  return 0;
 }
 
 int ChabocheFlowRule::dh_ds_time(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
-  return hardening_->dh_ds_time(s, alpha, T, dhv);
+  hardening_->dh_ds_time(s, alpha, T, dhv);
+  return 0;
 }
 
 int ChabocheFlowRule::dh_da_time(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
-  return hardening_->dh_da_time(s, alpha, T, dhv);
+  hardening_->dh_da_time(s, alpha, T, dhv);
+  return 0;
 }
 
 // Hardening rule wrt temperature
 int ChabocheFlowRule::h_temp(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
-  return hardening_->h_temp(s, alpha, T, hv);
+  hardening_->h_temp(s, alpha, T, hv);
+  return 0;
 }
 
 int ChabocheFlowRule::dh_ds_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
-  return hardening_->dh_ds_temp(s, alpha, T, dhv);
+  hardening_->dh_ds_temp(s, alpha, T, dhv);
+  return 0;
 }
 
 int ChabocheFlowRule::dh_da_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
-  return hardening_->dh_da_temp(s, alpha, T, dhv);
+  hardening_->dh_da_temp(s, alpha, T, dhv);
+  return 0;
 }
 
 YaguchiGr91FlowRule::YaguchiGr91FlowRule(ParameterSet & params) : 

--- a/src/visco_flow.cxx
+++ b/src/visco_flow.cxx
@@ -212,7 +212,7 @@ size_t PerzynaFlowRule::nhist() const
 int PerzynaFlowRule::init_hist(double * const h) const
 {
   if (surface_->nhist() != hardening_->nhist()) {
-    return INCOMPATIBLE_MODELS;
+    throw NEMLError("Hardening model and flow surface are not compatible");
   }
   return hardening_->init_hist(h);
 }
@@ -527,7 +527,7 @@ size_t ChabocheFlowRule::nhist() const
 int ChabocheFlowRule::init_hist(double * const h) const
 {
   if (surface_->nhist() != hardening_->ninter()) {
-    return INCOMPATIBLE_MODELS;
+    throw NEMLError("Hardening model and flow surface are not compatible");
   }
   return hardening_->init_hist(h);
 }

--- a/src/visco_flow.cxx
+++ b/src/visco_flow.cxx
@@ -14,103 +14,91 @@ ViscoPlasticFlowRule::ViscoPlasticFlowRule(ParameterSet & params) :
 }
 
 // Default implementation of flow rule wrt time
-int ViscoPlasticFlowRule::g_time(const double * const s, 
+void ViscoPlasticFlowRule::g_time(const double * const s, 
                                  const double * const alpha, double T, 
                                  double * const gv) const
 {
   std::fill(gv, gv+6, 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dg_ds_time(const double * const s, 
+void ViscoPlasticFlowRule::dg_ds_time(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dgv) const
 {
   std::fill(dgv, dgv+36, 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dg_da_time(const double * const s, 
+void ViscoPlasticFlowRule::dg_da_time(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dgv) const
 {
   std::fill(dgv, dgv+6*nhist(), 0.0);
-  return 0;
 }
 
 // Default implementation of flow rule wrt temperature
-int ViscoPlasticFlowRule::g_temp(const double * const s, 
+void ViscoPlasticFlowRule::g_temp(const double * const s, 
                                  const double * const alpha, double T, 
                                  double * const gv) const
 {
   std::fill(gv, gv+6, 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dg_ds_temp(const double * const s, 
+void ViscoPlasticFlowRule::dg_ds_temp(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dgv) const
 {
   std::fill(dgv, dgv+36, 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dg_da_temp(const double * const s, 
+void ViscoPlasticFlowRule::dg_da_temp(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dgv) const
 {
   std::fill(dgv, dgv+6*nhist(), 0.0);
-  return 0;
 }
 
 // Default implementation of hardening rule wrt time
-int ViscoPlasticFlowRule::h_time(const double * const s, 
+void ViscoPlasticFlowRule::h_time(const double * const s, 
                                  const double * const alpha, double T, 
                                  double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dh_ds_time(const double * const s, 
+void ViscoPlasticFlowRule::dh_ds_time(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dhv) const
 {
   std::fill(dhv, dhv+6*nhist(), 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dh_da_time(const double * const s, 
+void ViscoPlasticFlowRule::dh_da_time(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
-  return 0;
 }
 
 // Default implementation of hardening rule wrt temperature
-int ViscoPlasticFlowRule::h_temp(const double * const s, 
+void ViscoPlasticFlowRule::h_temp(const double * const s, 
                                  const double * const alpha, double T, 
                                  double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dh_ds_temp(const double * const s, 
+void ViscoPlasticFlowRule::dh_ds_temp(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dhv) const
 {
   std::fill(dhv, dhv+6*nhist(), 0.0);
-  return 0;
 }
 
-int ViscoPlasticFlowRule::dh_da_temp(const double * const s, 
+void ViscoPlasticFlowRule::dh_da_temp(const double * const s, 
                                      const double * const alpha, double T,
                                      double * const dhv) const
 {
   std::fill(dhv, dhv+nhist()*nhist(), 0.0);
-  return 0;
 }
 
 void ViscoPlasticFlowRule::override_guess(double * const guess)
@@ -209,18 +197,17 @@ size_t PerzynaFlowRule::nhist() const
   return hardening_->nhist();
 }
 
-int PerzynaFlowRule::init_hist(double * const h) const
+void PerzynaFlowRule::init_hist(double * const h) const
 {
   if (surface_->nhist() != hardening_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
   hardening_->init_hist(h);
 
-  return 0;
 }
 
 // Rate rule
-int PerzynaFlowRule::y(const double* const s, const double* const alpha, double T,
+void PerzynaFlowRule::y(const double* const s, const double* const alpha, double T,
               double & yv) const
 {
   std::vector<double> qv(nhist());
@@ -237,10 +224,9 @@ int PerzynaFlowRule::y(const double* const s, const double* const alpha, double 
     yv = 0.0;
   }
 
-  return 0;
 }
 
-int PerzynaFlowRule::dy_ds(const double* const s, const double* const alpha, double T,
+void PerzynaFlowRule::dy_ds(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   std::vector<double> qv(nhist());
@@ -260,10 +246,9 @@ int PerzynaFlowRule::dy_ds(const double* const s, const double* const alpha, dou
     }
   }
   
-  return 0;
 }
 
-int PerzynaFlowRule::dy_da(const double* const s, const double* const alpha, double T,
+void PerzynaFlowRule::dy_da(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   std::vector<double> qv(nhist());
@@ -293,32 +278,31 @@ int PerzynaFlowRule::dy_da(const double* const s, const double* const alpha, dou
     }
   }
 
-  return 0;
 
 }
 
 // Flow rule
-int PerzynaFlowRule::g(const double * const s, const double * const alpha, double T,
+void PerzynaFlowRule::g(const double * const s, const double * const alpha, double T,
               double * const gv) const
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_ds(s, q, T, gv);
+  surface_->df_ds(s, q, T, gv);
 }
 
-int PerzynaFlowRule::dg_ds(const double * const s, const double * const alpha, double T,
+void PerzynaFlowRule::dg_ds(const double * const s, const double * const alpha, double T,
               double * const dgv) const
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dsds(s, q, T, dgv);
+  surface_->df_dsds(s, q, T, dgv);
 }
 
-int PerzynaFlowRule::dg_da(const double * const s, const double * const alpha, double T,
+void PerzynaFlowRule::dg_da(const double * const s, const double * const alpha, double T,
              double * const dgv) const
 {
   std::vector<double> qv(nhist());
@@ -333,31 +317,31 @@ int PerzynaFlowRule::dg_da(const double * const s, const double * const alpha, d
   double * dd = &ddv[0];
   surface_->df_dsdq(s, q, T, dd);
 
-  return mat_mat(6, nhist(), nhist(), dd, jac, dgv);
+  mat_mat(6, nhist(), nhist(), dd, jac, dgv);
 }
 
 // Hardening rule
-int PerzynaFlowRule::h(const double * const s, const double * const alpha, double T,
+void PerzynaFlowRule::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dq(s, q, T, hv);
+  surface_->df_dq(s, q, T, hv);
 }
 
-int PerzynaFlowRule::dh_ds(const double * const s, const double * const alpha, double T,
+void PerzynaFlowRule::dh_ds(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dqds(s, q, T, dhv);
+  surface_->df_dqds(s, q, T, dhv);
 }
 
-int PerzynaFlowRule::dh_da(const double * const s, const double * const alpha, double T,
+void PerzynaFlowRule::dh_da(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   std::vector<double> qv(nhist());
@@ -372,7 +356,7 @@ int PerzynaFlowRule::dh_da(const double * const s, const double * const alpha, d
   double * dd = &ddv[0];
   surface_->df_dqdq(s, q, T, dd);
 
-  return mat_mat(nhist(), nhist(), nhist(), dd, jac, dhv);
+  mat_mat(nhist(), nhist(), nhist(), dd, jac, dhv);
 }
 
 FluidityModel::FluidityModel(ParameterSet & params) :
@@ -506,17 +490,16 @@ size_t ChabocheFlowRule::nhist() const
   return hardening_->nhist();
 }
 
-int ChabocheFlowRule::init_hist(double * const h) const
+void ChabocheFlowRule::init_hist(double * const h) const
 {
   if (surface_->nhist() != hardening_->ninter()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
   hardening_->init_hist(h);
-  return 0;
 }
 
 // Rate rule
-int ChabocheFlowRule::y(const double* const s, const double* const alpha, double T,
+void ChabocheFlowRule::y(const double* const s, const double* const alpha, double T,
               double & yv) const
 {
   std::vector<double> qv(hardening_->ninter());
@@ -533,10 +516,9 @@ int ChabocheFlowRule::y(const double* const s, const double* const alpha, double
     yv = 0.0;
   }
 
-  return 0;
 }
 
-int ChabocheFlowRule::dy_ds(const double* const s, const double* const alpha, double T,
+void ChabocheFlowRule::dy_ds(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   std::vector<double> qv(hardening_->ninter());
@@ -557,10 +539,9 @@ int ChabocheFlowRule::dy_ds(const double* const s, const double* const alpha, do
       dyv[i] *= mv;
   }
 
-  return 0;
 }
 
-int ChabocheFlowRule::dy_da(const double* const s, const double* const alpha, double T,
+void ChabocheFlowRule::dy_da(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   std::vector<double> qv(hardening_->ninter());
@@ -596,32 +577,31 @@ int ChabocheFlowRule::dy_da(const double* const s, const double* const alpha, do
     dyv[0] += deta * mv2;
   }
 
-  return 0;
 
 }
 
 // Flow rule
-int ChabocheFlowRule::g(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::g(const double * const s, const double * const alpha, double T,
               double * const gv) const
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_ds(s, q, T, gv);
+  surface_->df_ds(s, q, T, gv);
 }
 
-int ChabocheFlowRule::dg_ds(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dg_ds(const double * const s, const double * const alpha, double T,
               double * const dgv) const
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
   hardening_->q(alpha, T, q);
 
-  return surface_->df_dsds(s, q, T, dgv);
+  surface_->df_dsds(s, q, T, dgv);
 }
 
-int ChabocheFlowRule::dg_da(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dg_da(const double * const s, const double * const alpha, double T,
              double * const dgv) const
 {
   std::vector<double> qv(hardening_->ninter());
@@ -636,73 +616,64 @@ int ChabocheFlowRule::dg_da(const double * const s, const double * const alpha, 
   double * dd = &ddv[0];
   surface_->df_dsdq(s, q, T, dd);
 
-  return mat_mat(6, nhist(), hardening_->ninter(), dd, jac, dgv);
+  mat_mat(6, nhist(), hardening_->ninter(), dd, jac, dgv);
 }
 
 // Hardening rule
-int ChabocheFlowRule::h(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   hardening_->h(s, alpha, T, hv);
-  return 0;
 }
 
-int ChabocheFlowRule::dh_ds(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dh_ds(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   hardening_->dh_ds(s, alpha, T, dhv);
-  return 0;
 }
 
-int ChabocheFlowRule::dh_da(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dh_da(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   hardening_->dh_da(s, alpha, T, dhv);
-  return 0;
 }
 
 // Hardening rule wrt time
-int ChabocheFlowRule::h_time(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::h_time(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   hardening_->h_time(s, alpha, T, hv);
-  return 0;
 }
 
-int ChabocheFlowRule::dh_ds_time(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dh_ds_time(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   hardening_->dh_ds_time(s, alpha, T, dhv);
-  return 0;
 }
 
-int ChabocheFlowRule::dh_da_time(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dh_da_time(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   hardening_->dh_da_time(s, alpha, T, dhv);
-  return 0;
 }
 
 // Hardening rule wrt temperature
-int ChabocheFlowRule::h_temp(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::h_temp(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   hardening_->h_temp(s, alpha, T, hv);
-  return 0;
 }
 
-int ChabocheFlowRule::dh_ds_temp(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dh_ds_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   hardening_->dh_ds_temp(s, alpha, T, dhv);
-  return 0;
 }
 
-int ChabocheFlowRule::dh_da_temp(const double * const s, const double * const alpha, double T,
+void ChabocheFlowRule::dh_da_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   hardening_->dh_da_temp(s, alpha, T, dhv);
-  return 0;
 }
 
 YaguchiGr91FlowRule::YaguchiGr91FlowRule(ParameterSet & params) : 
@@ -739,7 +710,7 @@ size_t YaguchiGr91FlowRule::nhist() const
   return 14;
 }
 
-int YaguchiGr91FlowRule::init_hist(double * const h) const
+void YaguchiGr91FlowRule::init_hist(double * const h) const
 {
   // This also hardcoded from the paper
   
@@ -752,12 +723,11 @@ int YaguchiGr91FlowRule::init_hist(double * const h) const
   // sa
   h[13] = 0.0;
 
-  return 0;
 
 }
 
 // Rate rule
-int YaguchiGr91FlowRule::y(const double* const s, const double* const alpha, double T,
+void YaguchiGr91FlowRule::y(const double* const s, const double* const alpha, double T,
               double & yv) const
 {
   double nT = n(T);
@@ -778,10 +748,9 @@ int YaguchiGr91FlowRule::y(const double* const s, const double* const alpha, dou
     yv = 0.0;
   }
 
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dy_ds(const double* const s, const double* const alpha, double T,
+void YaguchiGr91FlowRule::dy_ds(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   std::fill(dyv, dyv+6, 0.0);
@@ -811,10 +780,9 @@ int YaguchiGr91FlowRule::dy_ds(const double* const s, const double* const alpha,
     std::fill(dyv, dyv+6, 0.0);
   }
 
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dy_da(const double* const s, const double* const alpha, double T,
+void YaguchiGr91FlowRule::dy_da(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   std::fill(dyv, dyv+nhist(), 0.0);
@@ -863,12 +831,11 @@ int YaguchiGr91FlowRule::dy_da(const double* const s, const double* const alpha,
   }
   
 
-  return 0;
 
 }
 
 // Flow rule
-int YaguchiGr91FlowRule::g(const double * const s, const double * const alpha, double T,
+void YaguchiGr91FlowRule::g(const double * const s, const double * const alpha, double T,
               double * const gv) const
 {
   std::fill(gv, gv+6, 0.0);
@@ -889,10 +856,9 @@ int YaguchiGr91FlowRule::g(const double * const s, const double * const alpha, d
     }
   }
 
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dg_ds(const double * const s, const double * const alpha, double T,
+void YaguchiGr91FlowRule::dg_ds(const double * const s, const double * const alpha, double T,
               double * const dgv) const
 {
   std::fill(dgv, dgv+36, 0.0);
@@ -931,10 +897,9 @@ int YaguchiGr91FlowRule::dg_ds(const double * const s, const double * const alph
     dgv[i] *= 3.0/(2.0 * j2);
   }
 
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dg_da(const double * const s, const double * const alpha, double T,
+void YaguchiGr91FlowRule::dg_da(const double * const s, const double * const alpha, double T,
              double * const dgv) const
 {
   // Only the X terms have derivatives
@@ -953,11 +918,10 @@ int YaguchiGr91FlowRule::dg_da(const double * const s, const double * const alph
     }
   }
 
-  return 0;
 }
 
 // Hardening rule
-int YaguchiGr91FlowRule::h(const double * const s, const double * const alpha, double T,
+void YaguchiGr91FlowRule::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   std::fill(hv, hv+nhist(), 0.0);
@@ -1024,10 +988,9 @@ int YaguchiGr91FlowRule::h(const double * const s, const double * const alpha, d
     hv[13] = 0.0;
   }
 
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dh_ds(const double * const s, const double * const alpha, double T,
+void YaguchiGr91FlowRule::dh_ds(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   // Only the X terms have derivatives
@@ -1074,10 +1037,9 @@ int YaguchiGr91FlowRule::dh_ds(const double * const s, const double * const alph
     }
   }
 
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dh_da(const double * const s, const double * const alpha, double T,
+void YaguchiGr91FlowRule::dh_da(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   // Fair number of cross-terms are zero
@@ -1164,11 +1126,10 @@ int YaguchiGr91FlowRule::dh_da(const double * const s, const double * const alph
     dhv[CINDEX(13,13,nh)] += -bi;
   }
 
-  return 0;
 }
 
 // Hardening rule wrt to time
-int YaguchiGr91FlowRule::h_time(const double * const s, 
+void YaguchiGr91FlowRule::h_time(const double * const s, 
                                 const double * const alpha, double T,
                                 double * const hv) const
 {
@@ -1190,19 +1151,17 @@ int YaguchiGr91FlowRule::h_time(const double * const s,
     hv[i+6] = -g2i * pow(J2, mi-1.0) * alpha[i+6];
   }
 
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dh_ds_time(const double * const s, 
+void YaguchiGr91FlowRule::dh_ds_time(const double * const s, 
                                     const double * const alpha, double T,
                                     double * const dhv) const
 {
   // This is actually still zero
   std::fill(dhv, dhv+(nhist()*6), 0.0);
-  return 0;
 }
 
-int YaguchiGr91FlowRule::dh_da_time(const double * const s, 
+void YaguchiGr91FlowRule::dh_da_time(const double * const s, 
                                     const double * const alpha, double T,
                                     double * const dhv) const
 {
@@ -1259,8 +1218,6 @@ int YaguchiGr91FlowRule::dh_da_time(const double * const s,
       dhv[CINDEX((i+6),(j+6),nh)] = -g2i * dX2[CINDEX(i,j,6)];
     }
   }
-
-  return 0;
 }
 
 

--- a/src/visco_flow.cxx
+++ b/src/visco_flow.cxx
@@ -223,12 +223,10 @@ int PerzynaFlowRule::y(const double* const s, const double* const alpha, double 
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   double fv;
-  ier = surface_->f(s, q, T, fv);
-  if (ier != SUCCESS) return ier;
+  surface_->f(s, q, T, fv);
 
   if (fv > 0.0) {
     yv = g_->g(fabs(fv), T);
@@ -245,19 +243,16 @@ int PerzynaFlowRule::dy_ds(const double* const s, const double* const alpha, dou
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   double fv;
-  ier = surface_->f(s, q, T, fv);
-  if (ier != SUCCESS) return ier;
+  surface_->f(s, q, T, fv);
 
   std::fill(dyv, dyv + 6, 0.0);
 
   if (fv > 0.0) {
     double dgv = g_->dg(fabs(fv), T);
-    int ier = surface_->df_ds(s, q, T, dyv);
-    if (ier != SUCCESS) return ier;
+    surface_->df_ds(s, q, T, dyv);
     for (int i=0; i<6; i++) {
       dyv[i] *= dgv;
     }
@@ -271,12 +266,10 @@ int PerzynaFlowRule::dy_da(const double* const s, const double* const alpha, dou
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   double fv;
-  ier = surface_->f(s, q, T, fv);
-  if (ier != SUCCESS) return ier;
+  surface_->f(s, q, T, fv);
 
   std::fill(dyv, dyv + nhist(), 0.0);
 
@@ -285,16 +278,13 @@ int PerzynaFlowRule::dy_da(const double* const s, const double* const alpha, dou
     
     std::vector<double> jacv(nhist()*nhist());
     double * jac = &jacv[0];
-    ier = hardening_->dq_da(alpha, T, jac);
-    if (ier != SUCCESS) return ier;
+    hardening_->dq_da(alpha, T, jac);
     
     std::vector<double> rdv(nhist());
     double * rd = &rdv[0];
-    ier = surface_->df_dq(s, q, T, rd);
-    if (ier != SUCCESS) return ier;
+    surface_->df_dq(s, q, T, rd);
 
-    ier = mat_vec_trans(jac, nhist(), rd, nhist(), dyv);
-    if (ier != SUCCESS) return ier;
+    mat_vec_trans(jac, nhist(), rd, nhist(), dyv);
 
     for (size_t i=0; i<nhist(); i++) {
       dyv[i] *= dgv;
@@ -311,8 +301,7 @@ int PerzynaFlowRule::g(const double * const s, const double * const alpha, doubl
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_ds(s, q, T, gv);
 }
@@ -322,8 +311,7 @@ int PerzynaFlowRule::dg_ds(const double * const s, const double * const alpha, d
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dsds(s, q, T, dgv);
 }
@@ -333,18 +321,15 @@ int PerzynaFlowRule::dg_da(const double * const s, const double * const alpha, d
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   std::vector<double> jacv(nhist() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
   
   std::vector<double> ddv(6*nhist());
   double * dd = &ddv[0];
-  ier = surface_->df_dsdq(s, q, T, dd);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dsdq(s, q, T, dd);
 
   return mat_mat(6, nhist(), nhist(), dd, jac, dgv);
 }
@@ -355,8 +340,7 @@ int PerzynaFlowRule::h(const double * const s, const double * const alpha, doubl
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dq(s, q, T, hv);
 }
@@ -366,8 +350,7 @@ int PerzynaFlowRule::dh_ds(const double * const s, const double * const alpha, d
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dqds(s, q, T, dhv);
 }
@@ -377,18 +360,15 @@ int PerzynaFlowRule::dh_da(const double * const s, const double * const alpha, d
 {
   std::vector<double> qv(nhist());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   std::vector<double> jacv(nhist() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
   
   std::vector<double> ddv(nhist() * nhist());
   double * dd = &ddv[0];
-  ier = surface_->df_dqdq(s, q, T, dd);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dqdq(s, q, T, dd);
 
   return mat_mat(nhist(), nhist(), nhist(), dd, jac, dhv);
 }
@@ -538,12 +518,10 @@ int ChabocheFlowRule::y(const double* const s, const double* const alpha, double
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   double fv;
-  ier = surface_->f(s, q, T, fv);
-  if (ier != SUCCESS) return ier;
+  surface_->f(s, q, T, fv);
 
   if (fv > 0.0) {
     double eta = sqrt(2.0 / 3.0) * fluidity_->eta(alpha[0], T);
@@ -560,19 +538,15 @@ int ChabocheFlowRule::dy_ds(const double* const s, const double* const alpha, do
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
  
   double fv;
-  ier = surface_->f(s, q, T, fv);
-  if (ier != SUCCESS) return ier;
+  surface_->f(s, q, T, fv);
   
   std::fill(dyv, dyv+6, 0.0);
 
   if (fv > 0.0) {
-    ier = surface_->df_ds(s, q, T, dyv);
-    if (ier != SUCCESS)
-      return ier;
+    surface_->df_ds(s, q, T, dyv);
     double eta = sqrt(2.0 / 3.0) * fluidity_->eta(alpha[0], T);
     double mv = sqrt(3.0 / 2.0) * pow(fv / eta, n_->value(T) - 1.0) *
                 n_->value(T) / eta * prefactor_->value(T);
@@ -588,28 +562,23 @@ int ChabocheFlowRule::dy_da(const double* const s, const double* const alpha, do
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   double fv;
-  ier = surface_->f(s, q, T, fv);
-  if (ier != SUCCESS) return ier;
+  surface_->f(s, q, T, fv);
 
   std::fill(dyv, dyv + nhist(), 0.0);
 
   if (fv > 0.0) {
     std::vector<double> jacv(hardening_->ninter() * nhist());
     double * jac = &jacv[0];
-    ier = hardening_->dq_da(alpha, T, jac);
-    if (ier != SUCCESS) return ier;
+    hardening_->dq_da(alpha, T, jac);
     
     std::vector<double> dqv(hardening_->ninter());
     double * dq = &dqv[0];
-    ier = surface_->df_dq(s, q, T, dq);
-    if (ier != SUCCESS) return ier;
+    surface_->df_dq(s, q, T, dq);
 
-    ier = mat_vec_trans(jac, nhist(), dq, hardening_->ninter(), dyv);
-    if (ier != SUCCESS) return ier;
+    mat_vec_trans(jac, nhist(), dq, hardening_->ninter(), dyv);
 
     double eta = sqrt(2.0/3.0) * fluidity_->eta(alpha[0], T);
     double mv = sqrt(3.0 / 2.0) * pow(fv / eta, n_->value(T) - 1.0) *
@@ -634,8 +603,7 @@ int ChabocheFlowRule::g(const double * const s, const double * const alpha, doub
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_ds(s, q, T, gv);
 }
@@ -645,8 +613,7 @@ int ChabocheFlowRule::dg_ds(const double * const s, const double * const alpha, 
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
 
   return surface_->df_dsds(s, q, T, dgv);
 }
@@ -656,18 +623,15 @@ int ChabocheFlowRule::dg_da(const double * const s, const double * const alpha, 
 {
   std::vector<double> qv(hardening_->ninter());
   double * q = &qv[0];
-  int ier = hardening_->q(alpha, T, q);
-  if (ier != SUCCESS) return ier;
+  hardening_->q(alpha, T, q);
   
   std::vector<double> jacv(hardening_->ninter() * nhist());
   double * jac = &jacv[0];
-  ier = hardening_->dq_da(alpha, T, jac);
-  if (ier != SUCCESS) return ier;
+  hardening_->dq_da(alpha, T, jac);
   
   std::vector<double> ddv(6 * hardening_->ninter());
   double * dd = &ddv[0];
-  ier = surface_->df_dsdq(s, q, T, dd);
-  if (ier != SUCCESS) return ier;
+  surface_->df_dsdq(s, q, T, dd);
 
   return mat_mat(6, nhist(), hardening_->ninter(), dd, jac, dgv);
 }

--- a/src/visco_flow_wrap.cxx
+++ b/src/visco_flow_wrap.cxx
@@ -20,8 +20,7 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m) -> py::array_t<double>
            {
             auto h = alloc_vec<double>(m.nhist());
-            int ier = m.init_hist(arr2ptr<double>(h));
-            py_error(ier);
+            m.init_hist(arr2ptr<double>(h));
             return h;
            }, "Initialize history variables.")
 
@@ -29,24 +28,21 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> double
            {
             double fv;
-            int ier = m.y(arr2ptr<double>(s), arr2ptr<double>(alpha), T, fv);
-            py_error(ier);
+            m.y(arr2ptr<double>(s), arr2ptr<double>(alpha), T, fv);
             return fv;
            }, "Plastic multiplier value.")
       .def("dy_ds",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.dy_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dy_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Plastic multiplier derivative with respect to stress.")
       .def("dy_da",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.dy_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dy_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Plastic multiplier derivative with respect to history.")
 
@@ -54,24 +50,21 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.g(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.g(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule, rate part.")
       .def("dg_ds",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,6);
-            int ier = m.dg_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule (rate) derivative with respect to stress.")
       .def("dg_da",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,m.nhist());
-            int ier = m.dg_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule (rate) derivative with respect to history.")
 
@@ -79,24 +72,21 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.g_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.g_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule, time part.")
       .def("dg_ds_time",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,6);
-            int ier = m.dg_ds_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_ds_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule (time) derivative with respect to stress.")
       .def("dg_da_time",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,m.nhist());
-            int ier = m.dg_da_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_da_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule (time) derivative with respect to history.")
 
@@ -104,24 +94,21 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.g_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.g_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule, temperature part.")
       .def("dg_ds_temp",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,6);
-            int ier = m.dg_ds_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_ds_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule (temperature) derivative with respect to stress.")
       .def("dg_da_temp",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(6,m.nhist());
-            int ier = m.dg_da_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dg_da_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Flow rule (temperature) derivative with respect to history.")
 
@@ -129,24 +116,21 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.h(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.h(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule.")
       .def("dh_ds",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.dh_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule derivative with respect to stress.")
       .def("dh_da",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.dh_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_da(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule derivative with respect to history.")
 
@@ -154,24 +138,21 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.h_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.h_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule, time part.")
       .def("dh_ds_time",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.dh_ds_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_ds_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (time) derivative with respect to stress.")
       .def("dh_da_time",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.dh_da_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_da_time(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (time) derivative with respect to history.")
 
@@ -179,24 +160,21 @@ PYBIND11_MODULE(visco_flow, m) {
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(m.nhist());
-            int ier = m.h_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.h_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule, temperature part.")
       .def("dh_ds_temp",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),6);
-            int ier = m.dh_ds_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_ds_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (temperature) derivative with respect to stress.")
       .def("dh_da_temp",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
             auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            int ier = m.dh_da_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dh_da_temp(arr2ptr<double>(s), arr2ptr<double>(alpha), T, arr2ptr<double>(f));
             return f;
            }, "Hardening rule (temperature) derivative with respect to history.")
 

--- a/src/walker.cxx
+++ b/src/walker.cxx
@@ -55,14 +55,11 @@ int WalkerKremplSwitchRule::s(const double * const s, const double * const alpha
 
   double temp[6];
   double yv;
-  int ier = flow_->g(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
-  ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  flow_->g(s, alpha, T, temp);
+  flow_->y(s, alpha, T, yv);
   
   double kap;
-  ier = kappa(edot, T, kap);
-  if (ier != SUCCESS) return ier;
+  kappa(edot, T, kap);
 
   for (int i=0; i<6; i++) {
     erate[i] -= yv * kap * temp[i];
@@ -83,26 +80,21 @@ int WalkerKremplSwitchRule::ds_ds(const double * const s, const double * const a
               double * const d_sdot)
 {
   double yv;
-  int ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  flow_->y(s, alpha, T, yv);
 
   double kap;
-  ier = kappa(edot, T, kap);
-  if (ier != SUCCESS) return ier;
+  kappa(edot, T, kap);
 
   double work[36];
-  ier = flow_->dg_ds(s, alpha, T, work);
-  if (ier != SUCCESS) return ier;
+  flow_->dg_ds(s, alpha, T, work);
   for (int i=0; i<36; i++) {
     work[i] *= -yv * kap;
   }
 
   double t1[6];
-  ier = flow_->g(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  flow_->g(s, alpha, T, t1);
   double t2[6];
-  ier = flow_->dy_ds(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  flow_->dy_ds(s, alpha, T, t2);
   for (size_t i = 0; i < 6;  i++) t2[i] *= kap;
   outer_update_minus(t1, 6, t2, 6, work);
   
@@ -120,30 +112,25 @@ int WalkerKremplSwitchRule::ds_da(const double * const s, const double * const a
               double * const d_sdot)
 {
   double yv;
-  int ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  flow_->y(s, alpha, T, yv);
  
   double kap;
-  ier = kappa(edot, T, kap);
-  if (ier != SUCCESS) return ier;
+  kappa(edot, T, kap);
 
   int sz = 6 * nhist();
   
   std::vector<double> workv(sz);
   double * work = &workv[0];
-  ier = flow_->dg_da(s, alpha, T, work);
-  if (ier != SUCCESS) return ier;
+  flow_->dg_da(s, alpha, T, work);
   for (int i=0; i<sz; i++) {
     work[i] *= -yv * kap;
   }
 
   double t1[6];
-  ier = flow_->g(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  flow_->g(s, alpha, T, t1);
   std::vector<double> t2v(nhist());
   double * t2 = &t2v[0];
-  ier = flow_->dy_da(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  flow_->dy_da(s, alpha, T, t2);
   for (size_t i = 0; i < nhist(); i++) t2[i] *= kap;
   outer_update_minus(t1, 6, t2, nhist(), work);
   
@@ -164,16 +151,13 @@ int WalkerKremplSwitchRule::ds_de(const double * const s, const double * const a
   double work[36];
   
   double yv;
-  int ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  flow_->y(s, alpha, T, yv);
  
   double dkap[6];
-  ier = dkappa(edot, T, dkap);
-  if (ier != SUCCESS) return ier;
+  dkappa(edot, T, dkap);
 
   double g[6];
-  ier = flow_->g(s, alpha, T, g);
-  if (ier != SUCCESS) return ier;
+  flow_->g(s, alpha, T, g);
 
   for (size_t i = 0; i < 6; i++) g[i] *= yv;
 
@@ -182,8 +166,7 @@ int WalkerKremplSwitchRule::ds_de(const double * const s, const double * const a
   outer_update_minus(g, 6, dkap, 6, work);
 
   double C[36];
-  ier = elastic_->C(T, C);
-  if (ier != SUCCESS) return ier;
+  elastic_->C(T, C);
 
   mat_mat(6, 6, 6, C, work, d_sdot);
 
@@ -196,25 +179,20 @@ int WalkerKremplSwitchRule::a(const double * const s, const double * const alpha
               double * const adot)
 {
   double dg;
-  int ier = flow_->y(s, alpha, T, dg);
-  if (ier != SUCCESS) return 0;
+  flow_->y(s, alpha, T, dg);
 
   double kap;
-  ier = kappa(edot, T, kap);
-  if (ier != SUCCESS) return ier;
+  kappa(edot, T, kap);
 
-  ier = flow_->h(s, alpha, T, adot);
-  if (ier != SUCCESS) return 0;
+  flow_->h(s, alpha, T, adot);
   for (size_t i=0; i<nhist(); i++) adot[i] *= (dg * kap);
   
   std::vector<double> tempv(nhist());
   double * temp = &tempv[0];
-  ier = flow_->h_temp(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  flow_->h_temp(s, alpha, T, temp);
   for (size_t i=0; i<nhist(); i++) adot[i] += temp[i] * Tdot;
 
-  ier = flow_->h_time(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  flow_->h_time(s, alpha, T, temp);
   for (size_t i=0; i<nhist(); i++) adot[i] += (temp[i] * kap);
 
   return 0;
@@ -227,39 +205,32 @@ int WalkerKremplSwitchRule::da_ds(const double * const s, const double * const a
               double * const d_adot)
 {
   double dg;
-  int ier = flow_->y(s, alpha, T, dg);
-  if (ier != SUCCESS) return ier;
+  flow_->y(s, alpha, T, dg);
 
   double kap;
-  ier = kappa(edot, T, kap);
-  if (ier != SUCCESS) return ier;
+  kappa(edot, T, kap);
 
   int sz = nhist() * 6;
 
-  ier = flow_->dh_ds(s, alpha, T, d_adot);
-  if (ier != SUCCESS) return ier;
+  flow_->dh_ds(s, alpha, T, d_adot);
   for (int i=0; i<sz; i++) d_adot[i] *= (dg * kap);
 
   std::vector<double> t1v(nhist());
   double * t1 = &t1v[0];
-  ier = flow_->h(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  flow_->h(s, alpha, T, t1);
 
   double t2[6];
-  ier = flow_->dy_ds(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  flow_->dy_ds(s, alpha, T, t2);
   for (size_t i = 0; i < 6; i++) t2[i] *= kap;
 
   outer_update(t1, nhist(), t2, 6, d_adot);
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
-  ier = flow_->dh_ds_temp(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  flow_->dh_ds_temp(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * Tdot;
 
-  ier = flow_->dh_ds_time(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  flow_->dh_ds_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * kap;
 
   return 0;
@@ -272,29 +243,24 @@ int WalkerKremplSwitchRule::da_da(const double * const s, const double * const a
               double * const d_adot)
 {
   double dg;
-  int ier = flow_->y(s, alpha, T, dg);
-  if (ier != SUCCESS) return ier;
+  flow_->y(s, alpha, T, dg);
 
   double kap;
-  ier = kappa(edot, T, kap);
-  if (ier != SUCCESS) return ier;
+  kappa(edot, T, kap);
 
   int nh = nhist();
   int sz = nh * nh;
 
-  ier = flow_->dh_da(s, alpha, T, d_adot);
-  if (ier != SUCCESS) return ier;
+  flow_->dh_da(s, alpha, T, d_adot);
   for (int i=0; i<sz; i++) d_adot[i] *= dg * kap;
   
   std::vector<double> t1v(nh);
   double * t1 = &t1v[0];
-  ier = flow_->h(s, alpha, T, t1);
-  if (ier != SUCCESS) return ier;
+  flow_->h(s, alpha, T, t1);
   
   std::vector<double> t2v(nh);
   double * t2 = &t2v[0];
-  ier = flow_->dy_da(s, alpha, T, t2);
-  if (ier != SUCCESS) return ier;
+  flow_->dy_da(s, alpha, T, t2);
 
   for (int i = 0 ; i < nh; i++) t2[i] *= kap;
 
@@ -302,12 +268,10 @@ int WalkerKremplSwitchRule::da_da(const double * const s, const double * const a
   
   std::vector<double> t3v(sz);
   double * t3 = &t3v[0];
-  ier = flow_->dh_da_temp(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  flow_->dh_da_temp(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * Tdot;
 
-  ier = flow_->dh_da_time(s, alpha, T, t3);
-  if (ier != SUCCESS) return ier;
+  flow_->dh_da_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * kap;
 
   return 0;
@@ -319,23 +283,19 @@ int WalkerKremplSwitchRule::da_de(const double * const s, const double * const a
               double * const d_adot)
 {
   double dg;
-  int ier = flow_->y(s, alpha, T, dg);
-  if (ier != SUCCESS) return ier;
+  flow_->y(s, alpha, T, dg);
 
   double dkap[6];
-  ier = dkappa(edot, T, dkap);
-  if (ier != SUCCESS) return ier;
+  dkappa(edot, T, dkap);
 
   int nh = nhist();
   double * hr = new double [nh];
-  ier = flow_->h(s, alpha, T, hr);
-  if (ier != SUCCESS) return 0;
+  flow_->h(s, alpha, T, hr);
   for (int i = 0; i < nh; i++) hr[i] *= dg;
 
   outer_vec(hr, nh, dkap, 6, d_adot);
 
-  ier = flow_->h_time(s, alpha, T, hr);
-  if (ier != SUCCESS) return 0;
+  flow_->h_time(s, alpha, T, hr);
   outer_update(hr, nh, dkap, 6, d_adot);
 
   delete [] hr;
@@ -352,28 +312,23 @@ int WalkerKremplSwitchRule::work_rate(const double * const s,
   std::fill(erate, erate+6, 0.0);
 
   double kap;
-  int ier = kappa(edot, T, kap);
-  if (ier != SUCCESS) return ier;
+  kappa(edot, T, kap);
 
   double temp[6];
   double yv;
-  ier = flow_->g(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
-  ier = flow_->y(s, alpha, T, yv);
-  if (ier != SUCCESS) return ier;
+  flow_->g(s, alpha, T, temp);
+  flow_->y(s, alpha, T, yv);
 
   for (int i=0; i<6; i++) {
     erate[i] += yv * kap * temp[i];
   }
 
-  ier = flow_->g_temp(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  flow_->g_temp(s, alpha, T, temp);
   for (int i=0; i<6; i++) {
     erate[i] += Tdot * temp[i];
   }
 
-  ier = flow_->g_time(s, alpha, T, temp);
-  if (ier != SUCCESS) return ier;
+  flow_->g_time(s, alpha, T, temp);
   for (int i=0; i<6; i++) {
     erate[i] += temp[i];
   }

--- a/src/walker.cxx
+++ b/src/walker.cxx
@@ -40,12 +40,12 @@ size_t WalkerKremplSwitchRule::nhist() const
   return flow_->nhist();
 }
 
-int WalkerKremplSwitchRule::init_hist(double * const h)
+void WalkerKremplSwitchRule::init_hist(double * const h)
 {
   return flow_->init_hist(h);
 }
 
-int WalkerKremplSwitchRule::s(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::s(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const sdot)
@@ -69,12 +69,9 @@ int WalkerKremplSwitchRule::s(const double * const s, const double * const alpha
   elastic_->C(T, C);
 
   mat_vec(C, 6, erate, 6, sdot);
-
-  return 0;
-
 }
 
-int WalkerKremplSwitchRule::ds_ds(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::ds_ds(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_sdot)
@@ -102,11 +99,9 @@ int WalkerKremplSwitchRule::ds_ds(const double * const s, const double * const a
   elastic_->C(T, t3);
 
   mat_mat(6,6,6, t3, work, d_sdot);
-
-  return 0;
 }
 
-int WalkerKremplSwitchRule::ds_da(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::ds_da(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_sdot)
@@ -138,12 +133,9 @@ int WalkerKremplSwitchRule::ds_da(const double * const s, const double * const a
   elastic_->C(T, C);
 
   mat_mat(6, nhist(), 6, C, work, d_sdot);
-
-  return 0;
-
 }
 
-int WalkerKremplSwitchRule::ds_de(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::ds_de(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_sdot)
@@ -169,11 +161,9 @@ int WalkerKremplSwitchRule::ds_de(const double * const s, const double * const a
   elastic_->C(T, C);
 
   mat_mat(6, 6, 6, C, work, d_sdot);
-
-  return 0;
 }
 
-int WalkerKremplSwitchRule::a(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::a(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const adot)
@@ -194,12 +184,9 @@ int WalkerKremplSwitchRule::a(const double * const s, const double * const alpha
 
   flow_->h_time(s, alpha, T, temp);
   for (size_t i=0; i<nhist(); i++) adot[i] += (temp[i] * kap);
-
-  return 0;
-
 }
 
-int WalkerKremplSwitchRule::da_ds(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::da_ds(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_adot)
@@ -232,12 +219,9 @@ int WalkerKremplSwitchRule::da_ds(const double * const s, const double * const a
 
   flow_->dh_ds_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * kap;
-
-  return 0;
-  
 }
 
-int WalkerKremplSwitchRule::da_da(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::da_da(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_adot)
@@ -273,11 +257,9 @@ int WalkerKremplSwitchRule::da_da(const double * const s, const double * const a
 
   flow_->dh_da_time(s, alpha, T, t3);
   for (int i=0; i<sz; i++) d_adot[i] += t3[i] * kap;
-
-  return 0;
 }
 
-int WalkerKremplSwitchRule::da_de(const double * const s, const double * const alpha,
+void WalkerKremplSwitchRule::da_de(const double * const s, const double * const alpha,
               const double * const edot, double T,
               double Tdot,
               double * const d_adot)
@@ -299,11 +281,9 @@ int WalkerKremplSwitchRule::da_de(const double * const s, const double * const a
   outer_update(hr, nh, dkap, 6, d_adot);
 
   delete [] hr;
-
-  return 0;
 }
 
-int WalkerKremplSwitchRule::work_rate(const double * const s,
+void WalkerKremplSwitchRule::work_rate(const double * const s,
                                     const double * const alpha,
                                     const double * const edot, double T,
                                     double Tdot, double & p_dot)
@@ -334,27 +314,22 @@ int WalkerKremplSwitchRule::work_rate(const double * const s,
   }
 
   p_dot = dot_vec(s, erate, 6);
-  
-  return 0;
 }
 
-int WalkerKremplSwitchRule::elastic_strains(const double * const s_np1, double T_np1,
+void WalkerKremplSwitchRule::elastic_strains(const double * const s_np1, double T_np1,
                                  double * const e_np1) const
 {
   double S[36];
   elastic_->S(T_np1, S);
   mat_vec(S, 6, s_np1, 6, e_np1);
-
-  return 0;
 }
 
-int WalkerKremplSwitchRule::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
+void WalkerKremplSwitchRule::set_elastic_model(std::shared_ptr<LinearElasticModel> emodel)
 {
   elastic_ = emodel;
-  return 0;
 }
 
-int WalkerKremplSwitchRule::kappa(const double * const edot, double T, double &
+void WalkerKremplSwitchRule::kappa(const double * const edot, double T, double &
                                   kap)
 {
   double edev[6];
@@ -364,11 +339,9 @@ int WalkerKremplSwitchRule::kappa(const double * const edot, double T, double &
   double de = std::sqrt(2.0/3.0) * norm2_vec(edev, 6);
 
   kap = 1.0 - lambda_->value(T) + lambda_->value(T) * de / eps0_;
-
-  return 0;
 }
 
-int WalkerKremplSwitchRule::dkappa(const double * const edot, double T,
+void WalkerKremplSwitchRule::dkappa(const double * const edot, double T,
                                    double * const dkap)
 {
   std::copy(edot, edot+6, dkap);
@@ -377,15 +350,13 @@ int WalkerKremplSwitchRule::dkappa(const double * const edot, double T,
   if (norm2_vec(dkap, 6) == 0.0) {
     for (size_t i = 0; i < 6; i++)
       dkap[i] = 0.0;
-    return 0;
+    return;
   }
 
   double fact = lambda_->value(T)  / eps0_ * std::sqrt(2.0/3.0) / norm2_vec(dkap, 6);
 
   for (size_t i = 0; i < 6; i++)
     dkap[i] *= fact;
-
-  return 0;
 }
 
 void WalkerKremplSwitchRule::override_guess(double * const x)
@@ -1563,59 +1534,53 @@ size_t WrappedViscoPlasticFlowRule::nhist() const
   return blank_hist_().size();
 }
 
-int WrappedViscoPlasticFlowRule::init_hist(double * const h) const
+void WrappedViscoPlasticFlowRule::init_hist(double * const h) const
 {
   // Pointless memory error
   std::fill(h, h+nhist(), 0.0);
   // Actual stuff
   History hv = gather_hist_(h);
   initialize_hist(hv);
-  return 0;
 }
 
 // Rate rule
-int WrappedViscoPlasticFlowRule::y(const double* const s, const double* const alpha, double T,
+void WrappedViscoPlasticFlowRule::y(const double* const s, const double* const alpha, double T,
               double & yv) const
 {
   y(make_state_(s, alpha, T), yv);
-  return 0;
 }
 
-int WrappedViscoPlasticFlowRule::dy_ds(const double* const s, const double* const alpha, double T,
+void WrappedViscoPlasticFlowRule::dy_ds(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   Symmetric res(dyv);
   dy_ds(make_state_(s, alpha, T), res);
-  return 0;
 }
 
-int WrappedViscoPlasticFlowRule::dy_da(const double* const s, const double* const alpha, double T,
+void WrappedViscoPlasticFlowRule::dy_da(const double* const s, const double* const alpha, double T,
               double * const dyv) const
 {
   // This is transposed, but that doesn't matter as it's flat
   History res = gather_derivative_<double>(dyv);
   dy_da(make_state_(s, alpha, T), res);
-  return 0;
 }
 
 // Flow rule
-int WrappedViscoPlasticFlowRule::g(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::g(const double * const s, const double * const alpha, double T,
               double * const gv) const
 {
   Symmetric res(gv);
   g(make_state_(s, alpha, T), res);
-  return 0;
 }
 
-int WrappedViscoPlasticFlowRule::dg_ds(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dg_ds(const double * const s, const double * const alpha, double T,
               double * const dgv) const
 {
   SymSymR4 res(dgv);
   dg_ds(make_state_(s, alpha, T), res);
-  return 0;
 }
 
-int WrappedViscoPlasticFlowRule::dg_da(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dg_da(const double * const s, const double * const alpha, double T,
              double * const dgv) const
 {
   // This is transposed and it does matter
@@ -1627,28 +1592,24 @@ int WrappedViscoPlasticFlowRule::dg_da(const double * const s, const double * co
     for (size_t j = 0; j < 6; j++)
       dgv[CINDEX(j,i,nhist())] = temp[CINDEX(i,j,6)];
   delete [] temp;
-
-  return 0;
 }
 
 // Hardening rule
-int WrappedViscoPlasticFlowRule::h(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::h(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   History res = gather_hist_(hv);
   h(make_state_(s, alpha, T), res);
-  return 0;
 }
 
-int WrappedViscoPlasticFlowRule::dh_ds(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dh_ds(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   History res = gather_derivative_<Symmetric>(dhv);
   dh_ds(make_state_(s, alpha, T), res);
-  return 0;
 }
 
-int WrappedViscoPlasticFlowRule::dh_da(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dh_da(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   // Very messed up
@@ -1660,16 +1621,14 @@ int WrappedViscoPlasticFlowRule::dh_da(const double * const s, const double * co
   res.unravel_hh(blank_hist_(), dhv);
 
   delete [] temp;
-  return 0;
 }
 
 // Hardening rule wrt time
-int WrappedViscoPlasticFlowRule::h_time(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::h_time(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   History res = gather_hist_(hv);
   h_time(make_state_(s, alpha, T), res);
-  return 0;
 }
 
 void WrappedViscoPlasticFlowRule::h_time(const State & state, History & res) const
@@ -1677,12 +1636,11 @@ void WrappedViscoPlasticFlowRule::h_time(const State & state, History & res) con
   res.zero();
 }
 
-int WrappedViscoPlasticFlowRule::dh_ds_time(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dh_ds_time(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   History res = gather_derivative_<Symmetric>(dhv);
   dh_ds_time(make_state_(s, alpha, T), res);
-  return 0;
 }
 
 void WrappedViscoPlasticFlowRule::dh_ds_time(const State & state, History & res) const
@@ -1690,7 +1648,7 @@ void WrappedViscoPlasticFlowRule::dh_ds_time(const State & state, History & res)
   res.zero();
 }
 
-int WrappedViscoPlasticFlowRule::dh_da_time(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dh_da_time(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   // Very messed up
@@ -1702,7 +1660,6 @@ int WrappedViscoPlasticFlowRule::dh_da_time(const double * const s, const double
   res.unravel_hh(blank_hist_(), dhv);
 
   delete [] temp;
-  return 0;
 }
 
 void WrappedViscoPlasticFlowRule::dh_da_time(const State & state, History & res) const
@@ -1711,12 +1668,11 @@ void WrappedViscoPlasticFlowRule::dh_da_time(const State & state, History & res)
 }
 
 // Hardening rule wrt temperature
-int WrappedViscoPlasticFlowRule::h_temp(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::h_temp(const double * const s, const double * const alpha, double T,
               double * const hv) const
 {
   History res = gather_hist_(hv);
   h_temp(make_state_(s, alpha, T), res);
-  return 0;
 }
 
 void WrappedViscoPlasticFlowRule::h_temp(const State & state, History & res) const
@@ -1724,12 +1680,11 @@ void WrappedViscoPlasticFlowRule::h_temp(const State & state, History & res) con
   res.zero();
 }
 
-int WrappedViscoPlasticFlowRule::dh_ds_temp(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dh_ds_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   History res = gather_derivative_<Symmetric>(dhv);
   dh_ds_temp(make_state_(s, alpha, T), res);
-  return 0;
 }
 
 void WrappedViscoPlasticFlowRule::dh_ds_temp(const State & state, History & res) const
@@ -1737,12 +1692,11 @@ void WrappedViscoPlasticFlowRule::dh_ds_temp(const State & state, History & res)
   res.zero();
 }
 
-int WrappedViscoPlasticFlowRule::dh_da_temp(const double * const s, const double * const alpha, double T,
+void WrappedViscoPlasticFlowRule::dh_da_temp(const double * const s, const double * const alpha, double T,
               double * const dhv) const
 {
   History res = gather_derivative_<History>(dhv);
   dh_da_temp(make_state_(s, alpha, T), res);
-  return 0;
 }
 
 void WrappedViscoPlasticFlowRule::dh_da_temp(const State & state, History & res) const

--- a/src/walker_wrap.cxx
+++ b/src/walker_wrap.cxx
@@ -31,8 +31,7 @@ PYBIND11_MODULE(walker, m) {
               py::array::c_style> eps, double T) -> double
            {
              double res;
-             int ier = m.kappa(arr2ptr<double>(eps), T, res);
-             py_error(ier);
+             m.kappa(arr2ptr<double>(eps), T, res);
              return res;
            }, "Rate sliding function")
       .def("dkappa",
@@ -40,8 +39,7 @@ PYBIND11_MODULE(walker, m) {
               py::array::c_style> eps, double T) -> py::array_t<double>
            {
             auto f = alloc_vec<double>(6);
-            int ier = m.dkappa(arr2ptr<double>(eps), T, arr2ptr<double>(f));
-            py_error(ier);
+            m.dkappa(arr2ptr<double>(eps), T, arr2ptr<double>(f));
             return f;
            }, "Derivative of the kappa function wrt strain rate.")
       ;

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -11,7 +11,7 @@ class TestErrors(unittest.TestCase):
       test = parse.parse_xml(localize("examples.xml"), "test_badobject")
 
   def test_nomodel(self):
-    with self.assertRaises(parse.ModelNotFound):
+    with self.assertRaises(Exception):
       test = parse.parse_xml(localize("examples.xml"), "not_in_file")
 
   def test_malformed(self):

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -11,7 +11,7 @@ class TestErrors(unittest.TestCase):
       test = parse.parse_xml(localize("examples.xml"), "test_badobject")
 
   def test_nomodel(self):
-    with self.assertRaises(RuntimeError):
+    with self.assertRaises(parse.ModelNotFound):
       test = parse.parse_xml(localize("examples.xml"), "not_in_file")
 
   def test_malformed(self):

--- a/util/cxx_interface/cxxsimple.cxx
+++ b/util/cxx_interface/cxxsimple.cxx
@@ -47,25 +47,16 @@ int main(int argc, char** argv)
 
   double estrain[6];
 
-  int ier;
 
   for (int i=0; i<n; i++) {
     t_np1 = (i+1) * t / ((double) n);
     std::fill(e_np1, e_np1+6, 0.0);
     e_np1[0] = (i+1) * e / ((double) n);
 
-    ier = model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
+    model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
                            h_np1, h_n, A_np1, u_np1, u_n, p_np1, p_n);
 
-    if (ier != 0) {
-      throw std::runtime_error("Update went bad");
-    }
-
-    ier = model->elastic_strains(s_np1, T_np1, h_np1, estrain);
-
-    if (ier != 0) {
-      throw std::runtime_error("Elastic strains went bad");
-    }
+    model->elastic_strains(s_np1, T_np1, h_np1, estrain);
 
     std::copy(e_np1, e_np1+6, e_n);
     std::copy(s_np1, s_np1+6, s_n);

--- a/util/string_interface/cxxstring.cxx
+++ b/util/string_interface/cxxstring.cxx
@@ -44,25 +44,15 @@ int main(int argc, char** argv)
 
   double estrain[6];
 
-  int ier;
-
   for (int i=0; i<n; i++) {
     t_np1 = (i+1) * t / ((double) n);
     std::fill(e_np1, e_np1+6, 0.0);
     e_np1[0] = (i+1) * e / ((double) n);
 
-    ier = model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
+    model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
                            h_np1, h_n, A_np1, u_np1, u_n, p_np1, p_n);
 
-    if (ier != 0) {
-      throw std::runtime_error("Update went bad");
-    }
-
-    ier = model->elastic_strains(s_np1, T_np1, h_np1, estrain);
-
-    if (ier != 0) {
-      throw std::runtime_error("Elastic strains went bad");
-    }
+    model->elastic_strains(s_np1, T_np1, h_np1, estrain);
 
     std::copy(e_np1, e_np1+6, e_n);
     std::copy(s_np1, s_np1+6, s_n);


### PR DESCRIPTION
This PR:

- Removes all error codes from NEML
- Replaces error codes with exceptions
- Adds several useful error types
- Makes all NEML errors inherit from a common class (`NEMLError`)