### PR TITLE
Added functionality to damage model

### DIFF
--- a/include/damage.h
+++ b/include/damage.h
@@ -105,6 +105,12 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
                        const double * const s_n, const double * const h_n,
                        double u_n, double p_n,
                        SDTrialState & tss);
+  /// Used to find the damage value from the history
+  virtual double get_damage(const double *const h_np1);
+  /// Used to determine if element should be deleted
+  virtual bool should_del_element(const double *const h_np1);
+  /// Used to determine if this is a damage model
+  virtual bool is_damage_model() const;
 
  protected:
   void tangent_(const double * const e_np1, const double * const e_n,

--- a/include/models.h
+++ b/include/models.h
@@ -69,6 +69,12 @@ class NEML_EXPORT NEMLModel: public NEMLObject {
    virtual void elastic_strains(const double * const s_np1,
                                double T_np1, const double * const h_np1,
                                double * const e_np1) const = 0;
+   /// Used to find the damage value from the history
+   virtual double get_damage(const double *const h_np1);
+   /// Used to determine if element should be deleted
+   virtual bool should_del_element(const double *const h_np1);
+   /// Used to determine if this is a damage model
+   virtual bool is_damage_model() const;
 };
 
 /// Large deformation incremental update model

--- a/src/damage.cxx
+++ b/src/damage.cxx
@@ -298,6 +298,13 @@ void NEMLScalarDamagedModel_sd::ekill_update_(double T_np1,
     u_np1 = u_n;
   }
 }
+double NEMLScalarDamagedModel_sd::get_damage(const double *const h_np1) {
+  return h_np1[0];
+}
+bool NEMLScalarDamagedModel_sd::should_del_element(const double *const h_np1) {
+  return get_damage(h_np1) > dkill_;
+}
+bool NEMLScalarDamagedModel_sd::is_damage_model() const { return true; }
 
 ScalarDamage::ScalarDamage(ParameterSet & params) :
     NEMLObject(params),

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -24,6 +24,9 @@ void NEMLModel::save(std::string file_name, std::string model_name)
   outfile << representation;
   outfile.close();
 }
+double NEMLModel::get_damage(const double *const h_np1) { return 0.0; }
+bool NEMLModel::should_del_element(const double *const h_np1) { return false; }
+bool NEMLModel::is_damage_model() const { return false; }
 
 // NEMLModel_sd implementation
 NEMLModel_sd::NEMLModel_sd(ParameterSet & params) :


### PR DESCRIPTION
These functions will help make it easier to work with the damage models with MOOSE. Including a function to get the damage value from the history array. While we know currently it is the first element in the array, a function to get the damage is useful in case that location changes. 