### PR TITLE
Refactor engineering material models to use History and Tensor objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(NEML_version 1.4.1)
 ### Setup modules ###
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-### Need c++ 11 ###
-set(CMAKE_CXX_STANDARD 11)
+### Need c++ 17 ###
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ### Default to shared libs ###

--- a/include/cp/crystaldamage.h
+++ b/include/cp/crystaldamage.h
@@ -32,9 +32,9 @@ class NEML_EXPORT CrystalDamageModel: public NEMLObject {
   virtual void set_varnames(std::vector<std::string> names);
 
   /// Setup whatever history variables the model requires
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Initialize history
-  virtual void init_history(History & history) const = 0;
+  virtual void init_hist(History & history) const = 0;
 
   /// Returns the current projection operator
   virtual SymSymR4 projection(
@@ -85,7 +85,7 @@ class NEML_EXPORT NilDamageModel: public CrystalDamageModel {
   static ParameterSet parameters();
 
   /// Initialize history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Returns the current projection operator
   virtual SymSymR4 projection(
@@ -136,7 +136,7 @@ class NEML_EXPORT PlanarDamageModel: public CrystalDamageModel {
   static ParameterSet parameters();
 
   /// Initialize history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Returns the current projection operator
   virtual SymSymR4 projection(

--- a/include/cp/crystaldamage.h
+++ b/include/cp/crystaldamage.h
@@ -17,7 +17,7 @@ class SlipPlaneDamage;
 class TransformationFunction;
 
 /// Abstract base class for slip plane damage models
-class NEML_EXPORT CrystalDamageModel: public NEMLObject {
+class NEML_EXPORT CrystalDamageModel: public HistoryNEMLObject {
  public:
   CrystalDamageModel(ParameterSet & params,
                      std::vector<std::string> vars);

--- a/include/cp/hucocks.h
+++ b/include/cp/hucocks.h
@@ -30,9 +30,9 @@ class NEML_EXPORT HuCocksPrecipitationModel: public NEMLObject
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Actual (unscaled) f
   double f(const History & history) const;
@@ -207,9 +207,9 @@ class NEML_EXPORT DislocationSpacingHardening: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -283,9 +283,9 @@ class NEML_EXPORT HuCocksHardening: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,

--- a/include/cp/hucocks.h
+++ b/include/cp/hucocks.h
@@ -12,7 +12,7 @@ namespace neml {
 
 /// Implementation of a single chemistry <-> size model
 //  For details see Hu et al. MSE A, 2020
-class NEML_EXPORT HuCocksPrecipitationModel: public NEMLObject
+class NEML_EXPORT HuCocksPrecipitationModel: public HistoryNEMLObject
 {
  public:
   HuCocksPrecipitationModel(ParameterSet & params);

--- a/include/cp/inelasticity.h
+++ b/include/cp/inelasticity.h
@@ -17,13 +17,9 @@ namespace neml {
 /// A inelastic model supplying D_p and W_p
 //  A complete model for implicit rotations would include the derivatives wrt
 //  the orientation.  Similarly it would include all the w_p derivatives.
-class NEML_EXPORT InelasticModel: public NEMLObject {
+class NEML_EXPORT InelasticModel: public HistoryNEMLObject {
  public:
   InelasticModel(ParameterSet & params);
-  /// Populate a history object with the correct variables
-  virtual void populate_hist(History & history) const = 0;
-  /// Actually initialize the history object with the starting values
-  virtual void init_hist(History & history) const = 0;
 
   /// Helper for external models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T,

--- a/include/cp/inelasticity.h
+++ b/include/cp/inelasticity.h
@@ -21,9 +21,9 @@ class NEML_EXPORT InelasticModel: public NEMLObject {
  public:
   InelasticModel(ParameterSet & params);
   /// Populate a history object with the correct variables
-  virtual void populate_history(History & history) const = 0;
+  virtual void populate_hist(History & history) const = 0;
   /// Actually initialize the history object with the starting values
-  virtual void init_history(History & history) const = 0;
+  virtual void init_hist(History & history) const = 0;
 
   /// Helper for external models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T,
@@ -103,9 +103,9 @@ class NEML_EXPORT NoInelasticity: public InelasticModel {
   static ParameterSet parameters();
 
   /// Add history variables (none needed)
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Define initial history (none)
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Helper for external models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T,
@@ -185,9 +185,9 @@ class NEML_EXPORT AsaroInelasticity: public InelasticModel {
   static ParameterSet parameters();
 
   /// Populate the history, deferred to the SlipRule
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Initialize the history with the starting values, deferred to the SlipRule
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Helper for external models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T,
@@ -277,9 +277,9 @@ class NEML_EXPORT PowerLawInelasticity: public InelasticModel {
   static ParameterSet parameters();
 
   /// Setup history variables (none used in this implementation)
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Initialize the history variables (n/a)
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Helper for external models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T,
@@ -377,9 +377,9 @@ class NEML_EXPORT CombinedInelasticity: public InelasticModel {
                           const History & fixed) const;
 
   /// Setup all history variables
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Initialize history with actual values
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Sum the symmetric parts of the plastic deformation rates
   virtual Symmetric d_p(const Symmetric & stress,

--- a/include/cp/kinematics.h
+++ b/include/cp/kinematics.h
@@ -17,13 +17,9 @@
 namespace neml {
 
 /// Describes the stress, history, and rotation rates
-class NEML_EXPORT KinematicModel: public NEMLObject {
+class NEML_EXPORT KinematicModel: public HistoryNEMLObject {
  public:
   KinematicModel(ParameterSet & params);
-  /// Populate history with the correct variable names and types
-  virtual void populate_hist(History & history) const = 0;
-  /// Initialize history with actual starting values
-  virtual void init_hist(History & history) const = 0;
 
   /// Helper for external models that want a strength
   virtual double strength(const History & history, Lattice & L, double T,

--- a/include/cp/kinematics.h
+++ b/include/cp/kinematics.h
@@ -21,9 +21,9 @@ class NEML_EXPORT KinematicModel: public NEMLObject {
  public:
   KinematicModel(ParameterSet & params);
   /// Populate history with the correct variable names and types
-  virtual void populate_history(History & history) const = 0;
+  virtual void populate_hist(History & history) const = 0;
   /// Initialize history with actual starting values
-  virtual void init_history(History & history) const = 0;
+  virtual void init_hist(History & history) const = 0;
 
   /// Helper for external models that want a strength
   virtual double strength(const History & history, Lattice & L, double T,
@@ -171,9 +171,9 @@ class NEML_EXPORT StandardKinematicModel: public KinematicModel {
   static ParameterSet parameters();
 
   /// Populate a history object with the correct variables
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Initialize the history object with the starting values
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Helper for external models that want a strength
   virtual double strength(const History & history, Lattice & L, double T,
@@ -305,9 +305,9 @@ class NEML_EXPORT DamagedStandardKinematicModel: public StandardKinematicModel {
   static ParameterSet parameters();
 
   /// Populate a history object with the correct variables
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Initialize the history object with the starting values
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Stress rate
   virtual Symmetric stress_rate(

--- a/include/cp/polycrystal.h
+++ b/include/cp/polycrystal.h
@@ -15,9 +15,9 @@ class NEML_EXPORT PolycrystalModel: public NEMLModel_ldi
   PolycrystalModel(ParameterSet & params);
 
   size_t n() const;
-
-  virtual size_t nhist() const;
-  virtual void init_hist(double * const hist) const;
+  
+  virtual void populate_hist(History & hist) const;
+  virtual void init_hist(History & hist) const;
 
   double * history(double * const store, size_t i) const;
   double * stress(double * const store, size_t i) const;
@@ -48,9 +48,6 @@ class NEML_EXPORT TaylorModel: public PolycrystalModel
   static ParameterSet parameters();
   /// Setup from a ParameterSet
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
-
-  virtual size_t nstore() const;
-  virtual void init_store(double * const store) const;
 
   /// Large strain incremental update
   virtual void update_ld_inc(

--- a/include/cp/polycrystal.h
+++ b/include/cp/polycrystal.h
@@ -19,6 +19,9 @@ class NEML_EXPORT PolycrystalModel: public NEMLModel_ldi
   virtual void populate_hist(History & hist) const;
   virtual void init_hist(History & hist) const;
 
+  virtual void populate_state(History & hist) const {};
+  virtual void init_state(History & hist) const {};
+
   double * history(double * const store, size_t i) const;
   double * stress(double * const store, size_t i) const;
   double * d(double * const store, size_t i) const;

--- a/include/cp/postprocessors.h
+++ b/include/cp/postprocessors.h
@@ -16,8 +16,8 @@ class NEML_EXPORT CrystalPostprocessor: public NEMLObject {
  public:
   CrystalPostprocessor(ParameterSet & params);
 
-  virtual void populate_history(const Lattice & L, History & history) const = 0;
-  virtual void init_history(const Lattice & L, History & history) const = 0;
+  virtual void populate_hist(const Lattice & L, History & history) const = 0;
+  virtual void init_hist(const Lattice & L, History & history) const = 0;
 
   virtual void act(SingleCrystalModel & model, const Lattice &,
                    const double & T, const Symmetric & D,
@@ -37,8 +37,8 @@ class NEML_EXPORT PTRTwinReorientation: public CrystalPostprocessor {
   /// Setup from a ParameterSet
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
-  virtual void populate_history(const Lattice & L, History & history) const;
-  virtual void init_history(const Lattice & L, History & history) const;
+  virtual void populate_hist(const Lattice & L, History & history) const;
+  virtual void init_hist(const Lattice & L, History & history) const;
 
   virtual void act(SingleCrystalModel & model, const Lattice &,
                    const double & T, const Symmetric & D,

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -57,9 +57,14 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Setup blank history
-  void populate_hist(History & history) const;
+  void populate_state(History & history) const;
   /// Actually initialize history
-  void init_hist(History & history) const;
+  void init_state(History & history) const;
+  
+  /// Not changing state
+  void populate_static(History & history) const;
+  /// Static stat
+  void init_static(History & history) const;
 
   /// Useful methods for external models that want an idea of an average
   /// strength
@@ -121,12 +126,6 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   /// Actually update the Nye tensor
   void update_nye(double * const hist, const double * const nye) const;
 
-  /// Split internal variables into static and actual parts
-  std::tuple<History,History> split_state(const History & h) const;
-
-  /// Number of actual internal variables
-  size_t nupdated() const;
-
  private:
   void attempt_update_ld_inc_(
        const double * const d_np1, const double * const d_n,
@@ -138,10 +137,6 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
        double * const A_np1, double * const B_np1,
        double & u_np1, double u_n,
        double & p_np1, double p_n, int trial_type);
-
-  History gather_history_(double * data) const;
-  History gather_history_(const double * data) const;
-  History gather_blank_history_() const;
 
   void calc_tangents_(Symmetric & S, History & H,
                       SCTrialState * ts, double * const A, double * const B);
@@ -156,10 +151,6 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
 
   void solve_substep_(SCTrialState * ts, Symmetric & stress, History & hist);
 
-  std::vector<std::string> not_updated_() const;
-
-  void populate_static_(History & history) const;
-
  private:
   std::shared_ptr<KinematicModel> kinematics_;
   std::shared_ptr<Lattice> lattice_;
@@ -171,11 +162,7 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   bool verbose_, linesearch_;
   int max_divide_;
 
-  History stored_hist_;
-
   std::vector<std::shared_ptr<CrystalPostprocessor>> postprocessors_;
-  std::vector<std::string> static_names_;
-  size_t static_size_;
 
   bool elastic_predictor_, fallback_elastic_predictor_;
   int force_divide_;

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -121,6 +121,12 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   /// Actually update the Nye tensor
   void update_nye(double * const hist, const double * const nye) const;
 
+  /// Split internal variables into static and actual parts
+  std::tuple<History,History> split_state(const History & h) const;
+
+  /// Number of actual internal variables
+  size_t nupdated() const;
+
  private:
   void attempt_update_ld_inc_(
        const double * const d_np1, const double * const d_n,

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -57,10 +57,9 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Setup blank history
-  void populate_history(History & history) const;
-
+  void populate_hist(History & history) const;
   /// Actually initialize history
-  void init_history(History & history) const;
+  void init_hist(History & history) const;
 
   /// Useful methods for external models that want an idea of an average
   /// strength
@@ -81,11 +80,6 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
        double * const A_np1, double * const B_np1,
        double & u_np1, double u_n,
        double & p_np1, double p_n);
-
-  /// Number of stored history variables
-  virtual size_t nhist() const;
-  /// Initialize history raw pointer array
-  virtual void init_hist(double * const hist) const;
 
   /// Instantaneous CTE
   virtual double alpha(double T) const;

--- a/include/cp/singlecrystal.h
+++ b/include/cp/singlecrystal.h
@@ -75,16 +75,16 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
           double * Fe) const;
   
   /// Large deformation incremental update
-  virtual void update_ld_inc(
-       const double * const d_np1, const double * const d_n,
-       const double * const w_np1, const double * const w_n,
-       double T_np1, double T_n,
-       double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1, double * const B_np1,
-       double & u_np1, double u_n,
-       double & p_np1, double p_n);
+  virtual void update_ld_inc_interface(
+      const Symmetric & d_np1, const Symmetric & d_n,
+      const Skew & w_np1, const Skew & w_n,
+      double T_np1, double T_n,
+      double t_np1, double t_n,
+      Symmetric & s_np1, const Symmetric & s_n,
+      History & h_np1, const History & h_n,
+      SymSymR4 & A_np1, SymSkewR4 & B_np1,
+      double & u_np1, double u_n, 
+      double & p_np1, double p_n);
 
   /// Instantaneous CTE
   virtual double alpha(double T) const;
@@ -128,15 +128,15 @@ class NEML_EXPORT SingleCrystalModel: public NEMLModel_ldi, public Solvable
 
  private:
   void attempt_update_ld_inc_(
-       const double * const d_np1, const double * const d_n,
-       const double * const w_np1, const double * const w_n,
-       double T_np1, double T_n,
-       double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1, double * const B_np1,
-       double & u_np1, double u_n,
-       double & p_np1, double p_n, int trial_type);
+      const Symmetric & d_np1, const Symmetric & d_n,
+      const Skew & w_np1, const Skew & w_n,
+      double T_np1, double T_n,
+      double t_np1, double t_n,
+      Symmetric & s_np1, const Symmetric & s_n,
+      History & h_np1, const History & h_n,
+      SymSymR4 & A_np1, SymSkewR4 & B_np1,
+      double & u_np1, double u_n, 
+      double & p_np1, double p_n, int trial_type);
 
   void calc_tangents_(Symmetric & S, History & H,
                       SCTrialState * ts, double * const A, double * const B);

--- a/include/cp/slipharden.h
+++ b/include/cp/slipharden.h
@@ -23,7 +23,7 @@ namespace neml {
 class SlipRule; // Why would we need a forward declaration?
 
 /// ABC for a slip hardening model
-class NEML_EXPORT SlipHardening: public NEMLObject
+class NEML_EXPORT SlipHardening: public HistoryNEMLObject
 {
  public:
   SlipHardening(ParameterSet & params);
@@ -31,11 +31,6 @@ class NEML_EXPORT SlipHardening: public NEMLObject
   virtual std::vector<std::string> varnames() const = 0;
   /// Set new varnames
   virtual void set_varnames(std::vector<std::string> vars) = 0;
-
-  /// Request whatever history you will need
-  virtual void populate_hist(History & history) const = 0;
-  /// Setup history
-  virtual void init_hist(History & history) const = 0;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,

--- a/include/cp/slipharden.h
+++ b/include/cp/slipharden.h
@@ -33,9 +33,9 @@ class NEML_EXPORT SlipHardening: public NEMLObject
   virtual void set_varnames(std::vector<std::string> vars) = 0;
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const = 0;
+  virtual void populate_hist(History & history) const = 0;
   /// Setup history
-  virtual void init_history(History & history) const = 0;
+  virtual void init_hist(History & history) const = 0;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -116,9 +116,9 @@ class NEML_EXPORT FixedStrengthHardening: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -174,9 +174,9 @@ class NEML_EXPORT VocePerSystemHardening: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -239,9 +239,9 @@ class NEML_EXPORT FASlipHardening: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -303,9 +303,9 @@ class NEML_EXPORT GeneralLinearHardening: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -380,9 +380,9 @@ class NEML_EXPORT SimpleLinearHardening: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -454,9 +454,9 @@ class NEML_EXPORT LANLTiModel: public SlipHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Map the set of history variables to the slip system hardening
   virtual double hist_to_tau(size_t g, size_t i, const History & history,
@@ -550,9 +550,9 @@ class NEML_EXPORT SlipSingleStrengthHardening: public SlipSingleHardening
   virtual void set_varnames(std::vector<std::string> vars);
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// The rate of the history
   virtual History hist(const Symmetric & stress,
@@ -656,9 +656,9 @@ class NEML_EXPORT SumSlipSingleStrengthHardening: public SlipSingleHardening
   static ParameterSet parameters();
 
   /// Request whatever history you will need
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Setup history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// The rate of the history
   virtual History hist(const Symmetric & stress,

--- a/include/cp/sliprules.h
+++ b/include/cp/sliprules.h
@@ -28,9 +28,9 @@ class NEML_EXPORT SlipRule: public NEMLObject
  public:
   SlipRule(ParameterSet & params);
   /// Populate the history object with the appropriate variable names and types
-  virtual void populate_history(History & history) const = 0;
+  virtual void populate_hist(History & history) const = 0;
   /// Actually set the history to their initial values
-  virtual void init_history(History & history) const = 0;
+  virtual void init_hist(History & history) const = 0;
 
   /// Helper for models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T,
@@ -95,9 +95,9 @@ class NEML_EXPORT SlipMultiStrengthSlipRule: public SlipRule
   size_t nstrength() const;
 
   /// Populate the history
-  virtual void populate_history(History & history) const;
+  virtual void populate_hist(History & history) const;
   /// Actually initialize the history
-  virtual void init_history(History & history) const;
+  virtual void init_hist(History & history) const;
 
   /// Helper for models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T, 

--- a/include/cp/sliprules.h
+++ b/include/cp/sliprules.h
@@ -23,14 +23,10 @@ namespace neml {
 class SlipHardening;
 
 /// Abstract base class for a slip rule
-class NEML_EXPORT SlipRule: public NEMLObject
+class NEML_EXPORT SlipRule: public HistoryNEMLObject
 {
  public:
   SlipRule(ParameterSet & params);
-  /// Populate the history object with the appropriate variable names and types
-  virtual void populate_hist(History & history) const = 0;
-  /// Actually set the history to their initial values
-  virtual void init_hist(History & history) const = 0;
 
   /// Helper for models that want an average strength
   virtual double strength(const History & history, Lattice & L, double T,

--- a/include/creep.h
+++ b/include/creep.h
@@ -16,20 +16,15 @@ class NEML_EXPORT ScalarCreepRule: public NEMLObject {
    ScalarCreepRule(ParameterSet & params);
    /// Scalar creep strain rate as a function of effective stress,
    /// effective strain, time, and temperature
-   virtual void g(double seq, double eeq, double t, double T, double & g)
-       const = 0;
+   virtual double g(double seq, double eeq, double t, double T) const = 0;
    /// Derivative of scalar creep rate wrt effective stress
-   virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
-       const = 0;
+   virtual double dg_ds(double seq, double eeq, double t, double T) const = 0;
    /// Derivative of scalar creep rate wrt effective strain
-   virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
-       const = 0;
+   virtual double dg_de(double seq, double eeq, double t, double T) const = 0;
    /// Derivative of scalar creep rate wrt time, defaults to zero
-   virtual void dg_dt(double seq, double eeq, double t, double T, double & dg)
-       const;
+   virtual double dg_dt(double seq, double eeq, double t, double T) const;
    /// Derivative of scalar creep rate wrt temperature, defaults to zero
-   virtual void dg_dT(double seq, double eeq, double t, double T, double & dg)
-       const;
+   virtual double dg_dT(double seq, double eeq, double t, double T) const;
 };
 
 /// Creep rate law from Blackburn 1972
@@ -45,16 +40,13 @@ class NEML_EXPORT BlackburnMinimumCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = A * (sinh(beta*s/n)^n * exp(-Q/(R*T))
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective strain = 0
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt temperature
-  virtual void dg_dT(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_dT(double seq, double eeq, double t, double T) const;
 
  private:
   const std::shared_ptr<const Interpolate> A_, n_, beta_;
@@ -76,16 +68,13 @@ class NEML_EXPORT SwindemanMinimumCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = C * S^n * exp(V*S) * exp(-Q/T)
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective strain = 0
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt temperature
-  virtual void dg_dT(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_dT(double seq, double eeq, double t, double T) const;
 
  private:
   const double C_, n_, V_, Q_, shift_;
@@ -107,13 +96,11 @@ class NEML_EXPORT PowerLawCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = A * seq**n
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective strain = 0
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
 
   /// Getter for the prefactor
   double A(double T) const;
@@ -140,13 +127,11 @@ class NEML_EXPORT NormalizedPowerLawCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// rate = (seq/s0)**n
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective strain = 0
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
 
  private:
   const std::shared_ptr<const Interpolate> s0_, n_;
@@ -170,11 +155,11 @@ class NEML_EXPORT RegionKMCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// See documentation for details of the creep rate
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
-  /// Derivative of creep rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
-  /// Derivative of creep rate wrt effective strain
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective stress
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective strain = 0
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
 
  private:
   void select_region_(double seq, double T, double & Ai, double & Bi) const;
@@ -204,11 +189,11 @@ class NEML_EXPORT NortonBaileyCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// creep rate = m * A**(1/m) * seq**(n/m) * eeq ** ((m-1)/m)
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
-  /// Derivative of creep rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
-  /// Derivative of creep rate wrt effective strain
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective stress
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective strain = 0
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
 
   /// Getter for the prefactor
   double A(double T) const;
@@ -240,11 +225,11 @@ class NEML_EXPORT MukherjeeCreep: public ScalarCreepRule {
 
   /// scalar creep rate = A * D0 * exp(Q / (RT)) * mu * b / (k * T) *
   /// (seq / mu)**n
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
-  /// Derivative of creep rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
-  /// Derivative of creep rate wrt effective strain
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective stress
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective strain = 0
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
 
   /// Getter for A
   double A() const;
@@ -282,11 +267,11 @@ class NEML_EXPORT GenericCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// scalar creep rate = exp(f(log(sigma)))
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
-  /// Derivative of creep rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg) const;
-  /// Derivative of creep rate wrt effective strain
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective stress
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
+  /// Derivative of rate wrt effective strain = 0
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
 
  private:
   const std::shared_ptr<Interpolate> cfn_;
@@ -309,13 +294,11 @@ class NEML_EXPORT MinCreep225Cr1MoCreep: public ScalarCreepRule {
   static ParameterSet parameters();
 
   /// See documentation for the hideous formula
-  virtual void g(double seq, double eeq, double t, double T, double & g) const;
+  virtual double g(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective stress
-  virtual void dg_ds(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_ds(double seq, double eeq, double t, double T) const;
   /// Derivative of rate wrt effective strain = 0
-  virtual void dg_de(double seq, double eeq, double t, double T, double & dg)
-      const;
+  virtual double dg_de(double seq, double eeq, double t, double T) const;
 
  private:
   double e1_(double seq, double T) const;

--- a/include/creep.h
+++ b/include/creep.h
@@ -356,20 +356,15 @@ class NEML_EXPORT CreepModel: public NEMLObject, public Solvable {
               SymSymR4 & A_np1);
 
   /// The creep rate as a function of stress, strain, time, and temperature
-  virtual void f(const double * const s, const double * const e, double t, double T,
-                double * const f) const = 0;
+  virtual Symmetric f(const Symmetric & s, const Symmetric & e, double t, double T) const = 0;
   /// The derivative of the creep rate wrt stress
-  virtual void df_ds(const double * const s, const double * const e, double t, double T,
-                double * const df) const = 0;
+  virtual SymSymR4 df_ds(const Symmetric & s, const Symmetric & e, double t, double T) const = 0;
   /// The derivative of the creep rate wrt strain
-  virtual void df_de(const double * const s, const double * const e, double t, double T,
-                double * const df) const = 0;
+  virtual SymSymR4 df_de(const Symmetric & s, const Symmetric & e, double t, double T) const = 0;
   /// The derivative of the creep rate wrt time, defaults to zero
-  virtual void df_dt(const double * const s, const double * const e, double t, double T,
-                double * const df) const;
+  virtual Symmetric df_dt(const Symmetric & s, const Symmetric & e, double t, double T) const;
   /// The derivative of the creep rate wrt temperature, defaults to zero
-  virtual void df_dT(const double * const s, const double * const e, double t, double T,
-                double * const df) const;
+  virtual Symmetric df_dT(const Symmetric & s, const Symmetric & e, double t, double T) const;
 
   /// Setup a trial state for the solver
   std::unique_ptr<CreepModelTrialState> make_trial_state(const Symmetric & s_np1,
@@ -409,28 +404,23 @@ class NEML_EXPORT J2CreepModel: public CreepModel {
   static ParameterSet parameters();
 
   /// creep_rate = dev(s) / ||dev(s)|| * scalar(effective_strain,
-  /// effective_stress, time, temperature)
-  virtual void f(const double * const s, const double * const e, double t, double T,
-                double * const f) const;
-  /// Derivative of creep rate wrt stress
-  virtual void df_ds(const double * const s, const double * const e, double t, double T,
-                double * const df) const;
-  /// Derivative of creep rate wrt strain
-  virtual void df_de(const double * const s, const double * const e, double t, double T,
-                double * const df) const;
-  /// Derivative of creep rate wrt time
-  virtual void df_dt(const double * const s, const double * const e, double t, double T,
-                double * const df) const;
-  /// Derivative of creep rate wrt temperature
-  virtual void df_dT(const double * const s, const double * const e, double t, double T,
-                double * const df) const;
+  /// The creep rate as a function of stress, strain, time, and temperature
+  virtual Symmetric f(const Symmetric & s, const Symmetric & e, double t, double T) const;
+  /// The derivative of the creep rate wrt stress
+  virtual SymSymR4 df_ds(const Symmetric & s, const Symmetric & e, double t, double T) const;
+  /// The derivative of the creep rate wrt strain
+  virtual SymSymR4 df_de(const Symmetric & s, const Symmetric & e, double t, double T) const;
+  /// The derivative of the creep rate wrt time, defaults to zero
+  virtual Symmetric df_dt(const Symmetric & s, const Symmetric & e, double t, double T) const;
+  /// The derivative of the creep rate wrt temperature, defaults to zero
+  virtual Symmetric df_dT(const Symmetric & s, const Symmetric & e, double t, double T) const;
 
  private:
   // Helpers for computing the above
-  double seq(const double * const s) const;
-  double eeq(const double * const e) const;
-  void sdir(double * const s) const;
-  void edir(double * const e) const;
+  double seq(const Symmetric & s) const;
+  double eeq(const Symmetric & e) const;
+  Symmetric sdir(const Symmetric & s) const;
+  Symmetric edir(const Symmetric & e) const;
 
  private:
   std::shared_ptr<ScalarCreepRule> rule_;

--- a/include/damage.h
+++ b/include/damage.h
@@ -26,7 +26,7 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
   virtual void init_state(History & hist) const;
 
   /// The damaged stress update
-  virtual void update_sd_actual(
+  virtual void update_sd_state(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -78,7 +78,7 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Stress update using the scalar damage model
-  virtual void update_sd_actual(
+  virtual void update_sd_state(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,

--- a/include/damage.h
+++ b/include/damage.h
@@ -53,7 +53,7 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
 /// Scalar damage trial state
 class SDTrialState: public TrialState {
  public:
-  virtual ~SDTrialState() {};
+  SDTrialState() {};
   double e_np1[6];
   double e_n[6];
   double T_np1, T_n, t_np1, t_n, u_n, p_n;
@@ -103,11 +103,10 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   virtual void RJ(const double * const x, TrialState * ts,double * const R,
                  double * const J);
   /// Setup a trial state from known information
-  void make_trial_state(const double * const e_np1, const double * const e_n,
+  SDTrialState make_trial_state(const double * const e_np1, const double * const e_n,
                        double T_np1, double T_n, double t_np1, double t_n,
                        const double * const s_n, const double * const h_n,
-                       double u_n, double p_n,
-                       SDTrialState & tss);
+                       double u_n, double p_n);
   /// Used to find the damage value from the history
   virtual double get_damage(const double *const h_np1);
   /// Used to determine if element should be deleted

--- a/include/damage.h
+++ b/include/damage.h
@@ -122,11 +122,10 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   virtual bool is_damage_model() const;
 
  protected:
-  void tangent_(const double * const e_np1, const double * const e_n,
-               const double * const s_np1, const double * const s_n,
-               double T_np1, double T_n, double t_np1, double t_n,
-               double w_np1, double w_n, const double * const A_prime,
-               double * const A);
+  SymSymR4 tangent_(const Symmetric & e_np1, const Symmetric & e_n,
+                    const Symmetric & s_np1, const Symmetric & s_n,
+                    double T_np1, double T_n, double t_np1, double t_n,
+                    double w_np1, double w_n, const SymSymR4 & A_prime);
   void ekill_update_(double T_np1, const Symmetric & e_np1, 
                     Symmetric & s_np1, 
                     History & h_np1, const History & h_n,

--- a/include/damage.h
+++ b/include/damage.h
@@ -22,9 +22,10 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
 
   /// How many history variables?  Equal to base_history + ndamage
   virtual size_t nhist() const;
+  /// Populate the internal variables
+  virtual void populate_hist(History & hist) const;
   /// Initialize base according to the base model and damage according to
-  /// init_damage
-  virtual void init_hist(double * const hist) const;
+  virtual void init_hist(History & hist) const;
 
   /// The damaged stress update
   virtual void update_sd(
@@ -39,8 +40,10 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
 
   /// Number of damage variables
   virtual size_t ndamage() const = 0;
+  /// Populate the damage variables
+  virtual void populate_damage(History & hist) const = 0;
   /// Setup the damage variables
-  virtual void init_damage(double * const damage) const = 0;
+  virtual void init_damage(History & hist) const = 0;
 
   /// Override the elastic model
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
@@ -89,8 +92,10 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
 
   /// Equal to 1
   virtual size_t ndamage() const;
+  /// Populate damage
+  virtual void populate_damage(History & hist) const;
   /// Initialize to zero
-  virtual void init_damage(double * const damage) const;
+  virtual void init_damage(History & hist) const;
 
   /// Number of parameters for the solver
   virtual size_t nparams() const;

--- a/include/damage.h
+++ b/include/damage.h
@@ -20,8 +20,6 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
   /// Input is an elastic model, an undamaged base material, and the CTE
   NEMLDamagedModel_sd(ParameterSet & params);
 
-  /// How many history variables?  Equal to base_history + ndamage
-  virtual size_t nhist() const;
   /// Populate the internal variables
   virtual void populate_hist(History & hist) const;
   /// Initialize base according to the base model and damage according to

--- a/include/damage.h
+++ b/include/damage.h
@@ -53,13 +53,20 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
 /// Scalar damage trial state
 class SDTrialState: public TrialState {
  public:
-  SDTrialState() {};
-  double e_np1[6];
-  double e_n[6];
-  double T_np1, T_n, t_np1, t_n, u_n, p_n;
-  double s_n[6];
-  double w_n;
-  std::vector<double> h_n;
+  SDTrialState(const Symmetric & e_np1, const Symmetric & e_n, 
+               const Symmetric & s_n,
+               double T_np1, double T_n, double t_np1, 
+               double t_n, double u_n, double p_n, double w_n,
+               const History & h_n) :
+      e_np1(e_np1), e_n(e_n), s_n(s_n), T_np1(T_np1), T_n(t_n),
+      t_np1(t_np1), t_n(t_n), u_n(u_n), p_n(p_n), w_n(w_n),
+      h_n(h_n)
+  {};
+  Symmetric e_np1;
+  Symmetric e_n;
+  Symmetric s_n;
+  double T_np1, T_n, t_np1, t_n, u_n, p_n, w_n;
+  History h_n;
 };
 
 /// Special case where the damage variable is a scalar
@@ -103,9 +110,9 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   virtual void RJ(const double * const x, TrialState * ts,double * const R,
                  double * const J);
   /// Setup a trial state from known information
-  SDTrialState make_trial_state(const double * const e_np1, const double * const e_n,
+  SDTrialState make_trial_state(const Symmetric & e_np1, const Symmetric & e_n,
                        double T_np1, double T_n, double t_np1, double t_n,
-                       const double * const s_n, const double * const h_n,
+                       const Symmetric & s_n, const History & h_n,
                        double u_n, double p_n);
   /// Used to find the damage value from the history
   virtual double get_damage(const double *const h_np1);

--- a/include/damage.h
+++ b/include/damage.h
@@ -121,10 +121,10 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
                double T_np1, double T_n, double t_np1, double t_n,
                double w_np1, double w_n, const double * const A_prime,
                double * const A);
-  void ekill_update_(double T_np1, const double * const e_np1, 
-                    double * const s_np1, 
-                    double * const h_np1, const double * const h_n,
-                    double * A_np1, 
+  void ekill_update_(double T_np1, const Symmetric & e_np1, 
+                    Symmetric & s_np1, 
+                    History & h_np1, const History & h_n,
+                    SymSymR4 & A_np1, 
                     double & u_np1, double u_n, 
                     double & p_np1, double p_n);
 

--- a/include/damage.h
+++ b/include/damage.h
@@ -21,12 +21,12 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
   NEMLDamagedModel_sd(ParameterSet & params);
 
   /// Populate the internal variables
-  virtual void populate_hist(History & hist) const;
+  virtual void populate_state(History & hist) const;
   /// Initialize base according to the base model and damage according to
-  virtual void init_hist(History & hist) const;
+  virtual void init_state(History & hist) const;
 
   /// The damaged stress update
-  virtual void update_sd(
+  virtual void update_sd_actual(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -78,7 +78,7 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Stress update using the scalar damage model
-  virtual void update_sd(
+  virtual void update_sd_actual(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,

--- a/include/damage.h
+++ b/include/damage.h
@@ -27,14 +27,14 @@ class NEML_EXPORT NEMLDamagedModel_sd: public NEMLModel_sd {
 
   /// The damaged stress update
   virtual void update_sd_state(
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n) = 0;
+    const Symmetric & E_np1, const Symmetric & E_n,
+    double T_np1, double T_n,
+    double t_np1, double t_n,
+    Symmetric & S_np1, const Symmetric & S_n,
+    History & H_np1, const History & H_n,
+    SymSymR4 & AA_np1,
+    double & u_np1, double u_n,
+    double & p_np1, double p_n) = 0;
 
   /// Number of damage variables
   virtual size_t ndamage() const = 0;
@@ -79,14 +79,14 @@ class NEML_EXPORT NEMLScalarDamagedModel_sd: public NEMLDamagedModel_sd, public 
 
   /// Stress update using the scalar damage model
   virtual void update_sd_state(
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n);
+    const Symmetric & E_np1, const Symmetric & E_n,
+    double T_np1, double T_n,
+    double t_np1, double t_n,
+    Symmetric & S_np1, const Symmetric & S_n,
+    History & H_np1, const History & H_n,
+    SymSymR4 & AA_np1,
+    double & u_np1, double u_n,
+    double & p_np1, double p_n);
 
   /// Equal to 1
   virtual size_t ndamage() const;

--- a/include/general_flow.h
+++ b/include/general_flow.h
@@ -12,16 +12,9 @@
 namespace neml {
 
 /// ABC for a completely general flow rule...
-class NEML_EXPORT GeneralFlowRule: public NEMLObject {
+class NEML_EXPORT GeneralFlowRule: public HistoryNEMLObject {
  public:
   GeneralFlowRule(ParameterSet & params);
-
-  /// Setup internal state
-  virtual void populate_hist(History & h) const = 0;
-  /// Initialize the history at time zero
-  virtual void init_hist(History & h) const = 0;
-  /// Number of history variables
-  virtual size_t nhist() const;
 
   /// Stress rate
   virtual void s(const double * const s, const double * const alpha,

--- a/include/general_flow.h
+++ b/include/general_flow.h
@@ -16,10 +16,12 @@ class NEML_EXPORT GeneralFlowRule: public NEMLObject {
  public:
   GeneralFlowRule(ParameterSet & params);
 
-  /// Number of history variables
-  virtual size_t nhist() const = 0;
+  /// Setup internal state
+  virtual void populate_hist(History & h) const = 0;
   /// Initialize the history at time zero
-  virtual void init_hist(double * const h) = 0;
+  virtual void init_hist(History & h) const = 0;
+  /// Number of history variables
+  virtual size_t nhist() const;
 
   /// Stress rate
   virtual void s(const double * const s, const double * const alpha,
@@ -94,10 +96,10 @@ class NEML_EXPORT TVPFlowRule : public GeneralFlowRule {
   /// Initialize from parameter set
   static ParameterSet parameters();
 
-  /// Number of history variables
-  virtual size_t nhist() const;
+  // Setup internal state
+  virtual void populate_hist(History & h) const;
   /// Initialize history
-  virtual void init_hist(double * const h);
+  virtual void init_hist(History & h) const;
 
   /// Stress rate
   virtual void s(const double * const s, const double * const alpha,

--- a/include/general_flow.h
+++ b/include/general_flow.h
@@ -17,56 +17,34 @@ class NEML_EXPORT GeneralFlowRule: public HistoryNEMLObject {
   GeneralFlowRule(ParameterSet & params);
 
   /// Stress rate
-  virtual void s(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const sdot) = 0;
+  virtual Symmetric s(const Symmetric & s, const History & alpha, 
+                      const Symmetric & edot, double T, double Tdot) = 0;
   /// Partial of stress rate wrt stress
-  virtual void ds_ds(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot) = 0;
+  virtual SymSymR4 ds_ds(const Symmetric & s, const History & alpha, 
+                         const Symmetric & edot, double T, double Tdot) = 0;
   /// Partial of stress rate wrt history
-  virtual void ds_da(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot) = 0;
+  virtual History ds_da(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot) = 0;
   /// Partial of stress rate wrt strain rate
-  virtual void ds_de(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot) = 0;
+  virtual SymSymR4 ds_de(const Symmetric & s, const History & alpha, 
+                         const Symmetric & edot, double T, double Tdot) = 0;
 
   /// History rate
-  virtual void a(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const adot) = 0;
+  virtual History a(const Symmetric & s, const History & alpha, 
+                    const Symmetric & edot, double T, double Tdot) = 0;
   /// Partial of history rate wrt stress
-  virtual void da_ds(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot) = 0;
+  virtual History da_ds(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot) = 0;
   /// Partial of history rate wrt history
-  virtual void da_da(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot) = 0;
+  virtual History da_da(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot) = 0;
   /// Partial of history rate wrt strain rate
-  virtual void da_de(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot) = 0;
+  virtual History da_de(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot) = 0;
 
   /// The implementation needs to define inelastic dissipation
-  virtual void work_rate(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double & p_rate);
-
-  /// The implementation needs to define elastic strain
-  virtual void elastic_strains(const double * const s_np1, double T_np1,
-                              double * const e_np1) const = 0;
+  virtual double work_rate(const Symmetric & s, const History & alpha, 
+                           const Symmetric & edot, double T, double Tdot);
 
   /// Set a new elastic model
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
@@ -95,56 +73,34 @@ class NEML_EXPORT TVPFlowRule : public GeneralFlowRule {
   virtual void init_hist(History & h) const;
 
   /// Stress rate
-  virtual void s(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const sdot);
+  virtual Symmetric s(const Symmetric & s, const History & alpha, 
+                      const Symmetric & edot, double T, double Tdot);
   /// Partial of stress rate wrt stress
-  virtual void ds_ds(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot);
+  virtual SymSymR4 ds_ds(const Symmetric & s, const History & alpha, 
+                         const Symmetric & edot, double T, double Tdot);
   /// Partial of stress rate wrt history
-  virtual void ds_da(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot);
+  virtual History ds_da(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
   /// Partial of stress rate wrt strain rate
-  virtual void ds_de(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot);
+  virtual SymSymR4 ds_de(const Symmetric & s, const History & alpha, 
+                         const Symmetric & edot, double T, double Tdot);
 
   /// History rate
-  virtual void a(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const adot);
+  virtual History a(const Symmetric & s, const History & alpha, 
+                    const Symmetric & edot, double T, double Tdot);
   /// Partial of history rate wrt stress
-  virtual void da_ds(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot);
+  virtual History da_ds(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
   /// Partial of history rate wrt history
-  virtual void da_da(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot);
+  virtual History da_da(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
   /// Partial of history rate wrt strain rate
-  virtual void da_de(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot);
+  virtual History da_de(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
 
   /// The implementation needs to define inelastic dissipation
-  virtual void work_rate(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double & p_rate);
-
-  /// The implementation needs to define elastic strain
-  virtual void elastic_strains(const double * const s_np1, double T_np1,
-                              double * const e_np1) const;
+  virtual double work_rate(const Symmetric & s, const History & alpha, 
+                           const Symmetric & edot, double T, double Tdot);
 
   /// Set a new elastic model
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);

--- a/include/hardening.h
+++ b/include/hardening.h
@@ -16,15 +16,9 @@ namespace neml {
 /// Interface for a generic hardening rule
 //    1) Take alpha to q
 //    2) Give the gradient of that function
-class NEML_EXPORT HardeningRule: public NEMLObject {
+class NEML_EXPORT HardeningRule: public HistoryNEMLObject {
  public:
   HardeningRule(ParameterSet & params);
-  /// Setup the internal state
-  virtual void populate_hist(History & h) const = 0;
-  /// Initialize the history
-  virtual void init_hist(History & h) const = 0;
-  /// This should be replaced at some point
-  virtual size_t nhist() const;
 
   /// The map between strain-like and stress-like variables
   virtual void q(const double * const alpha, double T, double * const qv) const = 0;
@@ -260,19 +254,12 @@ class NEML_EXPORT CombinedHardeningRule: public HardeningRule {
 static Register<CombinedHardeningRule> regCombinedHardeningRule;
 
 /// ABC of a non-associative hardening rule
-class NEML_EXPORT NonAssociativeHardening: public NEMLObject {
+class NEML_EXPORT NonAssociativeHardening: public HistoryNEMLObject {
  public:
   NonAssociativeHardening(ParameterSet & params);
   /// How many stress-like variables
   virtual size_t ninter() const = 0; // How many "q" variables it spits out
   
-  /// Setup the internal state
-  virtual void populate_hist(History & h) const;
-  /// Initialize the history
-  virtual void init_hist(History & h) const;
-  /// Number of history variables, can be removed in the future
-  virtual size_t nhist() const;
-
   /// Map from strain to stress
   virtual void q(const double * const alpha, double T, double * const qv) const = 0;
   /// Derivative of the map
@@ -458,7 +445,7 @@ class NEML_EXPORT Chaboche: public NonAssociativeHardening {
  private:
   std::shared_ptr<IsotropicHardeningRule> iso_;
   const std::vector<std::shared_ptr<Interpolate>> c_;  
-  const int n_;
+  const size_t n_;
   std::vector<std::shared_ptr<GammaModel>> gmodels_;
 
   const std::vector<std::shared_ptr<Interpolate>> A_;
@@ -545,7 +532,7 @@ class NEML_EXPORT ChabocheVoceRecovery: public NonAssociativeHardening {
   const std::shared_ptr<Interpolate> r2_;
 
   const std::vector<std::shared_ptr<Interpolate>> c_;  
-  const int n_;
+  const size_t n_;
   std::vector<std::shared_ptr<GammaModel>> gmodels_;
 
   const std::vector<std::shared_ptr<Interpolate>> A_;

--- a/include/history.h
+++ b/include/history.h
@@ -280,6 +280,11 @@ class NEML_EXPORT HistoryNEMLObject: public NEMLObject {
   /// This should be replaced at some point
   virtual size_t nhist() const;
 
+  /// Setup a flat vector history
+  virtual void init_store(double * const h) const;
+  /// Now just = nhist
+  virtual size_t nstore() const;
+
   /// Set the object prefix
   void set_variable_prefix(std::string prefix);
   /// Get the prefix

--- a/include/history.h
+++ b/include/history.h
@@ -267,6 +267,20 @@ inline History History::derivative<History>() const
   return history_derivative(*this);
 }
 
+/// NEMLObject that maintains some internal state variables
+class NEML_EXPORT HistoryNEMLObject: public NEMLObject {
+ public:
+  HistoryNEMLObject(ParameterSet & params);
+  virtual ~HistoryNEMLObject() {};
+
+  /// Setup the internal state
+  virtual void populate_hist(History & h) const = 0;
+  /// Initialize the history
+  virtual void init_hist(History & h) const = 0;
+  /// This should be replaced at some point
+  virtual size_t nhist() const;
+};
+
 } // namespace neml
 
 #endif // HISTORY_H

--- a/include/history.h
+++ b/include/history.h
@@ -160,7 +160,7 @@ class NEML_EXPORT History {
   void increase_store(size_t newsize);
 
   /// Multiply everything by a scalar
-  void scalar_multiply(double scalar);
+  History & scalar_multiply(double scalar);
 
   /// Add another history to this one
   History & operator+=(const History & other);
@@ -221,6 +221,9 @@ class NEML_EXPORT History {
   /// Quick function to check to see if something is in the vector
   inline bool contains(std::string name) const { return loc_.find(name) !=
     loc_.end();};
+  
+  /// Premultiply by various objects
+  History premultiply(const SymSymR4 & T);
 
   /// Postmultiply by various objects
   History postmultiply(const SymSymR4 & T);

--- a/include/history.h
+++ b/include/history.h
@@ -158,12 +158,21 @@ class NEML_EXPORT History {
 
   /// Actually increase internal storage
   void increase_store(size_t newsize);
+  
+  /// Nice form for scalar multiplication
+  History & operator*=(const double & scalar);
 
   /// Multiply everything by a scalar
-  History & scalar_multiply(double scalar);
+  History & scalar_multiply(const double & scalar);
 
   /// Add another history to this one
   History & operator+=(const History & other);
+
+  /// Negation
+  History operator-() const;
+
+  /// Subtract another history from this one
+  History & operator-=(const History & other);
 
   /// Combine another history object through a union
   History & add_union(const History & other);
@@ -269,6 +278,18 @@ inline History History::derivative<History>() const
 {
   return history_derivative(*this);
 }
+
+/// Scalar multiplication
+History operator*(const double & s, const History & v);
+
+/// Other scalar multiplication
+History operator*(const History & v, const double & s);
+
+/// History addition
+History operator+(const History & a, const History & b);
+
+/// History subtraction
+History operator-(const History & a, const History & b);
 
 /// NEMLObject that maintains some internal state variables
 class NEML_EXPORT HistoryNEMLObject: public NEMLObject {

--- a/include/history.h
+++ b/include/history.h
@@ -19,7 +19,8 @@ enum StorageType {
   TYPE_SYMMETRIC = 3,
   TYPE_SKEW      = 4,
   TYPE_ROT       = 5,
-  TYPE_SYMSYM    = 6
+  TYPE_SYMSYM    = 6,
+  TYPE_BLANK     = 7
 };
 
 // Black magic to map a type to the enum
@@ -123,6 +124,13 @@ class NEML_EXPORT History {
     error_if_not_exists_(name);
     error_if_wrong_type_(name, GetStorageType<T>());
     return T(&(storage_[loc_.at(name)]));
+  }
+
+  /// Get a pointer to the raw location of an item
+  double * get_data(std::string name)
+  {
+    error_if_not_exists_(name);
+    return &(storage_[loc_.at(name)]);
   }
 
   /// Get the location map

--- a/include/history.h
+++ b/include/history.h
@@ -279,6 +279,18 @@ class NEML_EXPORT HistoryNEMLObject: public NEMLObject {
   virtual void init_hist(History & h) const = 0;
   /// This should be replaced at some point
   virtual size_t nhist() const;
+
+  /// Set the object prefix
+  void set_variable_prefix(std::string prefix);
+  /// Get the prefix
+  std::string get_variable_prefix() const;
+  /// Assemble a complete variable name
+  std::string prefix(std::string basename) const;
+  /// Assemble a complete derivative name
+  std::string dprefix(std::string a, std::string b) const;
+
+ protected:
+  std::string prefix_;
 };
 
 } // namespace neml

--- a/include/history.h
+++ b/include/history.h
@@ -317,9 +317,18 @@ class NEML_EXPORT HistoryNEMLObject: public NEMLObject {
   std::string prefix(std::string basename) const;
   /// Assemble a complete derivative name
   std::string dprefix(std::string a, std::string b) const;
+  
+   /// Quickly setup history
+   virtual History gather_history_(double * data) const;
+   virtual History gather_history_(const double * data) const;
+   virtual History gather_blank_history_() const;
+
+ protected:
+   virtual void cache_history_();
 
  protected:
   std::string prefix_;
+  History stored_hist_;
 };
 
 } // namespace neml

--- a/include/history.h
+++ b/include/history.h
@@ -125,7 +125,7 @@ class NEML_EXPORT History {
     error_if_wrong_type_(name, GetStorageType<T>());
     return T(&(storage_[loc_.at(name)]));
   }
-
+  
   /// Get a pointer to the raw location of an item
   double * get_data(std::string name)
   {

--- a/include/math/tensors.h
+++ b/include/math/tensors.h
@@ -584,6 +584,11 @@ NEML_EXPORT SymSymSymR6 operator/(const SymSymSymR6 & v, double s);
 NEML_EXPORT SymSymSymR6 operator+(const SymSymSymR6 & a, const SymSymSymR6 & b);
 NEML_EXPORT SymSymSymR6 operator-(const SymSymSymR6 & a, const SymSymSymR6 & b);
 
+// Complicated objective stress update
+Symmetric truesdell_update_sym(const Symmetric & D, const Skew & W, 
+                               const Symmetric & cauchy_n,
+                               const Symmetric & dS);
+
 } // namespace neml
 
 #endif

--- a/include/math/tensors.h
+++ b/include/math/tensors.h
@@ -247,6 +247,9 @@ class NEML_EXPORT Skew: public Tensor {
   /// Skew a general tensor
   Skew(const RankTwo & other);
 
+  static Skew zero() { return
+    Skew(std::vector<double>({0,0,0}));};
+
   RankTwo to_full() const;
 
   Skew opposite() const;

--- a/include/models.h
+++ b/include/models.h
@@ -364,12 +364,18 @@ class SSRIPTrialState : public TrialState {
 /// Small strain creep+plasticity trial state
 class SSCPTrialState : public TrialState {
  public:
-  virtual ~SSCPTrialState() {};
-  double ep_strain[6];            // Current plastic strain
-  double e_n[6], e_np1[6];        // Previous and next total strain
-  double s_n[6];                  // Previous stress
+  SSCPTrialState(const Symmetric & ep_strain, const Symmetric & e_n,
+                 const Symmetric & e_np1, const Symmetric & s_n,
+                 double T_n, double T_np1, double t_n, double t_np1,
+                 const History & h_n) :
+      ep_strain(ep_strain), e_n(e_n), e_np1(e_np1), s_n(s_n), 
+      T_n(T_n), T_np1(T_np1), t_n(t_n), t_np1(t_np1), h_n(h_n)
+  {};
+  Symmetric ep_strain;            // Current plastic strain
+  Symmetric e_n, e_np1;           // Previous and next total strain
+  Symmetric s_n;                  // Previous stress
   double T_n, T_np1, t_n, t_np1;  // Next and previous time and temperature
-  std::vector<double> h_n;        // Previous history vector
+  History h_n;                    // Previous history vector
 };
 
 /// General inelastic integrator trial state
@@ -617,10 +623,10 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
                  double * const J);
 
   /// Setup a trial state from known information
-  void make_trial_state(const double * const e_np1, const double * const e_n,
-                       double T_np1, double T_n, double t_np1, double t_n,
-                       const double * const s_n, const double * const h_n,
-                       SSCPTrialState & ts);
+  std::shared_ptr<SSCPTrialState> make_trial_state(
+      const Symmetric & e_np1, const Symmetric & e_n,
+      double T_np1, double T_n, double t_np1, double t_n,
+      const Symmetric & s_n, const History & h_n);
 
   /// Set a new elastic model
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);

--- a/include/models.h
+++ b/include/models.h
@@ -212,9 +212,9 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
    virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
   private:
-   void calc_tangent_(const double * const D, const double * const W,
-                     const double * const C, const double * const S,
-                     double * const A, double * const B);
+   void calc_tangent_(const Symmetric & D, const Skew & W,
+                     const SymSymR4 & C, const Symmetric & S,
+                     SymSymR4 & A, SymSkewR4 & B);
 
   protected:
    std::shared_ptr<LinearElasticModel> elastic_;

--- a/include/models.h
+++ b/include/models.h
@@ -110,17 +110,22 @@ class NEML_EXPORT NEMLModel: public HistoryNEMLObject {
    /// Number of static variables
    size_t nstatic() const;
 
+   /// Quickly setup history
+   History gather_history_(double * data) const;
+   History gather_history_(const double * data) const;
+   History gather_blank_history_() const;
+
+   /// Quickly setup state
+   History gather_state_(double * data) const;
+   History gather_state_(const double * data) const;
+   History gather_blank_state_() const;
+
   protected:
    /// Split internal variables into static and actual parts
    std::tuple<History,History> split_state(const History & h) const;
 
    /// Cache history objects with a view to increasing performance
    void cache_history_();
-
-   /// Quickly setup history
-   History gather_history_(double * data) const;
-   History gather_history_(const double * data) const;
-   History gather_blank_history_() const;
 
   protected:
    History stored_hist_;
@@ -164,12 +169,12 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
 
    /// The small strain stress update interface with just the state variables
    virtual void update_sd_state(
-       const double * const e_np1, const double * const e_n,
+       const Symmetric & E_np1, const Symmetric & E_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1,
+       Symmetric & S_np1, const Symmetric & S_n,
+       History & H_np1, const History & H_n,
+       SymSymR4 & AA_np1,
        double & u_np1, double u_n,
        double & p_np1, double p_n) = 0;
 
@@ -223,14 +228,14 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
 
   /// Complete substep update
   virtual void update_sd_state(
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n);
+       const Symmetric & E_np1, const Symmetric & E_n,
+       double T_np1, double T_n,
+       double t_np1, double t_n,
+       Symmetric & S_np1, const Symmetric & S_n,
+       History & H_np1, const History & H_n,
+       SymSymR4 & AA_np1,
+       double & u_np1, double u_n,
+       double & p_np1, double p_n);
 
   /// Single step update
   virtual void update_step(
@@ -314,14 +319,14 @@ class NEML_EXPORT SmallStrainElasticity: public NEMLModel_sd {
 
   /// Small strain stress update
   virtual void update_sd_state(
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n);
+       const Symmetric & E_np1, const Symmetric & E_n,
+       double T_np1, double T_n,
+       double t_np1, double t_n,
+       Symmetric & S_np1, const Symmetric & S_n,
+       History & H_np1, const History & H_n,
+       SymSymR4 & AA_np1,
+       double & u_np1, double u_n,
+       double & p_np1, double p_n);
   
   /// Populate internal variables (none)
   virtual void populate_state(History & h) const;
@@ -589,14 +594,14 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
 
   /// Small strain stress update
   virtual void update_sd_state(
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n);
+       const Symmetric & E_np1, const Symmetric & E_n,
+       double T_np1, double T_n,
+       double t_np1, double t_n,
+       Symmetric & S_np1, const Symmetric & S_n,
+       History & H_np1, const History & H_n,
+       SymSymR4 & AA_np1,
+       double & u_np1, double u_n,
+       double & p_np1, double p_n);
   
   /// Populate list of internal variables
   virtual void populate_state(History & hist) const;
@@ -761,14 +766,14 @@ class NEML_EXPORT KMRegimeModel: public NEMLModel_sd {
 
   /// The small strain stress update
   virtual void update_sd_state(
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n);
+       const Symmetric & E_np1, const Symmetric & E_n,
+       double T_np1, double T_n,
+       double t_np1, double t_n,
+       Symmetric & S_np1, const Symmetric & S_n,
+       History & H_np1, const History & H_n,
+       SymSymR4 & AA_np1,
+       double & u_np1, double u_n,
+       double & p_np1, double p_n);
 
   /// Populate internal variables
   virtual void populate_state(History & hist) const;
@@ -791,5 +796,11 @@ class NEML_EXPORT KMRegimeModel: public NEMLModel_sd {
 };
 
 static Register<KMRegimeModel> regKMRegimeModel;
+
+/// Useful helper to calculate work and energy with the trapezoid rule
+std::tuple<double,double> trapezoid_energy(
+    const Symmetric & e_np1, const Symmetric & e_n,
+    const Symmetric & ep_np1, const Symmetric & ep_n,
+    const Symmetric & s_np1, const Symmetric & s_n);
 
 } // namespace neml

--- a/include/models.h
+++ b/include/models.h
@@ -626,8 +626,7 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
  private:
-  void form_tangent_(double * const A, double * const B,
-                    double * const A_np1);
+  SymSymR4 form_tangent_(const SymSymR4 & A, const SymSymR4 & B);
 
  private:
   std::shared_ptr<NEMLModel_sd> plastic_;

--- a/include/models.h
+++ b/include/models.h
@@ -55,7 +55,18 @@ class NEML_EXPORT NEMLModel: public HistoryNEMLObject {
        double * const h_np1, const double * const h_n,
        double * const A_np1,
        double & u_np1, double u_n,
-       double & p_np1, double p_n) = 0;
+       double & p_np1, double p_n);
+
+   /// Small strain update, wrapped objects
+   virtual void update_sd_interface(
+       const Symmetric & e_np1, const Symmetric & e_n,
+       double T_np1, double T_n,
+       double t_np1, double t_n,
+       Symmetric & s_np1, Symmetric & s_n,
+       History & h_np1, const History & h_n,
+       SymSymR4 & A_np1,
+       double & u_np1, double u_n,
+       double & p_np1, double p_n) {}; // Fix after all updated
 
    /// Raw data large strain incremental update
    virtual void update_ld_inc(
@@ -67,7 +78,19 @@ class NEML_EXPORT NEMLModel: public HistoryNEMLObject {
        double * const h_np1, const double * const h_n,
        double * const A_np1, double * const B_np1,
        double & u_np1, double u_n,
-       double & p_np1, double p_n) = 0;
+       double & p_np1, double p_n);
+
+   /// Large strain incremental update, wrapped objects
+   virtual void update_ld_inc_interface(
+       const Symmetric & d_np1, const Symmetric & d_n,
+       const Skew & w_np1, const Skew & w_n,
+       double T_np1, double T_n,
+       double t_np1, double t_n,
+       Symmetric & s_np1, const Symmetric & s_n,
+       History & h_np1, const History & h_n,
+       SymSymR4 & A_np1, SymSkewR4 & B_np1,
+       double & u_np1, double u_n,
+       double & p_np1, double p_n) {}; // Fix after all updated
   
    /// Instantaneous thermal expansion coefficient as a function of temperature
    virtual double alpha(double T) const = 0;
@@ -110,28 +133,16 @@ class NEML_EXPORT NEMLModel_ldi: public NEMLModel {
   public:
     NEMLModel_ldi(ParameterSet & params);
 
-   /// The small strain stress update interface
-   virtual void update_sd(
-       const double * const e_np1, const double * const e_n,
+   /// Small strain update, wrapped objects
+   virtual void update_sd_interface(
+       const Symmetric & e_np1, const Symmetric & e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1,
+       Symmetric & s_np1, Symmetric & s_n,
+       History & h_np1, const History & h_n,
+       SymSymR4 & A_np1,
        double & u_np1, double u_n,
        double & p_np1, double p_n);
-
-   /// Large strain incremental update
-   virtual void update_ld_inc(
-       const double * const d_np1, const double * const d_n,
-       const double * const w_np1, const double * const w_n,
-       double T_np1, double T_n,
-       double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1, double * const B_np1,
-       double & u_np1, double u_n,
-       double & p_np1, double p_n) = 0;
 };
 
 /// Small deformation stress update
@@ -140,19 +151,19 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
     /// All small strain models use small strain elasticity and CTE
     NEMLModel_sd(ParameterSet & params);
 
-   /// Vector interface can go here
-   virtual void update_sd(
-       const double * const e_np1, const double * const e_n,
+   /// Small strain update, wrapped objects
+   virtual void update_sd_interface(
+       const Symmetric & e_np1, const Symmetric & e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1,
+       Symmetric & s_np1, Symmetric & s_n,
+       History & h_np1, const History & h_n,
+       SymSymR4 & A_np1,
        double & u_np1, double u_n,
-       double & p_np1, double p_n);
+       double & p_np1, double p_n); 
 
-   /// The small strain stress update interface
-   virtual void update_sd_actual(
+   /// The small strain stress update interface with just the state variables
+   virtual void update_sd_state(
        const double * const e_np1, const double * const e_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
@@ -163,14 +174,14 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
        double & p_np1, double p_n) = 0;
 
    /// Large strain incremental update
-   virtual void update_ld_inc(
-       const double * const d_np1, const double * const d_n,
-       const double * const w_np1, const double * const w_n,
+   virtual void update_ld_inc_interface(
+       const Symmetric & d_np1, const Symmetric & d_n,
+       const Skew & w_np1, const Skew & w_n,
        double T_np1, double T_n,
        double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1, double * const B_np1,
+       Symmetric & s_np1, const Symmetric & s_n,
+       History & h_np1, const History & h_n,
+       SymSymR4 & A_np1, SymSkewR4 & B_np1,
        double & u_np1, double u_n,
        double & p_np1, double p_n);
 
@@ -211,7 +222,7 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
   SubstepModel_sd(ParameterSet & params);
 
   /// Complete substep update
-  virtual void update_sd_actual(
+  virtual void update_sd_state(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -302,7 +313,7 @@ class NEML_EXPORT SmallStrainElasticity: public NEMLModel_sd {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Small strain stress update
-  virtual void update_sd_actual(
+  virtual void update_sd_state(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -577,7 +588,7 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Small strain stress update
-  virtual void update_sd_actual(
+  virtual void update_sd_state(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -749,7 +760,7 @@ class NEML_EXPORT KMRegimeModel: public NEMLModel_sd {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// The small strain stress update
-  virtual void update_sd_actual(
+  virtual void update_sd_state(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,

--- a/include/models.h
+++ b/include/models.h
@@ -239,11 +239,10 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
 
   /// Single step update
   virtual void update_step(
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
+      double T_np1, double T_n, double t_np1, double t_n,
+      Symmetric & s_np1, const Symmetric & s_n,
+      History & h_np1, const History & h_n,
       double * const A, double * const E,
       double & u_np1, double u_n,
       double & p_np1, double p_n);
@@ -287,13 +286,13 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
   /// Do the work calculation
   virtual void work_and_energy(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
+      const Symmetric & s_np1, const Symmetric & s_n,
+      const History & h_np1, const History & h_n,
       double & u_np1, double u_n,
-      double & p_np1, double p_n) = 0;
+      double & p_np1, double p_n);
 
  protected:
   double rtol_, atol_;
@@ -458,17 +457,6 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
       const double * const h_np1, const double * const h_n,
       double * de);
 
-  /// Do the work calculation
-  virtual void work_and_energy(
-      const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n);
-
   /// Helper to return the yield stress
   double ys(double T) const;
 
@@ -538,17 +526,6 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
       const double * const s_np1, const double * const s_n,
       const double * const h_np1, const double * const h_n,
       double * const de);
-
-  /// Do the work calculation
-  virtual void work_and_energy(
-      const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
-      double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double & u_np1, double u_n,
-      double & p_np1, double p_n);
 
   /// Number of solver parameters
   virtual size_t nparams() const;
@@ -686,15 +663,15 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
       const double * const s_np1, const double * const s_n,
       const double * const h_np1, const double * const h_n,
       double * de);
-
-  /// Do the work calculation
+  
+  /// Need special call for dissipation
   virtual void work_and_energy(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
+      const Symmetric & s_np1, const Symmetric & s_n,
+      const History & h_np1, const History & h_n,
       double & u_np1, double u_n,
       double & p_np1, double p_n);
 

--- a/include/models.h
+++ b/include/models.h
@@ -259,30 +259,30 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
   /// Ignore update and take an elastic step
   virtual bool elastic_step(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_n,
-      const double * const h_n) = 0;
+      const Symmetric & s_n,
+      const History & h_n) = 0;
 
   /// Interpret the x vector
   virtual void update_internal(
       const double * const x,
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
+      double T_np1, double T_n, 
       double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n) = 0;
+      Symmetric & s_np1, const Symmetric & s_n,
+      History & h_np1, const History & h_n) = 0;
 
   /// Minus the partial derivative of the residual with respect to the strain
   virtual void strain_partial(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_np1, const double * const s_n,
-      const double * const h_np1, const double * const h_n,
-      double * const de) = 0;
+      const Symmetric & s_np1, const Symmetric & s_n,
+      const History & h_np1, const History & h_n,
+      double * de) = 0;
 
   /// Do the work calculation
   virtual void work_and_energy(
@@ -448,29 +448,29 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
   /// Take an elastic step
   virtual bool elastic_step(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_n,
-      const double * const h_n);
+      const Symmetric & s_n,
+      const History & h_n);
 
   /// Interpret the x vector
   virtual void update_internal(
       const double * const x,
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
+      double T_np1, double T_n, 
       double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n);
+      Symmetric & s_np1, const Symmetric & s_n,
+      History & h_np1, const History & h_n);
 
   /// Minus the partial derivative of the residual with respect to the strain
   virtual void strain_partial(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_np1, const double * const s_n,
-      const double * const h_np1, const double * const h_n,
+      const Symmetric & s_np1, const Symmetric & s_n,
+      const History & h_np1, const History & h_n,
       double * de);
 
   /// Helper to return the yield stress
@@ -518,30 +518,30 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
   /// Ignore update and take an elastic step
   virtual bool elastic_step(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_n,
-      const double * const h_n);
+      const Symmetric & s_n,
+      const History & h_n);
 
   /// Interpret the x vector
   virtual void update_internal(
       const double * const x,
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
+      double T_np1, double T_n, 
       double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n);
+      Symmetric & s_np1, const Symmetric & s_n,
+      History & h_np1, const History & h_n);
 
   /// Minus the partial derivative of the residual with respect to the strain
   virtual void strain_partial(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_np1, const double * const s_n,
-      const double * const h_np1, const double * const h_n,
-      double * const de);
+      const Symmetric & s_np1, const Symmetric & s_n,
+      const History & h_np1, const History & h_n,
+      double * de);
 
   /// Number of solver parameters
   virtual size_t nparams() const;
@@ -655,29 +655,29 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
   /// Take an elastic step
   virtual bool elastic_step(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_n,
-      const double * const h_n);
+      const Symmetric & s_n,
+      const History & h_n);
 
   /// Interpret the x vector
   virtual void update_internal(
       const double * const x,
-      const double * const e_np1, const double * const e_n,
-      double T_np1, double T_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
+      double T_np1, double T_n, 
       double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n);
+      Symmetric & s_np1, const Symmetric & s_n,
+      History & h_np1, const History & h_n);
 
   /// Minus the partial derivative of the residual with respect to the strain
   virtual void strain_partial(
       const TrialState * ts,
-      const double * const e_np1, const double * const e_n,
+      const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
-      const double * const s_np1, const double * const s_n,
-      const double * const h_np1, const double * const h_n,
+      const Symmetric & s_np1, const Symmetric & s_n,
+      const History & h_np1, const History & h_n,
       double * de);
   
   /// Need special call for dissipation

--- a/include/models.h
+++ b/include/models.h
@@ -789,10 +789,8 @@ class NEML_EXPORT KMRegimeModel: public NEMLModel_sd {
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
 
  private:
-  double activation_energy_(const double * const e_np1,
-                            const double * const e_n,
-                            double T_np1,
-                            double t_np1, double t_n);
+  double activation_energy_(const Symmetric & e_np1, const Symmetric & e_n,
+                            double T_np1, double t_np1, double t_n);
 
  private:
   std::vector<std::shared_ptr<NEMLModel_sd>> models_;

--- a/include/models.h
+++ b/include/models.h
@@ -23,7 +23,7 @@ namespace neml {
 /// NEML material model interface definitions
 //  All material models inherit from this base class.  It defines interfaces
 //  and provides the methods for reading in material parameters.
-class NEML_EXPORT NEMLModel: public NEMLObject {
+class NEML_EXPORT NEMLModel: public HistoryNEMLObject {
   public:
    NEMLModel(ParameterSet & params);
    virtual ~NEMLModel() {};
@@ -63,15 +63,6 @@ class NEML_EXPORT NEMLModel: public NEMLObject {
        double & u_np1, double u_n,
        double & p_np1, double p_n) = 0;
   
-   /// Number of model internal variables
-   virtual size_t nhist() const;
-   /// Populate the actual history, wrapped object
-   virtual void populate_hist(History & hist) const = 0;
-   /// Populate the actual history, raw data
-   virtual void init_hist(double * const hist) const;
-   /// Initialize the history variables, wrapped object
-   virtual void init_hist(History & hist) const = 0;
-
    /// Instantaneous thermal expansion coefficient as a function of temperature
    virtual double alpha(double T) const = 0;
    /// Elastic strain for a given stress, temperature, and history state

--- a/include/models.h
+++ b/include/models.h
@@ -114,25 +114,17 @@ class NEML_EXPORT NEMLModel: public HistoryNEMLObject {
    /// Number of static variables
    size_t nstatic() const;
 
-   /// Quickly setup history
-   History gather_history_(double * data) const;
-   History gather_history_(const double * data) const;
-   History gather_blank_history_() const;
-
    /// Quickly setup state
    History gather_state_(double * data) const;
    History gather_state_(const double * data) const;
    History gather_blank_state_() const;
 
   protected:
+   virtual void cache_history_();
    /// Split internal variables into static and actual parts
    std::tuple<History,History> split_state(const History & h) const;
 
-   /// Cache history objects with a view to increasing performance
-   void cache_history_();
-
   protected:
-   History stored_hist_;
    History stored_state_;
    History stored_static_;
 };

--- a/include/models.h
+++ b/include/models.h
@@ -97,7 +97,10 @@ class NEML_EXPORT NEMLModel: public HistoryNEMLObject {
    /// Elastic strain for a given stress, temperature, and history state
    virtual void elastic_strains(const double * const s_np1,
                                double T_np1, const double * const h_np1,
-                               double * const e_np1) const = 0;
+                               double * const e_np1) const;
+   /// Nice interface for the elastic strain calculation
+   virtual Symmetric elastic_strains_interface(const Symmetric & s_np1, 
+                                               double T_np1, const History & h_np1) const;
 
    /// Used to find the damage value from the history
    virtual double get_damage(const double *const h_np1);
@@ -202,9 +205,8 @@ class NEML_EXPORT NEMLModel_sd: public NEMLModel {
    const std::shared_ptr<const LinearElasticModel> elastic() const;
 
    /// Return the elastic strains
-   virtual void elastic_strains(const double * const s_np1,
-                               double T_np1, const double * const h_np1,
-                               double * const e_np1) const;
+   virtual Symmetric elastic_strains_interface(const Symmetric & s_np1, 
+                                               double T_np1, const History & h_np1) const;
 
    /// Used to override the linear elastic model to match another object's
    virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);

--- a/include/models.h
+++ b/include/models.h
@@ -249,7 +249,7 @@ class SubstepModel_sd: public NEMLModel_sd, public Solvable {
       double & p_np1, double p_n);
 
   /// Setup the trial state
-  virtual TrialState * setup(
+  virtual std::unique_ptr<TrialState> setup(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -423,7 +423,7 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
                  double * const J);
 
   /// Setup the trial state
-  virtual TrialState * setup(
+  virtual std::unique_ptr<TrialState> setup(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -472,12 +472,6 @@ class NEML_EXPORT SmallStrainPerfectPlasticity: public SubstepModel_sd {
   /// Helper to return the yield stress
   double ys(double T) const;
 
-  /// Setup a trial state for the solver from the input information
-  void make_trial_state(const double * const e_np1, const double * const e_n,
-                       double T_np1, double T_n, double t_np1, double t_n,
-                       const double * const s_n, const double * const h_n,
-                       SSPPTrialState & ts);
-
  private:
   std::shared_ptr<YieldSurface> surface_;
   std::shared_ptr<Interpolate> ys_;
@@ -510,7 +504,7 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
   virtual void init_state(History & h) const;
 
   /// Setup the trial state
-  virtual TrialState * setup(
+  virtual std::unique_ptr<TrialState> setup(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -568,12 +562,6 @@ class NEML_EXPORT SmallStrainRateIndependentPlasticity: public SubstepModel_sd {
   /// Return the elastic model for subobjects
   const std::shared_ptr<const LinearElasticModel> elastic() const;
 
-  /// Setup a trial state
-  void make_trial_state(const double * const e_np1, const double * const e_n,
-                       double T_np1, double T_n, double t_np1, double t_n,
-                       const double * const s_n, const double * const h_n,
-                       SSRIPTrialState & ts);
-
  private:
   std::shared_ptr<RateIndependentFlowRule> flow_;
 };
@@ -623,7 +611,7 @@ class NEML_EXPORT SmallStrainCreepPlasticity: public NEMLModel_sd, public Solvab
                  double * const J);
 
   /// Setup a trial state from known information
-  std::shared_ptr<SSCPTrialState> make_trial_state(
+  std::unique_ptr<SSCPTrialState> make_trial_state(
       const Symmetric & e_np1, const Symmetric & e_n,
       double T_np1, double T_n, double t_np1, double t_n,
       const Symmetric & s_n, const History & h_n);
@@ -664,7 +652,7 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
 
   /// Setup the trial state
-  virtual TrialState * setup(
+  virtual std::unique_ptr<TrialState> setup(
       const double * const e_np1, const double * const e_n,
       double T_np1, double T_n,
       double t_np1, double t_n,
@@ -722,12 +710,6 @@ class NEML_EXPORT GeneralIntegrator: public SubstepModel_sd {
   /// The residual and jacobian for the nonlinear solve
   virtual void RJ(const double * const x, TrialState * ts,
                  double * const R, double * const J);
-
-  /// Initialize a trial state
-  void make_trial_state(const double * const e_np1, const double * const e_n,
-                       double T_np1, double T_n, double t_np1, double t_n,
-                       const double * const s_n, const double * const h_n,
-                       GITrialState & ts);
 
   /// Set a new elastic model
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);

--- a/include/ri_flow.h
+++ b/include/ri_flow.h
@@ -14,17 +14,10 @@
 namespace neml {
 
 /// ABC describing rate independent flow
-class NEML_EXPORT RateIndependentFlowRule: public NEMLObject {
+class NEML_EXPORT RateIndependentFlowRule: public HistoryNEMLObject {
  public:
   RateIndependentFlowRule(ParameterSet & params);
   
-  /// Setup internal state
-  virtual void populate_hist(History & h) const = 0;
-  /// Setup the history at time zero
-  virtual void init_hist(History & h) const = 0;
-  /// Number of history variables, get rid of this eventually
-  virtual size_t nhist() const;
-
   /// Yield surface
   virtual void f(const double* const s, const double* const alpha, double T,
                 double & fv) const = 0;

--- a/include/ri_flow.h
+++ b/include/ri_flow.h
@@ -4,6 +4,7 @@
 #include "objects.h"
 #include "surfaces.h"
 #include "hardening.h"
+#include "history.h"
 #include "math/nemlmath.h"
 
 #include "windows.h"
@@ -16,11 +17,13 @@ namespace neml {
 class NEML_EXPORT RateIndependentFlowRule: public NEMLObject {
  public:
   RateIndependentFlowRule(ParameterSet & params);
-
-  /// Number of history variables
-  virtual size_t nhist() const = 0;
+  
+  /// Setup internal state
+  virtual void populate_hist(History & h) const = 0;
   /// Setup the history at time zero
-  virtual void init_hist(double * const h) const = 0;
+  virtual void init_hist(History & h) const = 0;
+  /// Number of history variables, get rid of this eventually
+  virtual size_t nhist() const;
 
   /// Yield surface
   virtual void f(const double* const s, const double* const alpha, double T,
@@ -66,10 +69,10 @@ class NEML_EXPORT RateIndependentAssociativeFlow: public RateIndependentFlowRule
   /// Initialize from a parameter set
   static ParameterSet parameters();
 
-  /// History size according to the HardeningRule
-  virtual size_t nhist() const;
-  /// Initialize history with the HardeningRule
-  virtual void init_hist(double * const h) const;
+  /// Setup internal state
+  virtual void populate_hist(History & h) const;
+  /// Setup the history at time zero
+  virtual void init_hist(History & h) const;
 
   /// Yield surface
   virtual void f(const double* const s, const double* const alpha, double T,
@@ -127,10 +130,10 @@ class NEML_EXPORT RateIndependentNonAssociativeHardening: public RateIndependent
   /// Initialize from a parameter set
   static ParameterSet parameters();
 
-  /// History size according to the HardeningRule
-  virtual size_t nhist() const;
-  /// Initialize history with the HardeningRule
-  virtual void init_hist(double * const h) const;
+  /// Setup internal state
+  virtual void populate_hist(History & h) const;
+  /// Setup the history at time zero
+  virtual void init_hist(History & h) const;
 
   /// Yield surface
   virtual void f(const double* const s, const double* const alpha, double T,

--- a/include/visco_flow.h
+++ b/include/visco_flow.h
@@ -15,16 +15,9 @@
 namespace neml {
 
 /// ABC describing viscoplastic flow
-class NEML_EXPORT ViscoPlasticFlowRule: public NEMLObject {
+class NEML_EXPORT ViscoPlasticFlowRule: public HistoryNEMLObject {
  public:
   ViscoPlasticFlowRule(ParameterSet & params);
-
-  /// Number of history variables
-  virtual void populate_hist(History & hist) const = 0;
-  /// Initialize history at time zero
-  virtual void init_hist(History & hist) const = 0;
-  /// Number of history variables, temporary
-  virtual size_t nhist() const;
 
   /// Scalar flow rate
   virtual void y(const double* const s, const double* const alpha, double T,

--- a/include/visco_flow.h
+++ b/include/visco_flow.h
@@ -110,10 +110,10 @@ class NEML_EXPORT SuperimposedViscoPlasticFlowRule : public ViscoPlasticFlowRule
   /// Number of individual models being summed
   size_t nmodels() const;
 
-  /// Number of history variables
-  virtual size_t nhist() const;
+  /// Populate a blank history object
+  virtual void populate_hist(History & hist) const;
   /// Initialize history at time zero
-  virtual void init_hist(double * const h) const;
+  virtual void init_hist(History & hist) const;
 
   /// Scalar flow rate
   virtual void y(const double* const s, const double* const alpha, double T,
@@ -252,7 +252,7 @@ class NEML_EXPORT PerzynaFlowRule : public ViscoPlasticFlowRule {
   /// Initialize from parameters
   static ParameterSet parameters();
 
-  /// Number of history variables
+  /// Populate a blank history object
   virtual void populate_hist(History & hist) const;
   /// Initialize history at time zero
   virtual void init_hist(History & hist) const;
@@ -308,10 +308,10 @@ class NEML_EXPORT LinearViscousFlow : public ViscoPlasticFlowRule {
   /// Initialize from parameters
   static ParameterSet parameters();
 
-  /// Number of history variables
-  virtual size_t nhist() const;
+  /// Populate a blank history object
+  virtual void populate_hist(History & hist) const;
   /// Initialize history at time zero
-  virtual void init_hist(double * const h) const;
+  virtual void init_hist(History & hist) const;
 
   /// Scalar strain rate
   virtual void y(const double* const s, const double* const alpha, double T,

--- a/include/visco_flow.h
+++ b/include/visco_flow.h
@@ -6,6 +6,7 @@
 #include "surfaces.h"
 #include "hardening.h"
 #include "interpolate.h"
+#include "history.h"
 
 #include "windows.h"
 
@@ -19,9 +20,11 @@ class NEML_EXPORT ViscoPlasticFlowRule: public NEMLObject {
   ViscoPlasticFlowRule(ParameterSet & params);
 
   /// Number of history variables
-  virtual size_t nhist() const = 0;
+  virtual void populate_hist(History & hist) const = 0;
   /// Initialize history at time zero
-  virtual void init_hist(double * const h) const = 0;
+  virtual void init_hist(History & hist) const = 0;
+  /// Number of history variables, temporary
+  virtual size_t nhist() const;
 
   /// Scalar flow rate
   virtual void y(const double* const s, const double* const alpha, double T,
@@ -257,9 +260,9 @@ class NEML_EXPORT PerzynaFlowRule : public ViscoPlasticFlowRule {
   static ParameterSet parameters();
 
   /// Number of history variables
-  virtual size_t nhist() const;
+  virtual void populate_hist(History & hist) const;
   /// Initialize history at time zero
-  virtual void init_hist(double * const h) const;
+  virtual void init_hist(History & hist) const;
 
   /// Scalar strain rate
   virtual void y(const double* const s, const double* const alpha, double T,
@@ -438,10 +441,10 @@ class NEML_EXPORT ChabocheFlowRule: public ViscoPlasticFlowRule {
   /// Return default parameters
   static ParameterSet parameters();
 
-  /// Number of history variables (from the hardening model)
-  virtual size_t nhist() const;
+  /// Number of history variables
+  virtual void populate_hist(History & hist) const;
   /// Initialize history at time zero
-  virtual void init_hist(double * const h) const;
+  virtual void init_hist(History & hist) const;
 
   // Scalar inelastic strain rate
   virtual void y(const double* const s, const double* const alpha, double T,
@@ -526,11 +529,10 @@ class NEML_EXPORT YaguchiGr91FlowRule: public ViscoPlasticFlowRule {
   /// Default parameter set
   static ParameterSet parameters();
 
-  /// Number of history variables (14)
-  virtual size_t nhist() const;
-  /// Initialize history (6 values for X1, 6 values for X2, 1 value for Q and
-  /// 1 value for sigma_a)
-  virtual void init_hist(double * const h) const;
+  /// Number of history variables
+  virtual void populate_hist(History & hist) const;
+  /// Initialize history at time zero
+  virtual void init_hist(History & hist) const;
 
   /// Scalar inelastic strain rate
   virtual void y(const double* const s, const double* const alpha, double T,

--- a/include/walker.h
+++ b/include/walker.h
@@ -28,11 +28,13 @@ class NEML_EXPORT WalkerKremplSwitchRule : public GeneralFlowRule {
   static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
   /// Initialize from parameter set
   static ParameterSet parameters();
-
+  
   /// Number of history variables
   virtual size_t nhist() const;
+  /// Setup internal state
+  virtual void populate_hist(History & hist) const;
   /// Initialize history
-  virtual void init_hist(double * const h);
+  virtual void init_hist(History & hist) const;
 
   /// Stress rate
   virtual void s(const double * const s, const double * const alpha,
@@ -510,16 +512,6 @@ class NEML_EXPORT WrappedViscoPlasticFlowRule : public ViscoPlasticFlowRule {
   /// Default constructor sets up the structs for the conversion
   WrappedViscoPlasticFlowRule(ParameterSet & params);
 
-  /// Populate a history object
-  virtual void populate_hist(History & h) const = 0;
-  /// Initialize with starting values
-  virtual void initialize_hist(History & h) const = 0;
-
-  /// Number of history variables (from the hardening model)
-  virtual size_t nhist() const;
-  /// Initialize history at time zero
-  virtual void init_hist(double * const h) const;
-
   /// Scalar inelastic strain rate
   virtual void y(const double* const s, const double* const alpha, double T,
                 double & yv) const;
@@ -660,7 +652,7 @@ class NEML_EXPORT TestFlowRule: public WrappedViscoPlasticFlowRule
 
   /// Populate a history object
   virtual void populate_hist(History & h) const;
-  virtual void initialize_hist(History & h) const;
+  virtual void init_hist(History & h) const;
 
   // Scalar inelastic strain rate
   virtual void y(const State & state, double & res) const;
@@ -705,7 +697,7 @@ class NEML_EXPORT WalkerFlowRule: public WrappedViscoPlasticFlowRule
   /// Populate a history object
   virtual void populate_hist(History & h) const;
   /// Initialize history with time zero values
-  virtual void initialize_hist(History & h) const;
+  virtual void init_hist(History & h) const;
 
   // Scalar inelastic strain rate
   virtual void y(const State & state, double & res) const;

--- a/include/walker.h
+++ b/include/walker.h
@@ -34,66 +34,44 @@ class NEML_EXPORT WalkerKremplSwitchRule : public GeneralFlowRule {
   /// Initialize history
   virtual void init_hist(History & hist) const;
 
-  /// Stress rate
-  virtual void s(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const sdot);
+ /// Stress rate
+  virtual Symmetric s(const Symmetric & s, const History & alpha, 
+                      const Symmetric & edot, double T, double Tdot);
   /// Partial of stress rate wrt stress
-  virtual void ds_ds(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot);
+  virtual SymSymR4 ds_ds(const Symmetric & s, const History & alpha, 
+                         const Symmetric & edot, double T, double Tdot);
   /// Partial of stress rate wrt history
-  virtual void ds_da(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot);
+  virtual History ds_da(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
   /// Partial of stress rate wrt strain rate
-  virtual void ds_de(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_sdot);
+  virtual SymSymR4 ds_de(const Symmetric & s, const History & alpha, 
+                         const Symmetric & edot, double T, double Tdot);
 
   /// History rate
-  virtual void a(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const adot);
+  virtual History a(const Symmetric & s, const History & alpha, 
+                    const Symmetric & edot, double T, double Tdot);
   /// Partial of history rate wrt stress
-  virtual void da_ds(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot);
+  virtual History da_ds(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
   /// Partial of history rate wrt history
-  virtual void da_da(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot);
+  virtual History da_da(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
   /// Partial of history rate wrt strain rate
-  virtual void da_de(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double * const d_adot);
+  virtual History da_de(const Symmetric & s, const History & alpha, 
+                        const Symmetric & edot, double T, double Tdot);
 
   /// The implementation needs to define inelastic dissipation
-  virtual void work_rate(const double * const s, const double * const alpha,
-                const double * const edot, double T,
-                double Tdot,
-                double & p_rate);
-
-  /// The implementation needs to define elastic strain
-  virtual void elastic_strains(const double * const s_np1, double T_np1,
-                              double * const e_np1) const;
+  virtual double work_rate(const Symmetric & s, const History & alpha, 
+                           const Symmetric & edot, double T, double Tdot);
 
   /// Set a new elastic model
   virtual void set_elastic_model(std::shared_ptr<LinearElasticModel> emodel);
   
   /// The kappa function controlling rate sensitivity (public for testing)
-  void kappa(const double * const edot, double T, double & kap);
+  double kappa(const Symmetric & edot, double T);
 
   /// Derivative of kappa wrt the strain rate (public for testing)
-  void dkappa(const double * const edot, double T, double * const dkap);
+  Symmetric dkappa(const Symmetric & edot, double T);
 
   /// Override initial guess
   virtual void override_guess(double * const x);

--- a/include/walker.h
+++ b/include/walker.h
@@ -29,8 +29,6 @@ class NEML_EXPORT WalkerKremplSwitchRule : public GeneralFlowRule {
   /// Initialize from parameter set
   static ParameterSet parameters();
   
-  /// Number of history variables
-  virtual size_t nhist() const;
   /// Setup internal state
   virtual void populate_hist(History & hist) const;
   /// Initialize history

--- a/neml/__init__.py
+++ b/neml/__init__.py
@@ -2,3 +2,5 @@ import os
 
 ndir = os.path.dirname(__file__)
 os.environ['PATH'] += os.pathsep + ndir
+
+import neml.history

--- a/src/cp/crystaldamage.cxx
+++ b/src/cp/crystaldamage.cxx
@@ -6,7 +6,7 @@ namespace neml {
 
 CrystalDamageModel::CrystalDamageModel(ParameterSet & params, 
                                        std::vector<std::string> vars) :
-    NEMLObject(params),
+    HistoryNEMLObject(params),
     varnames_(vars)
 {
 

--- a/src/cp/crystaldamage.cxx
+++ b/src/cp/crystaldamage.cxx
@@ -27,7 +27,7 @@ void CrystalDamageModel::set_varnames(std::vector<std::string> names)
   varnames_ = names;
 }
 
-void CrystalDamageModel::populate_history(History & history) const
+void CrystalDamageModel::populate_hist(History & history) const
 {
   for (auto name : varnames_)
     history.add<double>(name);
@@ -56,7 +56,7 @@ ParameterSet NilDamageModel::parameters()
   return pset;
 }
 
-void NilDamageModel::init_history(History & history) const
+void NilDamageModel::init_hist(History & history) const
 {
   history.get<double>("whatever") = 0.0;
 }
@@ -170,7 +170,7 @@ ParameterSet PlanarDamageModel::parameters()
   return pset;
 }
 
-void PlanarDamageModel::init_history(History & history) const
+void PlanarDamageModel::init_hist(History & history) const
 {
   for (auto vn : varnames_)
     history.get<double>(vn) = damage_->setup();

--- a/src/cp/crystaldamage_wrap.cxx
+++ b/src/cp/crystaldamage_wrap.cxx
@@ -11,8 +11,6 @@ namespace neml {
 PYBIND11_MODULE(crystaldamage, m) {
   m.doc() = "Crystal plasticity damage models";
 
-  py::module::import("neml.history");
-
   py::class_<CrystalDamageModel, HistoryNEMLObject,
       std::shared_ptr<CrystalDamageModel>>(m, "CrystalDamageModel")
     .def_property_readonly("nvars", &CrystalDamageModel::nvars)

--- a/src/cp/crystaldamage_wrap.cxx
+++ b/src/cp/crystaldamage_wrap.cxx
@@ -16,8 +16,6 @@ PYBIND11_MODULE(crystaldamage, m) {
     .def_property_readonly("nvars", &CrystalDamageModel::nvars)
     .def_property_readonly("varnames", &CrystalDamageModel::varnames)
     .def("set_varnames", &CrystalDamageModel::set_varnames)
-    .def("populate_history", &CrystalDamageModel::populate_history)
-    .def("init_history", &CrystalDamageModel::init_history)
     .def("projection", &CrystalDamageModel::projection)
     .def("d_projection_d_stress", &CrystalDamageModel::d_projection_d_stress)
     .def("d_projection_d_history", &CrystalDamageModel::d_projection_d_history)

--- a/src/cp/crystaldamage_wrap.cxx
+++ b/src/cp/crystaldamage_wrap.cxx
@@ -11,7 +11,9 @@ namespace neml {
 PYBIND11_MODULE(crystaldamage, m) {
   m.doc() = "Crystal plasticity damage models";
 
-  py::class_<CrystalDamageModel, NEMLObject,
+  py::module::import("neml.history");
+
+  py::class_<CrystalDamageModel, HistoryNEMLObject,
       std::shared_ptr<CrystalDamageModel>>(m, "CrystalDamageModel")
     .def_property_readonly("nvars", &CrystalDamageModel::nvars)
     .def_property_readonly("varnames", &CrystalDamageModel::varnames)

--- a/src/cp/hucocks.cxx
+++ b/src/cp/hucocks.cxx
@@ -85,13 +85,13 @@ void HuCocksPrecipitationModel::set_varnames(std::vector<std::string> vars)
   varnames_ = vars;
 }
 
-void HuCocksPrecipitationModel::populate_history(History & history) const
+void HuCocksPrecipitationModel::populate_hist(History & history) const
 {
   for (auto vn : varnames_)
     history.add<double>(vn);
 }
 
-void HuCocksPrecipitationModel::init_history(History & history) const
+void HuCocksPrecipitationModel::init_hist(History & history) const
 {
   history.get<double>(varnames_[0]) = f_init_ / fs_;
   history.get<double>(varnames_[1]) = r_init_ / rs_;
@@ -565,14 +565,14 @@ void DislocationSpacingHardening::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void DislocationSpacingHardening::populate_history(History & history) const
+void DislocationSpacingHardening::populate_hist(History & history) const
 {
   for (auto vn : varnames_) {
     history.add<double>(vn);
   }
 }
 
-void DislocationSpacingHardening::init_history(History & history) const
+void DislocationSpacingHardening::init_hist(History & history) const
 {
   for (auto vn : varnames_) {
     history.get<double>(vn) = L0_;
@@ -812,19 +812,19 @@ void HuCocksHardening::set_varnames(std::vector<std::string> vars)
   throw std::runtime_error("Cannot override varnames for HuCocksHardening");
 }
 
-void HuCocksHardening::populate_history(History & history) const
+void HuCocksHardening::populate_hist(History & history) const
 {
-  dmodel_->populate_history(history);
+  dmodel_->populate_hist(history);
   for (auto pmodel : pmodels_)
-    pmodel->populate_history(history);
+    pmodel->populate_hist(history);
 }
 
-void HuCocksHardening::init_history(History & history) const
+void HuCocksHardening::init_hist(History & history) const
 {
   history.zero();
-  dmodel_->init_history(history);
+  dmodel_->init_hist(history);
   for (auto pmodel : pmodels_)
-    pmodel->init_history(history);
+    pmodel->init_hist(history);
 }
 
 double HuCocksHardening::hist_to_tau(size_t g, size_t i, 
@@ -925,7 +925,7 @@ History HuCocksHardening::d_hist_d_s(const Symmetric & stress,
   // These are zero
   for (size_t i = 0; i < pmodels_.size(); i++) {
     History pm;
-    pmodels_[i]->populate_history(pm);
+    pmodels_[i]->populate_hist(pm);
     History zero = pm.derivative<Symmetric>().zero();
     res.add_union(zero);
   }
@@ -944,7 +944,7 @@ History HuCocksHardening::d_hist_d_h(const Symmetric & stress,
   std::vector<History> phists;
   for (auto pmodel : pmodels_) {
     History pm;
-    pmodel->populate_history(pm);
+    pmodel->populate_hist(pm);
     phists.push_back(pm.zero());
   }
 

--- a/src/cp/hucocks.cxx
+++ b/src/cp/hucocks.cxx
@@ -4,7 +4,7 @@ namespace neml {
 
 HuCocksPrecipitationModel::HuCocksPrecipitationModel(
     ParameterSet & params) :
-      NEMLObject(params),
+      HistoryNEMLObject(params),
       c0_(params.get_object_parameter_vector<Interpolate>("c0")), 
       cp_(params.get_object_parameter_vector<Interpolate>("cp")), 
       ceq_(params.get_object_parameter_vector<Interpolate>("ceq")),

--- a/src/cp/hucocks_wrap.cxx
+++ b/src/cp/hucocks_wrap.cxx
@@ -15,7 +15,7 @@ PYBIND11_MODULE(hucocks, m) {
 
   m.doc() = "Objects for the Hu & Cocks 316H model";
 
-  py::class_<HuCocksPrecipitationModel, NEMLObject,
+  py::class_<HuCocksPrecipitationModel, HistoryNEMLObject,
       std::shared_ptr<HuCocksPrecipitationModel>>(m,
                                                   "HuCocksPrecipitationModel")
     .def(py::init([](py::args args, py::kwargs kwargs)
@@ -26,8 +26,6 @@ PYBIND11_MODULE(hucocks, m) {
                   }))
     .def("varnames", &HuCocksPrecipitationModel::varnames)
     .def("set_varnames", &HuCocksPrecipitationModel::set_varnames)
-    .def("populate_history", &HuCocksPrecipitationModel::populate_history)
-    .def("init_history", &HuCocksPrecipitationModel::init_history)
     .def("f", &HuCocksPrecipitationModel::f)
     .def("r", &HuCocksPrecipitationModel::r)
     .def("N", &HuCocksPrecipitationModel::N)

--- a/src/cp/inelasticity.cxx
+++ b/src/cp/inelasticity.cxx
@@ -43,12 +43,12 @@ std::unique_ptr<NEMLObject> NoInelasticity::initialize(ParameterSet & params)
   return neml::make_unique<NoInelasticity>(params); 
 }
 
-void NoInelasticity::populate_history(History & history) const
+void NoInelasticity::populate_hist(History & history) const
 {
   return;
 }
 
-void NoInelasticity::init_history(History & history) const
+void NoInelasticity::init_hist(History & history) const
 {
   return;
 }
@@ -169,14 +169,14 @@ std::unique_ptr<NEMLObject> AsaroInelasticity::initialize(ParameterSet & params)
   return neml::make_unique<AsaroInelasticity>(params); 
 }
 
-void AsaroInelasticity::populate_history(History & history) const
+void AsaroInelasticity::populate_hist(History & history) const
 {
-  rule_->populate_history(history);
+  rule_->populate_hist(history);
 }
 
-void AsaroInelasticity::init_history(History & history) const
+void AsaroInelasticity::init_hist(History & history) const
 {
-  rule_->init_history(history);
+  rule_->init_hist(history);
 }
 
 double AsaroInelasticity::strength(const History & history, Lattice & L,
@@ -359,12 +359,12 @@ std::unique_ptr<NEMLObject> PowerLawInelasticity::initialize(ParameterSet & para
   return neml::make_unique<PowerLawInelasticity>(params);
 }
 
-void PowerLawInelasticity::populate_history(History & history) const
+void PowerLawInelasticity::populate_hist(History & history) const
 {
   return;
 }
 
-void PowerLawInelasticity::init_history(History & history) const
+void PowerLawInelasticity::init_hist(History & history) const
 {
   return;
 }
@@ -508,18 +508,18 @@ std::unique_ptr<NEMLObject> CombinedInelasticity::initialize(ParameterSet & para
   return neml::make_unique<CombinedInelasticity>(params); 
 }
 
-void CombinedInelasticity::populate_history(History & history) const
+void CombinedInelasticity::populate_hist(History & history) const
 {
   for (auto model : models_) {
-    model->populate_history(history);
+    model->populate_hist(history);
   }
   return;
 }
 
-void CombinedInelasticity::init_history(History & history) const
+void CombinedInelasticity::init_hist(History & history) const
 {
   for (auto model : models_) {
-    model->init_history(history);
+    model->init_hist(history);
   }
   return;
 }

--- a/src/cp/inelasticity.cxx
+++ b/src/cp/inelasticity.cxx
@@ -5,7 +5,7 @@
 namespace neml {
 
 InelasticModel::InelasticModel(ParameterSet & params) : 
-    NEMLObject(params)
+    HistoryNEMLObject(params)
 {
 
 }

--- a/src/cp/inelasticity_wrap.cxx
+++ b/src/cp/inelasticity_wrap.cxx
@@ -11,10 +11,8 @@ namespace neml {
 PYBIND11_MODULE(inelasticity, m) {
   m.doc() = "Inelastic models for crystal plasticity";
 
-  py::class_<InelasticModel, NEMLObject, std::shared_ptr<InelasticModel>>(m,
+  py::class_<InelasticModel, HistoryNEMLObject, std::shared_ptr<InelasticModel>>(m,
                                                               "InelasticModel")
-      .def("populate_history", &InelasticModel::populate_history)
-      .def("init_history", &InelasticModel::init_history)
       .def("strength", &InelasticModel::strength)
       .def("d_p", &InelasticModel::d_p)
       .def("d_d_p_d_stress", &InelasticModel::d_d_p_d_stress)

--- a/src/cp/kinematics.cxx
+++ b/src/cp/kinematics.cxx
@@ -3,7 +3,7 @@
 namespace neml {
 
 KinematicModel::KinematicModel(ParameterSet & params) :
-    NEMLObject(params)
+    HistoryNEMLObject(params)
 {
 }
 

--- a/src/cp/kinematics.cxx
+++ b/src/cp/kinematics.cxx
@@ -76,14 +76,14 @@ ParameterSet StandardKinematicModel::parameters()
   return pset;
 }
 
-void StandardKinematicModel::populate_history(History & history) const
+void StandardKinematicModel::populate_hist(History & history) const
 {
-  imodel_->populate_history(history);
+  imodel_->populate_hist(history);
 }
 
-void StandardKinematicModel::init_history(History & history) const
+void StandardKinematicModel::init_hist(History & history) const
 {
-  imodel_->init_history(history);
+  imodel_->init_hist(history);
 }
 
 double StandardKinematicModel::strength(const History & history, Lattice & L,
@@ -311,16 +311,16 @@ ParameterSet DamagedStandardKinematicModel::parameters()
   return pset;
 }
 
-void DamagedStandardKinematicModel::populate_history(History & history) const
+void DamagedStandardKinematicModel::populate_hist(History & history) const
 {
-  imodel_->populate_history(history);
-  dmodel_->populate_history(history);
+  imodel_->populate_hist(history);
+  dmodel_->populate_hist(history);
 }
 
-void DamagedStandardKinematicModel::init_history(History & history) const
+void DamagedStandardKinematicModel::init_hist(History & history) const
 {
-  imodel_->init_history(history);
-  dmodel_->init_history(history);
+  imodel_->init_hist(history);
+  dmodel_->init_hist(history);
 }
 
 Symmetric DamagedStandardKinematicModel::stress_rate(
@@ -602,7 +602,7 @@ Symmetric DamagedStandardKinematicModel::stress_increment(
 std::vector<std::string> DamagedStandardKinematicModel::inames_() const
 {
   History ihist;
-  imodel_->populate_history(ihist);
+  imodel_->populate_hist(ihist);
   return ihist.items();
 }
 

--- a/src/cp/kinematics_wrap.cxx
+++ b/src/cp/kinematics_wrap.cxx
@@ -11,10 +11,8 @@ namespace neml {
 PYBIND11_MODULE(kinematics, m) {
   m.doc() = "Kinematic models for crystal plasticity";
   
-  py::class_<KinematicModel, NEMLObject, std::shared_ptr<KinematicModel>>(m,
+  py::class_<KinematicModel, HistoryNEMLObject, std::shared_ptr<KinematicModel>>(m,
                                                               "KinematicModel")
-      .def("populate_history", &KinematicModel::populate_history)
-      .def("init_history", &KinematicModel::init_history)
 
       .def("strength", &KinematicModel::strength)
 

--- a/src/cp/polycrystal.cxx
+++ b/src/cp/polycrystal.cxx
@@ -33,8 +33,8 @@ void PolycrystalModel::init_hist(History & hist) const
 {
   for (size_t i = 0; i < n(); i++) {
     History subhist(hist.get_data("history_"+std::to_string(i)));
-    model_->populate_store(subhist);
-    model_->init_store_object(subhist);
+    model_->populate_hist(subhist);
+    model_->init_hist(subhist);
     model_->set_active_orientation(subhist.rawptr(), *q0s_[i]);
 
     hist.get<Symmetric>("stress_"+std::to_string(i)) = Symmetric::zero();

--- a/src/cp/postprocessors.cxx
+++ b/src/cp/postprocessors.cxx
@@ -37,7 +37,7 @@ std::unique_ptr<NEMLObject> PTRTwinReorientation::initialize(
   return neml::make_unique<PTRTwinReorientation>(params);
 }
 
-void PTRTwinReorientation::populate_history(const Lattice & L, 
+void PTRTwinReorientation::populate_hist(const Lattice & L, 
                                             History & history) const
 {
   size_t j = 0;
@@ -51,7 +51,7 @@ void PTRTwinReorientation::populate_history(const Lattice & L,
   history.add<double>("twinned");
 }
 
-void PTRTwinReorientation::init_history(const Lattice & L,
+void PTRTwinReorientation::init_hist(const Lattice & L,
                                         History & history) const
 {
   size_t j = 0;

--- a/src/cp/postprocessors_wrap.cxx
+++ b/src/cp/postprocessors_wrap.cxx
@@ -12,8 +12,8 @@ PYBIND11_MODULE(postprocessors, m) {
   m.doc() = "Crystal plasticity postprocessors";
 
   py::class_<CrystalPostprocessor, NEMLObject, std::shared_ptr<CrystalPostprocessor>>(m,"CrystalPostprocessor")
-      .def("populate_history", &CrystalPostprocessor::populate_history)
-      .def("init_history", &CrystalPostprocessor::init_history)
+      .def("populate_history", &CrystalPostprocessor::populate_hist)
+      .def("init_history", &CrystalPostprocessor::init_hist)
       .def("act", &CrystalPostprocessor::act)
       ;
 

--- a/src/cp/singlecrystal.cxx
+++ b/src/cp/singlecrystal.cxx
@@ -23,7 +23,7 @@ SingleCrystalModel::SingleCrystalModel(ParameterSet & params) :
     elastic_predictor_first_step_(params.get_parameter<bool>(
             "elastic_predictor_first_step"))
 {
-  populate_history(stored_hist_);
+  populate_hist(stored_hist_);
   
   // Really dumb way to get the names of the parameters that stay fixed during
   // the update
@@ -70,11 +70,11 @@ std::unique_ptr<NEMLObject> SingleCrystalModel::initialize(ParameterSet & params
   return neml::make_unique<SingleCrystalModel>(params);
 }
 
-void SingleCrystalModel::populate_history(History & history) const
+void SingleCrystalModel::populate_hist(History & history) const
 {
   populate_static_(history);
 
-  kinematics_->populate_history(history);
+  kinematics_->populate_hist(history);
 }
 
 void SingleCrystalModel::populate_static_(History & history) const
@@ -85,10 +85,10 @@ void SingleCrystalModel::populate_static_(History & history) const
     history.add<RankTwo>("nye");
   }
   for (auto pp : postprocessors_)
-    pp->populate_history(*lattice_, history);
+    pp->populate_hist(*lattice_, history);
 }
 
-void SingleCrystalModel::init_history(History & history) const
+void SingleCrystalModel::init_hist(History & history) const
 {
   history.get<Orientation>("rotation") = *q0_;
   history.get<Orientation>("rotation0") = *q0_;
@@ -96,9 +96,9 @@ void SingleCrystalModel::init_history(History & history) const
     history.get<RankTwo>("nye") = RankTwo({0,0,0,0,0,0,0,0,0});
   }
   for (auto pp : postprocessors_)
-    pp->init_history(*lattice_, history);
+    pp->init_hist(*lattice_, history);
 
-  kinematics_->init_history(history);
+  kinematics_->init_hist(history);
 }
 
 double SingleCrystalModel::strength(double * const hist, double T) const
@@ -328,18 +328,6 @@ void SingleCrystalModel::attempt_update_ld_inc_(
   // Update model based on any post-processors
   for (auto pp : postprocessors_)
     pp->act(*this, local_lattice, T_np1, D, W, HF_np1, HF_n);
-}
-
-size_t SingleCrystalModel::nhist() const
-{
-  return stored_hist_.size();
-}
-
-void SingleCrystalModel::init_hist(double * const hist) const
-{
-  std::fill(hist, hist+nhist(), 0.0); // Shuts it up about initialized memory
-  History h = gather_history_(hist);
-  init_history(h);
 }
 
 double SingleCrystalModel::alpha(double T) const

--- a/src/cp/singlecrystal_wrap.cxx
+++ b/src/cp/singlecrystal_wrap.cxx
@@ -27,8 +27,6 @@ PYBIND11_MODULE(singlecrystal, m) {
                                                                       kwargs,
                                                                       {"kinematics", "lattice"});
                     }))
-      .def("populate_history", &SingleCrystalModel::populate_history)
-      .def("init_history", &SingleCrystalModel::init_history)
       .def("strength",
            [](SingleCrystalModel & m, py::array_t<double, py::array::c_style> h, double T) -> double
            {

--- a/src/cp/slipharden.cxx
+++ b/src/cp/slipharden.cxx
@@ -5,7 +5,7 @@
 namespace neml {
 
 SlipHardening::SlipHardening(ParameterSet & params): 
-    NEMLObject(params)
+    HistoryNEMLObject(params)
 {
 
 }

--- a/src/cp/slipharden.cxx
+++ b/src/cp/slipharden.cxx
@@ -25,7 +25,7 @@ History SlipHardening::cache(CacheType type) const
 void SlipHardening::init_cache_()
 {
   blank_ = make_unique<History>();
-  populate_history(*blank_);
+  populate_hist(*blank_);
   blank_->zero();
 
   double_ = make_unique<History>((*blank_).derivative<double>());
@@ -91,11 +91,11 @@ void FixedStrengthHardening::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void FixedStrengthHardening::populate_history(History & history) const
+void FixedStrengthHardening::populate_hist(History & history) const
 {
 }
 
-void FixedStrengthHardening::init_history(History & history) const
+void FixedStrengthHardening::init_hist(History & history) const
 {
 }
 
@@ -199,14 +199,14 @@ void VocePerSystemHardening::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void VocePerSystemHardening::populate_history(History & history) const
+void VocePerSystemHardening::populate_hist(History & history) const
 {
   for (auto vn : varnames_) {
     history.add<double>(vn);
   }
 }
 
-void VocePerSystemHardening::init_history(History & history) const
+void VocePerSystemHardening::init_hist(History & history) const
 {
   size_t i = 0;
   for (auto vn : varnames_) {
@@ -383,14 +383,14 @@ void FASlipHardening::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void FASlipHardening::populate_history(History & history) const
+void FASlipHardening::populate_hist(History & history) const
 {
   for (auto vn : varnames_) {
     history.add<double>(vn);
   }
 }
 
-void FASlipHardening::init_history(History & history) const
+void FASlipHardening::init_hist(History & history) const
 {
   size_t i = 0;
   for (auto vn : varnames_) {
@@ -563,14 +563,14 @@ void GeneralLinearHardening::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void GeneralLinearHardening::populate_history(History & history) const
+void GeneralLinearHardening::populate_hist(History & history) const
 {
   for (auto vn : varnames_) {
     history.add<double>(vn);
   }
 }
 
-void GeneralLinearHardening::init_history(History & history) const
+void GeneralLinearHardening::init_hist(History & history) const
 {
   size_t i = 0;
   for (auto vn : varnames_) {
@@ -790,14 +790,14 @@ void SimpleLinearHardening::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void SimpleLinearHardening::populate_history(History & history) const
+void SimpleLinearHardening::populate_hist(History & history) const
 {
   for (auto vn : varnames_) {
     history.add<double>(vn);
   }
 }
 
-void SimpleLinearHardening::init_history(History & history) const
+void SimpleLinearHardening::init_hist(History & history) const
 {
   size_t i = 0;
   for (auto vn : varnames_) {
@@ -1006,14 +1006,14 @@ void LANLTiModel::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void LANLTiModel::populate_history(History & history) const
+void LANLTiModel::populate_hist(History & history) const
 {
   for (auto vn : varnames_) {
     history.add<double>(vn);
   }
 }
 
-void LANLTiModel::init_history(History & history) const
+void LANLTiModel::init_hist(History & history) const
 {
   for (size_t i = 0; i < size(); i++) {
     if (i < nslip_()) {
@@ -1271,12 +1271,12 @@ void SlipSingleStrengthHardening::set_varnames(std::vector<std::string> vars)
   init_cache_();
 }
 
-void SlipSingleStrengthHardening::populate_history(History & history) const
+void SlipSingleStrengthHardening::populate_hist(History & history) const
 {
   history.add<double>(var_name_);
 }
 
-void SlipSingleStrengthHardening::init_history(History & history) const
+void SlipSingleStrengthHardening::init_hist(History & history) const
 {
   history.get<double>(var_name_) = init_strength();
 }
@@ -1429,14 +1429,14 @@ ParameterSet SumSlipSingleStrengthHardening::parameters()
   return pset;
 }
 
-void SumSlipSingleStrengthHardening::populate_history(History & history) const
+void SumSlipSingleStrengthHardening::populate_hist(History & history) const
 {
   for (size_t i = 0; i < nmodels(); i++) {
     history.add<double>("strength"+std::to_string(i));
   }
 }
 
-void SumSlipSingleStrengthHardening::init_history(History & history) const
+void SumSlipSingleStrengthHardening::init_hist(History & history) const
 {
   for (size_t i = 0; i < nmodels(); i++) {
     history.get<double>("strength"+std::to_string(i)) = models_[i]->init_strength();

--- a/src/cp/slipharden_wrap.cxx
+++ b/src/cp/slipharden_wrap.cxx
@@ -11,7 +11,9 @@ namespace neml {
 PYBIND11_MODULE(slipharden, m) {
   m.doc() = "Crystal plasticity slip rate relations";
 
-  py::class_<SlipHardening, NEMLObject, std::shared_ptr<SlipHardening>>(m, "SlipHardening")
+  py::module::import("neml.history");
+
+  py::class_<SlipHardening, HistoryNEMLObject, std::shared_ptr<SlipHardening>>(m, "SlipHardening")
       .def_property_readonly("varnames", &SlipHardening::varnames)
       .def("set_varnames", &SlipHardening::set_varnames)
       .def("hist_to_tau", &SlipHardening::hist_to_tau)

--- a/src/cp/slipharden_wrap.cxx
+++ b/src/cp/slipharden_wrap.cxx
@@ -14,8 +14,6 @@ PYBIND11_MODULE(slipharden, m) {
   py::class_<SlipHardening, NEMLObject, std::shared_ptr<SlipHardening>>(m, "SlipHardening")
       .def_property_readonly("varnames", &SlipHardening::varnames)
       .def("set_varnames", &SlipHardening::set_varnames)
-      .def("populate_history", &SlipHardening::populate_history)
-      .def("init_history", &SlipHardening::init_history)
       .def("hist_to_tau", &SlipHardening::hist_to_tau)
       .def("d_hist_to_tau", &SlipHardening::d_hist_to_tau)
       .def("hist", &SlipHardening::hist)

--- a/src/cp/slipharden_wrap.cxx
+++ b/src/cp/slipharden_wrap.cxx
@@ -11,8 +11,6 @@ namespace neml {
 PYBIND11_MODULE(slipharden, m) {
   m.doc() = "Crystal plasticity slip rate relations";
 
-  py::module::import("neml.history");
-
   py::class_<SlipHardening, HistoryNEMLObject, std::shared_ptr<SlipHardening>>(m, "SlipHardening")
       .def_property_readonly("varnames", &SlipHardening::varnames)
       .def("set_varnames", &SlipHardening::set_varnames)

--- a/src/cp/sliprules.cxx
+++ b/src/cp/sliprules.cxx
@@ -3,7 +3,7 @@
 namespace neml {
 
 SlipRule::SlipRule(ParameterSet & params) :
-    NEMLObject(params)
+    HistoryNEMLObject(params)
 {
 
 }

--- a/src/cp/sliprules.cxx
+++ b/src/cp/sliprules.cxx
@@ -87,17 +87,17 @@ size_t SlipMultiStrengthSlipRule::nstrength() const
   return strengths_.size();
 }
 
-void SlipMultiStrengthSlipRule::populate_history(History & history) const
+void SlipMultiStrengthSlipRule::populate_hist(History & history) const
 {
   for (auto strength : strengths_) {
-    strength->populate_history(history);
+    strength->populate_hist(history);
   }
 }
 
-void SlipMultiStrengthSlipRule::init_history(History & history) const
+void SlipMultiStrengthSlipRule::init_hist(History & history) const
 {
   for (auto strength : strengths_) {
-    strength->init_history(history);
+    strength->init_hist(history);
   }
 }
 

--- a/src/cp/sliprules_wrap.cxx
+++ b/src/cp/sliprules_wrap.cxx
@@ -12,8 +12,6 @@ PYBIND11_MODULE(sliprules, m) {
   m.doc() = "Crystal plasticity slip rate relations";
 
   py::class_<SlipRule, NEMLObject, std::shared_ptr<SlipRule>>(m, "SlipRule")
-      .def("populate_history", &SlipRule::populate_history)
-      .def("init_history", &SlipRule::init_history)
       .def("strength", &SlipRule::strength)
       .def("slip", &SlipRule::slip)
       .def("d_slip_d_s", &SlipRule::d_slip_d_s)

--- a/src/cp/sliprules_wrap.cxx
+++ b/src/cp/sliprules_wrap.cxx
@@ -11,7 +11,9 @@ namespace neml {
 PYBIND11_MODULE(sliprules, m) {
   m.doc() = "Crystal plasticity slip rate relations";
 
-  py::class_<SlipRule, NEMLObject, std::shared_ptr<SlipRule>>(m, "SlipRule")
+  py::module::import("neml.history");
+
+  py::class_<SlipRule, HistoryNEMLObject, std::shared_ptr<SlipRule>>(m, "SlipRule")
       .def("strength", &SlipRule::strength)
       .def("slip", &SlipRule::slip)
       .def("d_slip_d_s", &SlipRule::d_slip_d_s)

--- a/src/cp/sliprules_wrap.cxx
+++ b/src/cp/sliprules_wrap.cxx
@@ -11,8 +11,6 @@ namespace neml {
 PYBIND11_MODULE(sliprules, m) {
   m.doc() = "Crystal plasticity slip rate relations";
 
-  py::module::import("neml.history");
-
   py::class_<SlipRule, HistoryNEMLObject, std::shared_ptr<SlipRule>>(m, "SlipRule")
       .def("strength", &SlipRule::strength)
       .def("slip", &SlipRule::slip)

--- a/src/creep.cxx
+++ b/src/creep.cxx
@@ -16,18 +16,14 @@ ScalarCreepRule::ScalarCreepRule(ParameterSet & params) :
 }
 
 // Scalar creep default derivatives for time and temperature
-void ScalarCreepRule::dg_dt(double seq, double eeq, double t, double T,
-                           double & dg) const
+double ScalarCreepRule::dg_dt(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
-
+  return 0.0;
 }
 
-void ScalarCreepRule::dg_dT(double seq, double eeq, double t, double T,
-                           double & dg) const
+double ScalarCreepRule::dg_dT(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
-
+  return 0.0;
 }
 
 // Implementation of power law creep
@@ -60,21 +56,21 @@ std::unique_ptr<NEMLObject> PowerLawCreep::initialize(ParameterSet & params)
 }
 
 
-void PowerLawCreep::g(double seq, double eeq, double t, double T, double & g) const
+double PowerLawCreep::g(double seq, double eeq, double t, double T) const
 {
-  g = A_->value(T) * pow(seq, n_->value(T));
+  return A_->value(T) * pow(seq, n_->value(T));
 }
 
-void PowerLawCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double PowerLawCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   double nv = n_->value(T);
 
-  dg = A_->value(T) * nv * pow(seq, nv - 1.0);
+  return A_->value(T) * nv * pow(seq, nv - 1.0);
 }
 
-void PowerLawCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double PowerLawCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
 double PowerLawCreep::A(double T) const
@@ -117,22 +113,22 @@ std::unique_ptr<NEMLObject> NormalizedPowerLawCreep::initialize(ParameterSet & p
 }
 
 
-void NormalizedPowerLawCreep::g(double seq, double eeq, double t, double T, double & g) const
+double NormalizedPowerLawCreep::g(double seq, double eeq, double t, double T) const
 {
-  g = pow(seq / s0_->value(T), n_->value(T));
+  return pow(seq / s0_->value(T), n_->value(T));
 }
 
-void NormalizedPowerLawCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double NormalizedPowerLawCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   double nv = n_->value(T);
   double s0v = s0_->value(T);
 
-  dg = nv / s0v * pow(seq / s0v, nv - 1.0);
+  return nv / s0v * pow(seq / s0v, nv - 1.0);
 }
 
-void NormalizedPowerLawCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double NormalizedPowerLawCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
 // Implementation of the Blackburn minimum creep rate equation
@@ -171,39 +167,38 @@ std::unique_ptr<NEMLObject> BlackburnMinimumCreep::initialize(ParameterSet & par
 }
 
 
-void BlackburnMinimumCreep::g(double seq, double eeq, double t, double T, double & g) const
+double BlackburnMinimumCreep::g(double seq, double eeq, double t, double T) const
 {
   double A = A_->value(T);
   double n = n_->value(T);
   double beta = beta_->value(T);
 
-  g = A * pow(sinh(beta * seq / n), n) * exp(-Q_ / (R_ * T));
-
+  return A * pow(sinh(beta * seq / n), n) * exp(-Q_ / (R_ * T));
 }
 
-void BlackburnMinimumCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double BlackburnMinimumCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   double A = A_->value(T);
   double n = n_->value(T);
   double beta = beta_->value(T);
 
-  dg = A * beta * exp(-Q_ / (R_ * T)) * cosh(beta * seq / n) * 
+  return A * beta * exp(-Q_ / (R_ * T)) * cosh(beta * seq / n) * 
       pow(sinh(beta * seq / n), n - 1.0);
 
 }
 
-void BlackburnMinimumCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double BlackburnMinimumCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
-void BlackburnMinimumCreep::dg_dT(double seq, double eeq, double t, double T, double & dg) const
+double BlackburnMinimumCreep::dg_dT(double seq, double eeq, double t, double T) const
 {
   double A = A_->value(T);
   double n = n_->value(T);
   double beta = beta_->value(T);
 
-  dg = A * pow(sinh(beta * seq / n), n) * exp(-Q_ / (R_ * T)) * Q_ / (R_ * T * T);
+  return A * pow(sinh(beta * seq / n), n) * exp(-Q_ / (R_ * T)) * Q_ / (R_ * T * T);
 }
 
 // Implementation of the Swindeman minimum creep rate equation
@@ -243,27 +238,24 @@ std::unique_ptr<NEMLObject> SwindemanMinimumCreep::initialize(ParameterSet & par
 }
 
 
-void SwindemanMinimumCreep::g(double seq, double eeq, double t, double T, double & g) const
+double SwindemanMinimumCreep::g(double seq, double eeq, double t, double T) const
 {
-  g = C_ * pow(seq, n_) * exp(V_ * seq) * exp(-Q_/(T+shift_));
-
+  return C_ * pow(seq, n_) * exp(V_ * seq) * exp(-Q_/(T+shift_));
 }
 
-void SwindemanMinimumCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double SwindemanMinimumCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
-
-  dg = C_ * exp(-Q_/(T+shift_)) * (n_ + seq * V_) * exp(seq * V_) * pow(seq, n_ - 1.0);
-
+  return C_ * exp(-Q_/(T+shift_)) * (n_ + seq * V_) * exp(seq * V_) * pow(seq, n_ - 1.0);
 }
 
-void SwindemanMinimumCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double SwindemanMinimumCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
-void SwindemanMinimumCreep::dg_dT(double seq, double eeq, double t, double T, double & dg) const
+double SwindemanMinimumCreep::dg_dT(double seq, double eeq, double t, double T) const
 {
-  dg = C_ * pow(seq, n_) * exp(V_ * seq) * exp(-Q_/(T+shift_)) * Q_ /
+  return C_ * pow(seq, n_) * exp(V_ * seq) * exp(-Q_/(T+shift_)) * Q_ /
       ((T+shift_) * (T+shift_)); 
 }
 
@@ -310,31 +302,29 @@ std::unique_ptr<NEMLObject> RegionKMCreep::initialize(ParameterSet & params)
   return neml::make_unique<RegionKMCreep>(params); 
 }
 
-void RegionKMCreep::g(double seq, double eeq, double t, double T, double & g) const
+double RegionKMCreep::g(double seq, double eeq, double t, double T) const
 {
   double A, B;
   select_region_(seq, T, A, B);
   double G = emodel_->G(T);
   double C1 = -G * b3_ / (kboltz_*(T+shift_));
 
-  g = eps0_ * exp(C1*B) * pow(seq / G, C1 * A);
-
+  return eps0_ * exp(C1*B) * pow(seq / G, C1 * A);
 }
 
-void RegionKMCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double RegionKMCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   double A, B;
   select_region_(seq, T, A, B);
   double G = emodel_->G(T);
   double C1 = -G * b3_ / (kboltz_*(T+shift_));
   
-  dg = eps0_ * exp(C1*B) * C1 * A / G * pow(seq / G, C1 * A - 1.0);
-
+  return eps0_ * exp(C1*B) * C1 * A / G * pow(seq / G, C1 * A - 1.0);
 }
 
-void RegionKMCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double RegionKMCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
 void RegionKMCreep::select_region_(double seq, double T, double & Ai, double & Bi) const
@@ -398,7 +388,7 @@ std::unique_ptr<NEMLObject> NortonBaileyCreep::initialize(ParameterSet & params)
   return neml::make_unique<NortonBaileyCreep>(params); 
 }
 
-void NortonBaileyCreep::g(double seq, double eeq, double t, double T, double & g) const
+double NortonBaileyCreep::g(double seq, double eeq, double t, double T) const
 {
   double A = A_->value(T);
   double m = m_->value(T);
@@ -412,11 +402,10 @@ void NortonBaileyCreep::g(double seq, double eeq, double t, double T, double & g
     eeq = std::numeric_limits<double>::epsilon(); 
   }
 
-  g = m * pow(A, 1.0 / m) * pow(seq, n / m) * pow(eeq, (m - 1.0) / m); 
-
+  return m * pow(A, 1.0 / m) * pow(seq, n / m) * pow(eeq, (m - 1.0) / m); 
 }
 
-void NortonBaileyCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double NortonBaileyCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   double A = A_->value(T);
   double m = m_->value(T);
@@ -430,11 +419,10 @@ void NortonBaileyCreep::dg_ds(double seq, double eeq, double t, double T, double
     eeq = std::numeric_limits<double>::epsilon(); 
   }
 
-  dg = n * pow(A, 1.0 / m) * pow(seq, n / m - 1.0) * pow(eeq, (m - 1.0) / m);
-
+  return n * pow(A, 1.0 / m) * pow(seq, n / m - 1.0) * pow(eeq, (m - 1.0) / m);
 }
 
-void NortonBaileyCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double NortonBaileyCreep::dg_de(double seq, double eeq, double t, double T) const
 {
   double A = A_->value(T);
   double m = m_->value(T);
@@ -448,8 +436,7 @@ void NortonBaileyCreep::dg_de(double seq, double eeq, double t, double T, double
     eeq = std::numeric_limits<double>::epsilon(); 
   }
 
-  dg = (m - 1) * pow(A, 1.0 / m) * pow(seq, n / m) * pow(eeq, -1.0 / m);
-
+  return (m - 1) * pow(A, 1.0 / m) * pow(seq, n / m) * pow(eeq, -1.0 / m);
 }
 
 double NortonBaileyCreep::A(double T) const
@@ -508,26 +495,23 @@ std::unique_ptr<NEMLObject> MukherjeeCreep::initialize(ParameterSet & params)
   return neml::make_unique<MukherjeeCreep>(params); 
 }
 
-void MukherjeeCreep::g(double seq, double eeq, double t, double T, 
-                      double & g) const
+double MukherjeeCreep::g(double seq, double eeq, double t, double T) const
 {
   double mu = emodel_->G(T);
   double Dv = D0_ * exp(-Q_ / (R_ * T));
-  g = A_ * Dv * mu * b_ / (k_ * T) * pow(seq / mu, n_);
+  return A_ * Dv * mu * b_ / (k_ * T) * pow(seq / mu, n_);
 }
 
-void MukherjeeCreep::dg_ds(double seq, double eeq, double t, double T,
-                          double & dg) const
+double MukherjeeCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   double mu = emodel_->G(T);
   double Dv = D0_ * exp(-Q_ / (R_ * T));
-  dg = n_ * A_ * Dv * mu * b_ / (k_ * T) * pow(seq / mu, n_ - 1.0) / mu;
+  return n_ * A_ * Dv * mu * b_ / (k_ * T) * pow(seq / mu, n_ - 1.0) / mu;
 }
 
-void MukherjeeCreep::dg_de(double seq, double eeq, double t, double T,
-                          double & dg) const
+double MukherjeeCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
 double MukherjeeCreep::A() const
@@ -591,27 +575,27 @@ ParameterSet GenericCreep::parameters()
   return pset;
 }
 
-void GenericCreep::g(double seq, double eeq, double t, double T, double & g) const
+double GenericCreep::g(double seq, double eeq, double t, double T) const
 {
-  g = exp(cfn_->value(log(seq)));
+  return exp(cfn_->value(log(seq)));
 }
 
-void GenericCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double GenericCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   double f = cfn_->value(log(seq));
   double df = cfn_->derivative(log(seq));
   
   if (seq > 0.0) {
-    dg = f * exp(f) * df / seq;
+    return f * exp(f) * df / seq;
   }
   else {
-    dg = 0.0;
+    return 0.0;
   }
 }
 
-void GenericCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double GenericCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
 // Setup for solve
@@ -734,41 +718,41 @@ std::unique_ptr<NEMLObject> MinCreep225Cr1MoCreep::initialize(ParameterSet & par
 }
 
 
-void MinCreep225Cr1MoCreep::g(double seq, double eeq, double t, double T, double & g) const
+double MinCreep225Cr1MoCreep::g(double seq, double eeq, double t, double T) const
 {
   if (seq < 60.0) {
-    g = e1_(seq, T);
+    return e1_(seq, T);
   }
   else {
     if (T <= (13.571 * pow(seq, 0.68127) - 1.8 * seq + 710.78)) {
-      g = e1_(seq, T);
+      return e1_(seq, T);
     }
     else {
-      g = e2_(seq, T);
+      return e2_(seq, T);
     }
   }
 
 }
 
-void MinCreep225Cr1MoCreep::dg_ds(double seq, double eeq, double t, double T, double & dg) const
+double MinCreep225Cr1MoCreep::dg_ds(double seq, double eeq, double t, double T) const
 {
   if (seq < 60.0) {
-    dg = de1_(seq, T);
+    return de1_(seq, T);
   }
   else {
     if (T <= (13.571 * pow(seq, 0.68127) - 1.8 * seq + 710.78)) {
-      dg = de1_(seq, T);
+      return de1_(seq, T);
     }
     else {
-      dg = de2_(seq, T);
+      return de2_(seq, T);
     }
   }
 
 }
 
-void MinCreep225Cr1MoCreep::dg_de(double seq, double eeq, double t, double T, double & dg) const
+double MinCreep225Cr1MoCreep::dg_de(double seq, double eeq, double t, double T) const
 {
-  dg = 0.0;
+  return 0.0;
 }
 
 double MinCreep225Cr1MoCreep::e1_(double seq, double T) const
@@ -835,16 +819,8 @@ std::unique_ptr<NEMLObject> J2CreepModel::initialize(ParameterSet & params)
 
 Symmetric J2CreepModel::f(const Symmetric & s, const Symmetric & e, double t, double T) const
 {
-  // Gather the effective stresses
-  double se = seq(s);
-  double ee = eeq(e);
-
-  // Get the rate
-  double rate;
-  rule_->g(se, ee, t, T, rate);
-
   // Rate * direction
-  return 3.0/2.0 * sdir(s) * rate;
+  return 3.0/2.0 * sdir(s) * rule_->g(seq(s), eeq(e), t, T);
 }
 
 SymSymR4 J2CreepModel::df_ds(const Symmetric & s, const Symmetric & e, double t, double T) const
@@ -857,12 +833,10 @@ SymSymR4 J2CreepModel::df_ds(const Symmetric & s, const Symmetric & e, double t,
   Symmetric dir = sdir(s);
 
   // Get the rate
-  double rate;
-  rule_->g(se, ee, t, T, rate);
+  double rate = rule_->g(se, ee, t, T);
 
   // Get the rate derivative
-  double drate;
-  rule_->dg_ds(se, ee, t, T, drate);
+  double drate = rule_->dg_ds(se, ee, t, T);
 
   SymSymR4 ID = SymSymR4::id_dev() * 3.0 / 2.0;
 
@@ -879,13 +853,8 @@ SymSymR4 J2CreepModel::df_ds(const Symmetric & s, const Symmetric & e, double t,
 
 SymSymR4 J2CreepModel::df_de(const Symmetric & s, const Symmetric & e, double t, double T) const
 {
-  // Gather the effective stresses
-  double se = seq(s);
-  double ee = eeq(e);
- 
   // Get the derivative
-  double drate;
-  rule_->dg_de(se, ee, t, T, drate);
+  double drate = rule_->dg_de(seq(s), eeq(e), t, T);
 
   // Get the stress and strain direction
   Symmetric s_dir = sdir(s);
@@ -896,28 +865,12 @@ SymSymR4 J2CreepModel::df_de(const Symmetric & s, const Symmetric & e, double t,
 
 Symmetric J2CreepModel::df_dt(const Symmetric & s, const Symmetric & e, double t, double T) const 
 {
-  // Gather the effective quantities
-  double se = seq(s);
-  double ee = eeq(e);
- 
-  // Get the derivative
-  double drate;
-  rule_->dg_dt(se, ee, t, T, drate);
-
-  return 3.0/2.0 * sdir(s) * drate;
+  return 3.0/2.0 * sdir(s) * rule_->dg_dt(seq(s), eeq(e), t, T);
 }
 
 Symmetric J2CreepModel::df_dT(const Symmetric & s, const Symmetric & e, double t, double T) const
 {
-   // Gather the effective quantities
-  double se = seq(s);
-  double ee = eeq(e);
- 
-  // Get the derivative
-  double drate;
-  rule_->dg_dT(se, ee, t, T, drate);
-
-  return 3.0/2.0 * sdir(s) * drate; 
+  return 3.0/2.0 * sdir(s) * rule_->dg_dT(seq(s), eeq(e), t, T); 
 }
 
 // Helpers for J2 plasticity

--- a/src/creep_wrap.cxx
+++ b/src/creep_wrap.cxx
@@ -35,46 +35,11 @@ PYBIND11_MODULE(creep, m) {
 
            }, "Update to the next creep strain & tangent derivative.")
 
-      .def("f",
-           [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
-           {
-            auto fv = alloc_vec<double>(6);
-            m.f(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(fv));
-            return fv;
-           }, "Evaluate creep rate.")
-
-      .def("df_ds",
-           [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
-           {
-            auto dfv = alloc_mat<double>(6,6);
-            m.df_ds(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            return dfv;
-           }, "Evaluate creep rate derivative wrt stress.")
-
-      .def("df_de",
-           [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
-           {
-            auto dfv = alloc_mat<double>(6,6);
-            m.df_de(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            return dfv;
-           }, "Evaluate creep rate derivative wrt strain.")
-
-      .def("df_dt",
-           [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
-           {
-            auto dfv = alloc_vec<double>(6);
-            m.df_dt(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            return dfv;
-           }, "Evaluate creep rate derivative wrt time.")
-
-      .def("df_dT",
-           [](const CreepModel & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> e, double t, double T) -> py::array_t<double>
-           {
-            auto dfv = alloc_vec<double>(6);
-            m.df_dT(arr2ptr<double>(s), arr2ptr<double>(e), t, T, arr2ptr<double>(dfv));
-            return dfv;
-           }, "Evaluate creep rate derivative wrt temperature.")
-
+      .def("f", &CreepModel::f, "Evaluate creep rate.")
+      .def("df_ds", &CreepModel::df_ds, "Evaluate creep rate derivative wrt stress.")
+      .def("df_de", &CreepModel::df_de, "Evaluate creep rate derivative wrt strain.")
+      .def("df_dt", &CreepModel::df_dt, "Evaluate creep rate derivative wrt time.")
+      .def("df_dT", &CreepModel::df_dT, "Evaluate creep rate derivative wrt temperature.")
       
       .def("make_trial_state",
            [](CreepModel & m, py::array_t<double, py::array::c_style> s_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n) -> std::unique_ptr<CreepModelTrialState>

--- a/src/creep_wrap.cxx
+++ b/src/creep_wrap.cxx
@@ -26,8 +26,11 @@ PYBIND11_MODULE(creep, m) {
             auto e_np1 = alloc_vec<double>(6);
             auto A_np1 = alloc_mat<double>(6,6);
 
-            m.update(arr2ptr<double>(s_np1), arr2ptr<double>(e_np1), arr2ptr<double>(e_n), T_np1, T_n, t_np1, t_n, arr2ptr<double>(A_np1));
+            Symmetric E_np1(arr2ptr<double>(e_np1));
+            SymSymR4 AA_np1(arr2ptr<double>(A_np1));
 
+            m.update(Symmetric(arr2ptr<double>(s_np1)), E_np1, Symmetric(arr2ptr<double>(e_n)), T_np1, T_n, t_np1, t_n, AA_np1);
+            
             return std::make_tuple(e_np1, A_np1);
 
            }, "Update to the next creep strain & tangent derivative.")
@@ -76,13 +79,7 @@ PYBIND11_MODULE(creep, m) {
       .def("make_trial_state",
            [](CreepModel & m, py::array_t<double, py::array::c_style> s_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n) -> std::unique_ptr<CreepModelTrialState>
            {
-            std::unique_ptr<CreepModelTrialState> ts(new CreepModelTrialState);
-            m.make_trial_state(arr2ptr<double>(s_np1),
-                                         arr2ptr<double>(e_n),
-                                         T_np1, T_n, t_np1, t_n, *ts);
-
-            return ts;
-
+           return m.make_trial_state(Symmetric(arr2ptr<double>(s_np1)), Symmetric(arr2ptr<double>(e_n)), T_np1, T_n, t_np1, t_n);
            }, "Setup trial state for solve")
     ;
 

--- a/src/creep_wrap.cxx
+++ b/src/creep_wrap.cxx
@@ -56,45 +56,11 @@ PYBIND11_MODULE(creep, m) {
     ;
 
   py::class_<ScalarCreepRule, NEMLObject, std::shared_ptr<ScalarCreepRule>>(m, "ScalarCreepRule")
-      .def("g",
-           [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
-           {
-            double gv;
-            m.g(seq, eeq, t, T, gv);
-            return gv;
-           }, "Evaluate creep rate.")
-
-      .def("dg_ds",
-           [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
-           {
-            double gv;
-            m.dg_ds(seq, eeq, t, T, gv);
-            return gv;
-           }, "Evaluate creep rate derivative wrt stress.")
-
-      .def("dg_de",
-           [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
-           {
-            double gv;
-            m.dg_de(seq, eeq, t, T, gv);
-            return gv;
-           }, "Evaluate creep rate derivative wrt strain.")
-
-      .def("dg_dt",
-           [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
-           {
-            double gv;
-            m.dg_dt(seq, eeq, t, T, gv);
-            return gv;
-           }, "Evaluate creep rate wrt time.")
-
-      .def("dg_dT",
-           [](const ScalarCreepRule & m, double seq, double eeq, double t, double T) -> double
-           {
-            double gv;
-            m.dg_dT(seq, eeq, t, T, gv);
-            return gv;
-           }, "Evaluate creep rate wrt temperature.")
+      .def("g", &ScalarCreepRule::g, "Evaluate the creep rate")
+      .def("dg_ds", &ScalarCreepRule::dg_ds, "Evaluate creep rate derivative wrt stress.")
+      .def("dg_de", &ScalarCreepRule::dg_de, "Evaluate creep rate derivative wrt strain.")
+      .def("dg_dt", &ScalarCreepRule::dg_dt, "Evaluate creep rate derivative wrt time.")
+      .def("dg_dT", &ScalarCreepRule::dg_dT, "Evaluate creep rate derivative wrt temperature.")
       ;
   
   py::class_<PowerLawCreep, ScalarCreepRule, std::shared_ptr<PowerLawCreep>>(m, "PowerLawCreep")

--- a/src/damage.cxx
+++ b/src/damage.cxx
@@ -13,14 +13,14 @@ NEMLDamagedModel_sd::NEMLDamagedModel_sd(ParameterSet & params) :
 
 }
 
-void NEMLDamagedModel_sd::populate_hist(History & hist) const
+void NEMLDamagedModel_sd::populate_state(History & hist) const
 {
   populate_damage(hist);
   base_->set_variable_prefix(get_variable_prefix());
   base_->populate_hist(hist);
 }
 
-void NEMLDamagedModel_sd::init_hist(History & hist) const
+void NEMLDamagedModel_sd::init_state(History & hist) const
 {
   init_damage(hist);
   base_->init_hist(hist);
@@ -81,7 +81,7 @@ std::unique_ptr<NEMLObject> NEMLScalarDamagedModel_sd::initialize(ParameterSet &
   return neml::make_unique<NEMLScalarDamagedModel_sd>(params); 
 }
 
-void NEMLScalarDamagedModel_sd::update_sd(
+void NEMLScalarDamagedModel_sd::update_sd_actual(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n,
     double t_np1, double t_n,

--- a/src/damage.cxx
+++ b/src/damage.cxx
@@ -13,16 +13,10 @@ NEMLDamagedModel_sd::NEMLDamagedModel_sd(ParameterSet & params) :
 
 }
 
-size_t NEMLDamagedModel_sd::nhist() const
-{
-  History h;
-  populate_hist(h);
-  return h.size();
-}
-
 void NEMLDamagedModel_sd::populate_hist(History & hist) const
 {
   populate_damage(hist);
+  base_->set_variable_prefix(get_variable_prefix());
   base_->populate_hist(hist);
 }
 
@@ -145,12 +139,12 @@ size_t NEMLScalarDamagedModel_sd::ndamage() const
 
 void NEMLScalarDamagedModel_sd::populate_damage(History & hist) const
 {
-  hist.add<double>("damage");
+  hist.add<double>(prefix("damage"));
 }
 
 void NEMLScalarDamagedModel_sd::init_damage(History & hist) const
 {
-  hist.get<double>("damage") = dmodel_->d_init();
+  hist.get<double>(prefix("damage")) = dmodel_->d_init();
 }
 
 size_t NEMLScalarDamagedModel_sd::nparams() const

--- a/src/damage.cxx
+++ b/src/damage.cxx
@@ -106,8 +106,7 @@ void NEMLScalarDamagedModel_sd::update_sd_state(
   }
 
   // Make trial state
-  SDTrialState tss;
-  make_trial_state(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_n, h_n, u_n, p_n, tss);
+  SDTrialState tss = make_trial_state(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_n, h_n, u_n, p_n);
   
   // Call solve
   std::vector<double> xv(nparams());
@@ -232,13 +231,13 @@ void NEMLScalarDamagedModel_sd::RJ(const double * const x, TrialState * ts,
   J[CINDEX(6,6,7)] = 1.0 - ww - dot_vec(ws, s_curr, 6) / pow(1-w_curr,2.0);
 }
 
-void NEMLScalarDamagedModel_sd::make_trial_state(
+SDTrialState NEMLScalarDamagedModel_sd::make_trial_state(
     const double * const e_np1, const double * const e_n,
     double T_np1, double T_n, double t_np1, double t_n,
     const double * const s_n, const double * const h_n,
-    double u_n, double p_n,
-    SDTrialState & tss)
+    double u_n, double p_n)
 {
+  SDTrialState tss = SDTrialState();
   std::copy(e_np1, e_np1+6, tss.e_np1);
   std::copy(e_n, e_n+6, tss.e_n);
   tss.T_np1 = T_np1;
@@ -251,6 +250,7 @@ void NEMLScalarDamagedModel_sd::make_trial_state(
   tss.u_n = u_n;
   tss.p_n = p_n;
   tss.w_n = h_n[0];
+  return tss;
 }
 
 void NEMLScalarDamagedModel_sd::tangent_(

--- a/src/damage.cxx
+++ b/src/damage.cxx
@@ -15,13 +15,21 @@ NEMLDamagedModel_sd::NEMLDamagedModel_sd(ParameterSet & params) :
 
 size_t NEMLDamagedModel_sd::nhist() const
 {
-  return ndamage() + base_->nhist();
+  History h;
+  populate_hist(h);
+  return h.size();
 }
 
-void NEMLDamagedModel_sd::init_hist(double * const hist) const
+void NEMLDamagedModel_sd::populate_hist(History & hist) const
+{
+  populate_damage(hist);
+  base_->populate_hist(hist);
+}
+
+void NEMLDamagedModel_sd::init_hist(History & hist) const
 {
   init_damage(hist);
-  base_->init_hist(&hist[ndamage()]);
+  base_->init_hist(hist);
 }
 
 void NEMLDamagedModel_sd::set_elastic_model(std::shared_ptr<LinearElasticModel>
@@ -135,9 +143,14 @@ size_t NEMLScalarDamagedModel_sd::ndamage() const
   return 1;
 }
 
-void NEMLScalarDamagedModel_sd::init_damage(double * const damage) const
+void NEMLScalarDamagedModel_sd::populate_damage(History & hist) const
 {
-  damage[0] = dmodel_->d_init();
+  hist.add<double>("damage");
+}
+
+void NEMLScalarDamagedModel_sd::init_damage(History & hist) const
+{
+  hist.get<double>("damage") = dmodel_->d_init();
 }
 
 size_t NEMLScalarDamagedModel_sd::nparams() const

--- a/src/damage_wrap.cxx
+++ b/src/damage_wrap.cxx
@@ -39,11 +39,12 @@ PYBIND11_MODULE(damage, m) {
       .def("make_trial_state",
            [](NEMLScalarDamagedModel_sd & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n, double u_n, double p_n) -> SDTrialState
            {
-            return m.make_trial_state(arr2ptr<double>(e_np1),
-                                         arr2ptr<double>(e_n),
+            History test = m.gather_state_(arr2ptr<double>(h_n));
+            return m.make_trial_state(Symmetric(arr2ptr<double>(e_np1)),
+                                         Symmetric(arr2ptr<double>(e_n)),
                                          T_np1, T_n, t_np1, t_n,
-                                         arr2ptr<double>(s_n),
-                                         arr2ptr<double>(h_n),
+                                         Symmetric(arr2ptr<double>(s_n)),
+                                         m.gather_state_(arr2ptr<double>(h_n)),
                                          u_n, p_n);
            }, "Make a trial state, mostly for testing.")
       ;

--- a/src/damage_wrap.cxx
+++ b/src/damage_wrap.cxx
@@ -21,13 +21,7 @@ PYBIND11_MODULE(damage, m) {
 
   py::class_<NEMLDamagedModel_sd, NEMLModel_sd, std::shared_ptr<NEMLDamagedModel_sd>>(m, "NEMLDamagedModel_sd")
       .def_property_readonly("ndamage", &NEMLDamagedModel_sd::ndamage, "Number of damage variables.")
-      .def("init_damage",
-           [](NEMLDamagedModel_sd & m) -> py::array_t<double>
-           {
-            auto h = alloc_vec<double>(m.ndamage());
-            m.init_damage(arr2ptr<double>(h));
-            return h;
-           }, "Initialize damage variables.")
+      .def("init_damage", &NEMLDamagedModel_sd::init_damage)
       ;
 
   py::class_<SDTrialState, TrialState>(m, "SDTrialState")

--- a/src/damage_wrap.cxx
+++ b/src/damage_wrap.cxx
@@ -22,6 +22,7 @@ PYBIND11_MODULE(damage, m) {
   py::class_<NEMLDamagedModel_sd, NEMLModel_sd, std::shared_ptr<NEMLDamagedModel_sd>>(m, "NEMLDamagedModel_sd")
       .def_property_readonly("ndamage", &NEMLDamagedModel_sd::ndamage, "Number of damage variables.")
       .def("init_damage", &NEMLDamagedModel_sd::init_damage)
+      .def("populate_damage", &NEMLDamagedModel_sd::populate_damage)
       ;
 
   py::class_<SDTrialState, TrialState>(m, "SDTrialState")

--- a/src/damage_wrap.cxx
+++ b/src/damage_wrap.cxx
@@ -37,17 +37,14 @@ PYBIND11_MODULE(damage, m) {
                                                               "damage"});
         }))
       .def("make_trial_state",
-           [](NEMLScalarDamagedModel_sd & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n, double u_n, double p_n) -> std::unique_ptr<SDTrialState>
+           [](NEMLScalarDamagedModel_sd & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n, double u_n, double p_n) -> SDTrialState
            {
-            std::unique_ptr<SDTrialState> ts(new SDTrialState);
-            m.make_trial_state(arr2ptr<double>(e_np1),
+            return m.make_trial_state(arr2ptr<double>(e_np1),
                                          arr2ptr<double>(e_n),
                                          T_np1, T_n, t_np1, t_n,
                                          arr2ptr<double>(s_n),
                                          arr2ptr<double>(h_n),
-                                         u_n, p_n, *ts);
-
-            return ts;
+                                         u_n, p_n);
            }, "Make a trial state, mostly for testing.")
       ;
 

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -10,15 +10,8 @@
 namespace neml {
 
 GeneralFlowRule::GeneralFlowRule(ParameterSet & params) :
-    NEMLObject(params)
+    HistoryNEMLObject(params)
 {
-}
-
-size_t GeneralFlowRule::nhist() const
-{
-  History h;
-  populate_hist(h);
-  return h.size();
 }
 
 void GeneralFlowRule::work_rate(const double * const s,

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -14,6 +14,13 @@ GeneralFlowRule::GeneralFlowRule(ParameterSet & params) :
 {
 }
 
+size_t GeneralFlowRule::nhist() const
+{
+  History h;
+  populate_hist(h);
+  return h.size();
+}
+
 void GeneralFlowRule::work_rate(const double * const s,
                                             const double * const alpha,
                                             const double * const edot, double T,
@@ -62,15 +69,14 @@ std::unique_ptr<NEMLObject> TVPFlowRule::initialize(ParameterSet & params)
 }
 
 
-size_t TVPFlowRule::nhist() const
+void TVPFlowRule::populate_hist(History & h) const
 {
-  return flow_->nhist();
+  flow_->populate_hist(h);
 }
 
-void TVPFlowRule::init_hist(double * const h)
+void TVPFlowRule::init_hist(History & h) const
 {
   flow_->init_hist(h);
-
 }
 
 void TVPFlowRule::s(const double * const s, const double * const alpha,

--- a/src/general_flow.cxx
+++ b/src/general_flow.cxx
@@ -64,6 +64,7 @@ std::unique_ptr<NEMLObject> TVPFlowRule::initialize(ParameterSet & params)
 
 void TVPFlowRule::populate_hist(History & h) const
 {
+  flow_->set_variable_prefix(get_variable_prefix());
   flow_->populate_hist(h);
 }
 

--- a/src/general_flow_wrap.cxx
+++ b/src/general_flow_wrap.cxx
@@ -11,7 +11,6 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 namespace neml {
 PYBIND11_MODULE(general_flow, m) {
   py::module::import("neml.objects");
-  py::module::import("neml.history");
 
   m.doc() = "General flow models where subclass functions define everything.";
 

--- a/src/general_flow_wrap.cxx
+++ b/src/general_flow_wrap.cxx
@@ -15,92 +15,21 @@ PYBIND11_MODULE(general_flow, m) {
   m.doc() = "General flow models where subclass functions define everything.";
 
   py::class_<GeneralFlowRule, HistoryNEMLObject, std::shared_ptr<GeneralFlowRule>>(m, "GeneralFlowRule")
-      .def("s",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_vec<double>(6);
-            m.s(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot, 
-                          arr2ptr<double>(f));
-            return f;
-           }, "Stress rate.")
-      .def("ds_ds",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_mat<double>(6,6);
-            m.ds_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot, arr2ptr<double>(f));
-            return f;
-           }, "Stress rate derivative with respect to stress.")
-      .def("ds_da",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_mat<double>(6,m.nhist());
-            m.ds_da(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot,  arr2ptr<double>(f));
-            return f;
-           }, "Stress rate derivative with respect to history.")
-      .def("ds_de",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_mat<double>(6,6);
-            m.ds_de(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot,  arr2ptr<double>(f));
-            return f;
-           }, "Stress rate derivative with respect to strain.")
-
-
-      .def("a",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_vec<double>(m.nhist());
-            m.a(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot, 
-                          arr2ptr<double>(f));
-            return f;
-           }, "History rate.")
-      .def("da_ds",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_mat<double>(m.nhist(),6);
-            m.da_ds(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot, arr2ptr<double>(f));
-            return f;
-           }, "History rate derivative with respect to stress.")
-      .def("da_da",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_mat<double>(m.nhist(),m.nhist());
-            m.da_da(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot,  arr2ptr<double>(f));
-            return f;
-           }, "History rate derivative with respect to history.")
-      .def("da_de",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
-           {
-            auto f = alloc_mat<double>(m.nhist(),6);
-            m.da_de(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot,  arr2ptr<double>(f));
-            return f;
-           }, "History rate derivative with respect to strain.")
-      
-      .def("work_rate",
-           [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> double
-           {
-            double pi;
-            m.work_rate(arr2ptr<double>(s), arr2ptr<double>(alpha), 
-                          arr2ptr<double>(edot), T,
-                          Tdot,  pi);
-            return pi;
-           }, "Plastic work rate.")
+      .def("s", &GeneralFlowRule::s, "Stress rate")
+      .def("ds_ds", &GeneralFlowRule::ds_ds, "Stress rate derivative with respect "
+           "to stress.")
+      .def("ds_da", &GeneralFlowRule::ds_da, "Stress rate derivative with respect "
+           "to history.")
+      .def("ds_de", &GeneralFlowRule::ds_de, "Stress rate derivative with respect "
+           "to strain rate.")
+      .def("a", &GeneralFlowRule::a, "History rate.")
+      .def("da_ds", &GeneralFlowRule::da_ds, "History rate derivative with respect "
+           "to stress.")
+      .def("da_da", &GeneralFlowRule::da_da, "History rate derivative with respect "
+           "to history.")
+      .def("da_de", &GeneralFlowRule::da_de, "History rate derivative with respect "
+           "to strain rate.") 
+      .def("work_rate", &GeneralFlowRule::work_rate, "Inelastic work rate.")
       .def("set_elastic_model", &GeneralFlowRule::set_elastic_model)
   ;
 

--- a/src/general_flow_wrap.cxx
+++ b/src/general_flow_wrap.cxx
@@ -14,16 +14,7 @@ PYBIND11_MODULE(general_flow, m) {
 
   m.doc() = "General flow models where subclass functions define everything.";
 
-  py::class_<GeneralFlowRule, NEMLObject, std::shared_ptr<GeneralFlowRule>>(m, "GeneralFlowRule")
-      .def_property_readonly("nhist", &GeneralFlowRule::nhist, "Number of history variables.")
-      .def("init_hist",
-           [](GeneralFlowRule & m) -> py::array_t<double>
-           {
-            auto h = alloc_vec<double>(m.nhist());
-            m.init_hist(arr2ptr<double>(h));
-            return h;
-           }, "Initialize history variables.")
-
+  py::class_<GeneralFlowRule, HistoryNEMLObject, std::shared_ptr<GeneralFlowRule>>(m, "GeneralFlowRule")
       .def("s",
            [](GeneralFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, py::array_t<double, py::array::c_style> edot, double T, double Tdot) -> py::array_t<double>
            {

--- a/src/general_flow_wrap.cxx
+++ b/src/general_flow_wrap.cxx
@@ -11,6 +11,7 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 namespace neml {
 PYBIND11_MODULE(general_flow, m) {
   py::module::import("neml.objects");
+  py::module::import("neml.history");
 
   m.doc() = "General flow models where subclass functions define everything.";
 

--- a/src/hardening.cxx
+++ b/src/hardening.cxx
@@ -23,12 +23,12 @@ IsotropicHardeningRule::IsotropicHardeningRule(ParameterSet & params) :
 
 void IsotropicHardeningRule::populate_hist(History & h) const
 {
-  h.add<double>("alpha");
+  h.add<double>(prefix("alpha"));
 }
 
 void IsotropicHardeningRule::init_hist(History & h) const
 {
-  h.get<double>("alpha") = 0.0;
+  h.get<double>(prefix("alpha")) = 0.0;
 }
 
 // Implementation of linear hardening
@@ -304,12 +304,12 @@ KinematicHardeningRule::KinematicHardeningRule(ParameterSet & params) :
 // Implementation of kinematic base class
 void KinematicHardeningRule::populate_hist(History & hist) const
 {
-  hist.add<Symmetric>("backstress");
+  hist.add<Symmetric>(prefix("backstress"));
 }
 
 void KinematicHardeningRule::init_hist(History & hist) const
 {
-  hist.get<Symmetric>("backstress") = Symmetric::zero();
+  hist.get<Symmetric>(prefix("backstress")) = Symmetric::zero();
 }
 
 // Implementation of linear kinematic hardening
@@ -642,16 +642,16 @@ size_t Chaboche::ninter() const
 
 void Chaboche::populate_hist(History & h) const
 {
-  h.add<double>("alpha");
+  h.add<double>(prefix("alpha"));
   for (size_t i = 0; i < n_; i++)
-    h.add<Symmetric>("backstress_"+std::to_string(i));
+    h.add<Symmetric>(prefix("backstress_"+std::to_string(i)));
 }
 
 void Chaboche::init_hist(History & h) const
 {
-  h.get<double>("alpha") = 0.0;
+  h.get<double>(prefix("alpha")) = 0.0;
   for (size_t i = 0; i < n_; i++)
-    h.get<Symmetric>("backstress_"+std::to_string(i)) = Symmetric::zero();
+    h.get<Symmetric>(prefix("backstress_"+std::to_string(i))) = Symmetric::zero();
 }
 
 void Chaboche::q(const double * const alpha, double T, double * const qv) const
@@ -1014,16 +1014,16 @@ size_t ChabocheVoceRecovery::ninter() const
 
 void ChabocheVoceRecovery::populate_hist(History & h) const
 {
-  h.add<double>("alpha");
+  h.add<double>(prefix("alpha"));
   for (size_t i = 0; i < n_; i++)
-    h.add<Symmetric>("backstress_"+std::to_string(i));
+    h.add<Symmetric>(prefix("backstress_"+std::to_string(i)));
 }
 
 void ChabocheVoceRecovery::init_hist(History & h) const
 {
-  h.get<double>("alpha") = 0.0;
+  h.get<double>(prefix("alpha")) = 0.0;
   for (size_t i = 0; i < n_; i++)
-    h.get<Symmetric>("backstress_"+std::to_string(i)) = Symmetric::zero();
+    h.get<Symmetric>(prefix("backstress_"+std::to_string(i))) = Symmetric::zero();
 }
 
 void ChabocheVoceRecovery::q(const double * const alpha, double T, double * const qv) const

--- a/src/hardening_wrap.cxx
+++ b/src/hardening_wrap.cxx
@@ -15,17 +15,7 @@ PYBIND11_MODULE(hardening, m) {
 
   m.doc() = "Various hardening rules.";
 
-  py::class_<HardeningRule, NEMLObject, std::shared_ptr<HardeningRule>>(m, "HardeningRule")
-      .def_property_readonly("nhist", &HardeningRule::nhist, "Number of history variables.")
-
-      .def("init_hist",
-           [](const HardeningRule & m) -> py::array_t<double>
-           {
-            auto v = alloc_vec<double>(m.nhist());
-            m.init_hist(arr2ptr<double>(v));
-            return v;
-           }, "Initialize history.")
-        
+  py::class_<HardeningRule, HistoryNEMLObject, std::shared_ptr<HardeningRule>>(m, "HardeningRule")
       .def("q",
            [](const HardeningRule & m, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>
            {
@@ -128,15 +118,6 @@ PYBIND11_MODULE(hardening, m) {
 
   py::class_<NonAssociativeHardening, NEMLObject, std::shared_ptr<NonAssociativeHardening>>(m, "NonAssociativeHardening")
       .def_property_readonly("ninter", &NonAssociativeHardening::ninter, "Number of q variables.")
-      .def_property_readonly("nhist", &NonAssociativeHardening::nhist, "Number of a variables.")
-
-      .def("init_hist",
-           [](const NonAssociativeHardening & m) -> py::array_t<double>
-           {
-            auto v = alloc_vec<double>(m.nhist());
-            m.init_hist(arr2ptr<double>(v));
-            return v;
-           }, "Initialize history.")
         
       .def("q",
            [](const NonAssociativeHardening & m, py::array_t<double, py::array::c_style> alpha, double T) -> py::array_t<double>

--- a/src/hardening_wrap.cxx
+++ b/src/hardening_wrap.cxx
@@ -12,6 +12,7 @@ namespace neml {
 
 PYBIND11_MODULE(hardening, m) {
   py::module::import("neml.objects");
+  py::module::import("neml.history");
 
   m.doc() = "Various hardening rules.";
 
@@ -116,7 +117,7 @@ PYBIND11_MODULE(hardening, m) {
         }))
       ;
 
-  py::class_<NonAssociativeHardening, NEMLObject, std::shared_ptr<NonAssociativeHardening>>(m, "NonAssociativeHardening")
+  py::class_<NonAssociativeHardening, HistoryNEMLObject, std::shared_ptr<NonAssociativeHardening>>(m, "NonAssociativeHardening")
       .def_property_readonly("ninter", &NonAssociativeHardening::ninter, "Number of q variables.")
         
       .def("q",

--- a/src/hardening_wrap.cxx
+++ b/src/hardening_wrap.cxx
@@ -12,7 +12,6 @@ namespace neml {
 
 PYBIND11_MODULE(hardening, m) {
   py::module::import("neml.objects");
-  py::module::import("neml.history");
 
   m.doc() = "Various hardening rules.";
 

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -516,4 +516,28 @@ std::string HistoryNEMLObject::dprefix(std::string a, std::string b) const
   return prefix(a) + "_" + prefix(b);
 }
 
+void HistoryNEMLObject::cache_history_()
+{
+  populate_hist(stored_hist_);
+}
+
+History HistoryNEMLObject::gather_history_(double * data) const
+{
+  History h = gather_blank_history_();
+  h.set_data(data);
+  return h;
+}
+
+History HistoryNEMLObject::gather_history_(const double * data) const
+{
+  History h = gather_blank_history_();
+  h.set_data(const_cast<double*>(data));
+  return h;
+}
+
+History HistoryNEMLObject::gather_blank_history_() const
+{
+  return stored_hist_;
+}
+
 } // namespace neml

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -414,7 +414,7 @@ double * History::start_loc(std::string name)
 }
 
 HistoryNEMLObject::HistoryNEMLObject(ParameterSet & params) :
-    NEMLObject(params)
+    NEMLObject(params), prefix_("")
 {
 
 }
@@ -424,6 +424,26 @@ size_t HistoryNEMLObject::nhist() const
   History h;
   populate_hist(h);
   return h.size();
+}
+
+void HistoryNEMLObject::set_variable_prefix(std::string prefix)
+{
+  prefix_ = prefix;
+}
+
+std::string HistoryNEMLObject::get_variable_prefix() const
+{
+  return prefix_;
+}
+
+std::string HistoryNEMLObject::prefix(std::string basename) const
+{
+  return prefix_ + basename;
+}
+
+std::string HistoryNEMLObject::dprefix(std::string a, std::string b) const
+{
+  return prefix(a) + "_" + prefix(b);
 }
 
 } // namespace neml

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -426,6 +426,18 @@ size_t HistoryNEMLObject::nhist() const
   return h.size();
 }
 
+void HistoryNEMLObject::init_store(double * const h) const
+{
+  History hist(h);
+  populate_hist(hist);
+  init_hist(hist);
+}
+
+size_t HistoryNEMLObject::nstore() const
+{
+  return nhist();
+}
+
 void HistoryNEMLObject::set_variable_prefix(std::string prefix)
 {
   prefix_ = prefix;

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -182,11 +182,13 @@ void History::increase_store(size_t newsize)
   storage_ = newstore;
 }
 
-void History::scalar_multiply(double scalar)
+History & History::scalar_multiply(double scalar)
 {
   for (size_t i = 0; i < size_; i++) {
     storage_[i] *= scalar; 
   }
+
+  return *this;
 }
 
 History & History::operator+=(const History & other)
@@ -356,6 +358,19 @@ History & History::reorder(std::vector<std::string> vars)
   std::copy(nhist.rawptr(), nhist.rawptr() + size(), storage_);
 
   return *this;
+}
+
+History History::premultiply(const SymSymR4 & T)
+{
+  // This is a hack, really we would need to make sure each object is
+  // conformal
+  if (size_ % 6 != 0)
+    throw std::runtime_error("History object does not appear to be suitable "
+                             "for premultiplication by a SymSymR4!");
+  History nhist = this->deepcopy();
+  mat_mat(6, size_ / 6, 6, T.data(), storage_, nhist.rawptr());
+
+  return nhist;
 }
 
 History History::postmultiply(const SymSymR4 & T)

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -182,7 +182,12 @@ void History::increase_store(size_t newsize)
   storage_ = newstore;
 }
 
-History & History::scalar_multiply(double scalar)
+History & History::operator*=(const double & scalar)
+{
+  return scalar_multiply(scalar);
+}
+
+History & History::scalar_multiply(const double & scalar)
 {
   for (size_t i = 0; i < size_; i++) {
     storage_[i] *= scalar; 
@@ -200,6 +205,20 @@ History & History::operator+=(const History & other)
     storage_[i] += other.rawptr()[i];
   }
   return *this;
+}
+
+History History::operator-() const
+{
+  History cpy = deepcopy();
+  for (size_t i = 0; i < size_; i++)
+    cpy.rawptr()[i] = -cpy.rawptr()[i];
+
+  return cpy;
+}
+
+History & History::operator-=(const History & other)
+{
+  return this->operator+=(-other);
 }
 
 History History::copy_blank(std::vector<std::string> exclude) const
@@ -426,6 +445,30 @@ double * History::start_loc(std::string name)
 {
   error_if_not_exists_(name);
   return &(storage_[loc_.at(name)]);
+}
+
+History operator*(const double & s, const History & v)
+{
+  History cpy = v.deepcopy();
+  cpy *= s;
+  return cpy;
+}
+
+History operator*(const History & v, const double & s)
+{
+  return operator*(s, v);
+}
+
+History operator+(const History & a, const History & b)
+{
+  History res = a.deepcopy();
+  return res+=b;
+}
+
+History operator-(const History & a, const History & b)
+{
+  History res = a.deepcopy();
+  return res-=b;
 }
 
 HistoryNEMLObject::HistoryNEMLObject(ParameterSet & params) :

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -413,4 +413,17 @@ double * History::start_loc(std::string name)
   return &(storage_[loc_.at(name)]);
 }
 
+HistoryNEMLObject::HistoryNEMLObject(ParameterSet & params) :
+    NEMLObject(params)
+{
+
+}
+
+size_t HistoryNEMLObject::nhist() const
+{
+  History h;
+  populate_hist(h);
+  return h.size();
+}
+
 } // namespace neml

--- a/src/history_wrap.cxx
+++ b/src/history_wrap.cxx
@@ -171,6 +171,9 @@ PYBIND11_MODULE(history, m) {
              }, "Return a fully initialized history object")
         .def_property_readonly("nhist", &HistoryNEMLObject::nhist, 
                                "Number of internal variables")
+        .def_property("variable_prefix", &HistoryNEMLObject::get_variable_prefix,
+                      &HistoryNEMLObject::set_variable_prefix)
+        .def("prefix", &HistoryNEMLObject::prefix)
       ;
 }
 

--- a/src/history_wrap.cxx
+++ b/src/history_wrap.cxx
@@ -11,6 +11,8 @@ namespace neml {
 PYBIND11_MODULE(history, m) {
   m.doc() = "Internal variable tracking system.";
 
+  py::module::import("neml.objects");
+
   py::class_<History, std::shared_ptr<History>>(m, "History",
                                                 py::buffer_protocol())
       .def(py::init<>())

--- a/src/history_wrap.cxx
+++ b/src/history_wrap.cxx
@@ -162,6 +162,13 @@ PYBIND11_MODULE(history, m) {
              "Populate a blank history object with the names/types")
         .def("init_hist", &HistoryNEMLObject::init_hist,
              "Initialize the history with the initial conditions")
+        .def("initial_history", [](HistoryNEMLObject & m) -> History
+             {
+              History h;
+              m.populate_hist(h);
+              m.init_hist(h);
+              return h;
+             }, "Return a fully initialized history object")
         .def_property_readonly("nhist", &HistoryNEMLObject::nhist, 
                                "Number of internal variables")
       ;

--- a/src/history_wrap.cxx
+++ b/src/history_wrap.cxx
@@ -156,6 +156,15 @@ PYBIND11_MODULE(history, m) {
               return mat;
              }, "Unravel to c-style array")
       ;
+      py::class_<HistoryNEMLObject, NEMLObject,
+          std::shared_ptr<HistoryNEMLObject>>(m, "HistoryNEMLObject")
+        .def("populate_hist", &HistoryNEMLObject::populate_hist,
+             "Populate a blank history object with the names/types")
+        .def("init_hist", &HistoryNEMLObject::init_hist,
+             "Initialize the history with the initial conditions")
+        .def_property_readonly("nhist", &HistoryNEMLObject::nhist, 
+                               "Number of internal variables")
+      ;
 }
 
 } // namespace neml

--- a/src/history_wrap.cxx
+++ b/src/history_wrap.cxx
@@ -164,6 +164,15 @@ PYBIND11_MODULE(history, m) {
              "Populate a blank history object with the names/types")
         .def("init_hist", &HistoryNEMLObject::init_hist,
              "Initialize the history with the initial conditions")
+        .def_property_readonly("nstore", &HistoryNEMLObject::nstore, 
+                               "Number of variables the program needs to store.")
+        .def("init_store",
+             [](HistoryNEMLObject & m) -> py::array_t<double>
+             {
+              auto h = alloc_vec<double>(m.nstore());
+              m.init_store(arr2ptr<double>(h));
+              return h;
+             }, "Initialize stored variables.")
         .def("initial_history", [](HistoryNEMLObject & m) -> History
              {
               History h;

--- a/src/math/tensors.cxx
+++ b/src/math/tensors.cxx
@@ -2168,4 +2168,14 @@ SymSymSymR6 outer_product_k(const SymSymR4 & A, const Symmetric & B)
   return res;
 }
 
+Symmetric truesdell_update_sym(const Symmetric & D, const Skew & W, 
+                               const Symmetric & cauchy_n,
+                               const Symmetric & dS)
+{
+  Symmetric res;
+  truesdell_update_sym(D.data(), W.data(), cauchy_n.data(), dS.data(),
+                       res.s());
+  return res;
+}
+
 } // namespace neml

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -1705,7 +1705,7 @@ void KMRegimeModel::update_sd_state(
     double & p_np1, double p_n)
 {
   // Calculate activation energy
-  double g = activation_energy_(E_np1.data(), E_n.data(), T_np1, t_np1, t_n);
+  double g = activation_energy_(E_np1, E_n, T_np1, t_np1, t_n);
 
   // Note this relies on everything being sorted.  You probably want to
   // error check at some point
@@ -1734,17 +1734,13 @@ void KMRegimeModel::init_state(History & hist) const
   return models_[0]->init_hist(hist);
 }
 
-double KMRegimeModel::activation_energy_(const double * const e_np1, 
-                                         const double * const e_n,
+double KMRegimeModel::activation_energy_(const Symmetric & e_np1, 
+                                         const Symmetric & e_n,
                                          double T_np1,
                                          double t_np1, double t_n)
 {
-  double dt = t_np1 - t_n;
-
-  double de[6];
-  sub_vec(e_np1, e_n, 6, de);
-  for (int i=0; i<6; i++) de[i] /= dt;
-  double rate = sqrt(2.0/3.0) * norm2_vec(de, 6);
+  Symmetric de = (e_np1 - e_n) / (t_np1 - t_n);
+  double rate = sqrt(2.0/3.0) * de.norm();
   double mu = elastic_->G(T_np1);
   
   return kboltz_ * T_np1 / (mu* pow(b_, 3.0)) * log(eps0_ / rate);

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -1116,8 +1116,8 @@ void SmallStrainCreepPlasticity::update_sd_state(
   Symmetric creep_old = E_n - ts->ep_strain;
   Symmetric creep_new;
   SymSymR4 B;
-  creep_->update(S_np1.data(), creep_new.s(), creep_old.s(), T_np1, T_n,
-                 t_np1, t_n, B.s());
+  creep_->update(S_np1.data(), creep_new, creep_old, T_np1, T_n,
+                 t_np1, t_n, B);
 
   // Form the relatively simple tangent
   AA_np1 = form_tangent_(A, B);
@@ -1169,8 +1169,8 @@ void SmallStrainCreepPlasticity::RJ(const double * const x, TrialState * ts,
   Symmetric creep_old = tss->e_n - tss->ep_strain;
   Symmetric creep_new;
   SymSymR4 B;
-  creep_->update(S_np1.data(), creep_new.s(), creep_old.data(), tss->T_np1, tss->T_n,
-                 tss->t_np1, tss->t_n, B.s());
+  creep_->update(S_np1, creep_new, creep_old, tss->T_np1, tss->T_n,
+                 tss->t_np1, tss->t_n, B);
 
   // Form the residual
   Symmetric Rs(R);

--- a/src/models.cxx
+++ b/src/models.cxx
@@ -1355,7 +1355,7 @@ void GeneralIntegrator::work_and_energy(
 
   // Energy
   Symmetric de = e_np1 - e_n;
-  Symmetric ds = s_np1 - ds;
+  Symmetric ds = s_np1 - s_n;
   u_np1 = u_n + ds.contract(de) / 2.0;
 
   // Dissipation needs a special call

--- a/src/models_wrap.cxx
+++ b/src/models_wrap.cxx
@@ -154,17 +154,14 @@ PYBIND11_MODULE(models, m) {
                                                                   "creep"});
         }))
       .def("make_trial_state",
-           [](SmallStrainCreepPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<SSCPTrialState>
+           [](SmallStrainCreepPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::shared_ptr<SSCPTrialState>
            {
-              std::unique_ptr<SSCPTrialState> ts(new SSCPTrialState);
-              m.make_trial_state(arr2ptr<double>(e_np1),
-                                          arr2ptr<double>(e_n),
-                                          T_np1, T_n,
-                                          t_np1, t_n,
-                                          arr2ptr<double>(s_n),
-                                          arr2ptr<double>(h_n),
-                                          *ts);
-              return ts;
+              return m.make_trial_state(Symmetric(arr2ptr<double>(e_np1)),
+                                        Symmetric(arr2ptr<double>(e_n)),
+                                        T_np1, T_n,
+                                        t_np1, t_n,
+                                        Symmetric(arr2ptr<double>(s_n)),
+                                        m.gather_state_(arr2ptr<double>(h_n)));
            }, "Setup trial state for solve.")
       ;
 

--- a/src/models_wrap.cxx
+++ b/src/models_wrap.cxx
@@ -72,6 +72,16 @@ PYBIND11_MODULE(models, m) {
 
   py::class_<SubstepModel_sd, NEMLModel_sd, std::shared_ptr<SubstepModel_sd>>(m,
                                                                               "SubstepModel_sd")
+      .def("make_trial_state",
+           [](SubstepModel_sd & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<TrialState>
+           {
+           return m.setup(arr2ptr<double>(e_np1),
+                                          arr2ptr<double>(e_n),
+                                          T_np1, T_n,
+                                          t_np1, t_n,
+                                          arr2ptr<double>(s_n),
+                                          arr2ptr<double>(h_n));
+           }, "Setup trial state for solve.")
       ;
 
   py::class_<SmallStrainElasticity, NEMLModel_sd, std::shared_ptr<SmallStrainElasticity>>(m, "SmallStrainElasticity")
@@ -105,20 +115,6 @@ PYBIND11_MODULE(models, m) {
         }))
 
       .def("ys", &SmallStrainPerfectPlasticity::ys)
-
-      .def("make_trial_state",
-           [](SmallStrainPerfectPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<SSPPTrialState>
-           {
-              std::unique_ptr<SSPPTrialState> ts(new SSPPTrialState);
-              m.make_trial_state(arr2ptr<double>(e_np1),
-                                          arr2ptr<double>(e_n),
-                                          T_np1, T_n,
-                                          t_np1, t_n,
-                                          arr2ptr<double>(s_n),
-                                          arr2ptr<double>(h_n),
-                                          *ts);
-              return ts;
-           }, "Setup trial state for solve.")
       ;
 
   py::class_<SmallStrainRateIndependentPlasticity, SubstepModel_sd, Solvable, std::shared_ptr<SmallStrainRateIndependentPlasticity>>(m, "SmallStrainRateIndependentPlasticity")
@@ -128,20 +124,6 @@ PYBIND11_MODULE(models, m) {
           return create_object_python<SmallStrainRateIndependentPlasticity>(args, kwargs,
                                                              {"elastic", "flow"});
         }))
-
-      .def("make_trial_state",
-           [](SmallStrainRateIndependentPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<SSRIPTrialState>
-           {
-              std::unique_ptr<SSRIPTrialState> ts(new SSRIPTrialState);
-              m.make_trial_state(arr2ptr<double>(e_np1),
-                                          arr2ptr<double>(e_n),
-                                          T_np1, T_n,
-                                          t_np1, t_n,
-                                          arr2ptr<double>(s_n),
-                                          arr2ptr<double>(h_n),
-                                          *ts);
-              return ts;
-           }, "Setup trial state for solve.")
       ;
 
   py::class_<SmallStrainCreepPlasticity, NEMLModel_sd, Solvable, std::shared_ptr<SmallStrainCreepPlasticity>>(m, "SmallStrainCreepPlasticity")
@@ -154,7 +136,7 @@ PYBIND11_MODULE(models, m) {
                                                                   "creep"});
         }))
       .def("make_trial_state",
-           [](SmallStrainCreepPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::shared_ptr<SSCPTrialState>
+           [](SmallStrainCreepPlasticity & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<SSCPTrialState>
            {
               return m.make_trial_state(Symmetric(arr2ptr<double>(e_np1)),
                                         Symmetric(arr2ptr<double>(e_n)),
@@ -165,8 +147,6 @@ PYBIND11_MODULE(models, m) {
            }, "Setup trial state for solve.")
       ;
 
-
-
   py::class_<GeneralIntegrator, SubstepModel_sd, Solvable, std::shared_ptr<GeneralIntegrator>>(m, "GeneralIntegrator")
       PICKLEABLE(GeneralIntegrator)
       .def(py::init([](py::args args, py::kwargs kwargs)
@@ -174,20 +154,6 @@ PYBIND11_MODULE(models, m) {
           return create_object_python<GeneralIntegrator>(args, kwargs, 
                                                          {"elastic", "rule"});
         }))
-
-      .def("make_trial_state",
-           [](GeneralIntegrator & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n) -> std::unique_ptr<GITrialState>
-           {
-              std::unique_ptr<GITrialState> ts(new GITrialState);
-              m.make_trial_state(arr2ptr<double>(e_np1),
-                                          arr2ptr<double>(e_n),
-                                          T_np1, T_n,
-                                          t_np1, t_n,
-                                          arr2ptr<double>(s_n),
-                                          arr2ptr<double>(h_n),
-                                          *ts);
-              return ts;
-           }, "Setup trial state for solve.")
       ;
 
   py::class_<KMRegimeModel, NEMLModel_sd, std::shared_ptr<KMRegimeModel>>(m, "KMRegimeModel")

--- a/src/models_wrap.cxx
+++ b/src/models_wrap.cxx
@@ -19,14 +19,6 @@ PYBIND11_MODULE(models, m) {
   
   py::class_<NEMLModel, HistoryNEMLObject, std::shared_ptr<NEMLModel>>(m, "NEMLModel")
       .def("save", &NEMLModel::save)
-      .def_property_readonly("nstore", &NEMLModel::nstore, "Number of variables the program needs to store.")
-      .def("init_store",
-           [](NEMLModel & m) -> py::array_t<double>
-           {
-            auto h = alloc_vec<double>(m.nstore());
-            m.init_store(arr2ptr<double>(h));
-            return h;
-           }, "Initialize stored variables.")
       .def("update_sd",
            [](NEMLModel & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n, double u_n, double p_n) -> std::tuple<py::array_t<double>, py::array_t<double>, py::array_t<double>, double, double>
            {

--- a/src/models_wrap.cxx
+++ b/src/models_wrap.cxx
@@ -14,7 +14,6 @@ namespace neml {
 PYBIND11_MODULE(models, m) {
   py::module::import("neml.objects");
   py::module::import("neml.solvers");
-  py::module::import("neml.history");
 
   m.doc() = "Base class for all material models.";
   

--- a/src/models_wrap.cxx
+++ b/src/models_wrap.cxx
@@ -14,10 +14,11 @@ namespace neml {
 PYBIND11_MODULE(models, m) {
   py::module::import("neml.objects");
   py::module::import("neml.solvers");
+  py::module::import("neml.history");
 
   m.doc() = "Base class for all material models.";
   
-  py::class_<NEMLModel, NEMLObject, std::shared_ptr<NEMLModel>>(m, "NEMLModel")
+  py::class_<NEMLModel, HistoryNEMLObject, std::shared_ptr<NEMLModel>>(m, "NEMLModel")
       .def("save", &NEMLModel::save)
       .def_property_readonly("nstore", &NEMLModel::nstore, "Number of variables the program needs to store.")
       .def("init_store",
@@ -27,15 +28,6 @@ PYBIND11_MODULE(models, m) {
             m.init_store(arr2ptr<double>(h));
             return h;
            }, "Initialize stored variables.")
-
-      .def_property_readonly("nhist", &NEMLModel::nhist, "Number of actual history variables.")
-      .def("init_hist",
-           [](NEMLModel & m) -> py::array_t<double>
-           {
-            auto h = alloc_vec<double>(m.nhist());
-            m.init_hist(arr2ptr<double>(h));
-            return h;
-           }, "Initialize history variables.")
       .def("update_sd",
            [](NEMLModel & m, py::array_t<double, py::array::c_style> e_np1, py::array_t<double, py::array::c_style> e_n, double T_np1, double T_n, double t_np1, double t_n, py::array_t<double, py::array::c_style> s_n, py::array_t<double, py::array::c_style> h_n, double u_n, double p_n) -> std::tuple<py::array_t<double>, py::array_t<double>, py::array_t<double>, double, double>
            {

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -10,6 +10,13 @@ RateIndependentFlowRule::RateIndependentFlowRule(ParameterSet & params) :
 
 }
 
+size_t RateIndependentFlowRule::nhist() const
+{
+  History h;
+  populate_hist(h);
+  return h.size();
+}
+
 RateIndependentAssociativeFlow::RateIndependentAssociativeFlow(ParameterSet &
                                                                params) :
     RateIndependentFlowRule(params),
@@ -39,18 +46,17 @@ std::unique_ptr<NEMLObject> RateIndependentAssociativeFlow::initialize(Parameter
   return neml::make_unique<RateIndependentAssociativeFlow>(params); 
 }
 
-size_t RateIndependentAssociativeFlow::nhist() const
-{
-  return hardening_->nhist();
-}
-
-void RateIndependentAssociativeFlow::init_hist(double * const h) const
+void RateIndependentAssociativeFlow::populate_hist(History & hist) const
 {
   if (hardening_->nhist() != surface_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
+  hardening_->populate_hist(hist);
+}
 
-  hardening_->init_hist(h);
+void RateIndependentAssociativeFlow::init_hist(History & hist) const
+{
+  hardening_->init_hist(hist);
 }
 
 void RateIndependentAssociativeFlow::f(const double* const s, 
@@ -209,19 +215,17 @@ std::unique_ptr<NEMLObject> RateIndependentNonAssociativeHardening::initialize(P
   return neml::make_unique<RateIndependentNonAssociativeHardening>(params); 
 }
 
-size_t RateIndependentNonAssociativeHardening::nhist() const
-{
-  return hardening_->nhist();
-}
-
-void RateIndependentNonAssociativeHardening::init_hist(double * const h) const
+void RateIndependentNonAssociativeHardening::populate_hist(History & hist) const
 {
   if (hardening_->ninter() != surface_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
+  hardening_->populate_hist(hist);
+}
 
-  hardening_->init_hist(h);
-
+void RateIndependentNonAssociativeHardening::init_hist(History & hist) const
+{
+  hardening_->populate_hist(hist);
 }
 
 void RateIndependentNonAssociativeHardening::f(const double* const s, 

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -44,6 +44,7 @@ void RateIndependentAssociativeFlow::populate_hist(History & hist) const
   if (hardening_->nhist() != surface_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
+  hardening_->set_variable_prefix(get_variable_prefix());
   hardening_->populate_hist(hist);
 }
 
@@ -213,6 +214,7 @@ void RateIndependentNonAssociativeHardening::populate_hist(History & hist) const
   if (hardening_->ninter() != surface_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
+  hardening_->set_variable_prefix(get_variable_prefix());
   hardening_->populate_hist(hist);
 }
 

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -218,7 +218,7 @@ void RateIndependentNonAssociativeHardening::populate_hist(History & hist) const
 
 void RateIndependentNonAssociativeHardening::init_hist(History & hist) const
 {
-  hardening_->populate_hist(hist);
+  hardening_->init_hist(hist);
 }
 
 void RateIndependentNonAssociativeHardening::f(const double* const s, 

--- a/src/ri_flow.cxx
+++ b/src/ri_flow.cxx
@@ -5,16 +5,9 @@
 namespace neml {
 
 RateIndependentFlowRule::RateIndependentFlowRule(ParameterSet & params) :
-    NEMLObject(params)
+    HistoryNEMLObject(params)
 {
 
-}
-
-size_t RateIndependentFlowRule::nhist() const
-{
-  History h;
-  populate_hist(h);
-  return h.size();
 }
 
 RateIndependentAssociativeFlow::RateIndependentAssociativeFlow(ParameterSet &

--- a/src/ri_flow_wrap.cxx
+++ b/src/ri_flow_wrap.cxx
@@ -12,7 +12,6 @@ namespace neml {
 
 PYBIND11_MODULE(ri_flow, m) {
   py::module::import("neml.objects");
-  py::module::import("neml.history");
 
   m.doc() = "Rate independent flow models.";
   

--- a/src/ri_flow_wrap.cxx
+++ b/src/ri_flow_wrap.cxx
@@ -12,6 +12,7 @@ namespace neml {
 
 PYBIND11_MODULE(ri_flow, m) {
   py::module::import("neml.objects");
+  py::module::import("neml.history");
 
   m.doc() = "Rate independent flow models.";
   

--- a/src/ri_flow_wrap.cxx
+++ b/src/ri_flow_wrap.cxx
@@ -15,16 +15,7 @@ PYBIND11_MODULE(ri_flow, m) {
 
   m.doc() = "Rate independent flow models.";
   
-  py::class_<RateIndependentFlowRule, NEMLObject, std::shared_ptr<RateIndependentFlowRule>>(m, "RateIndenpendentFlowRule")
-      .def_property_readonly("nhist", &RateIndependentFlowRule::nhist, "Number of history variables.")
-      .def("init_hist",
-           [](RateIndependentFlowRule & m) -> py::array_t<double>
-           {
-            auto h = alloc_vec<double>(m.nhist());
-            m.init_hist(arr2ptr<double>(h));
-            return h;
-           }, "Initialize history variables.")
-
+  py::class_<RateIndependentFlowRule, HistoryNEMLObject, std::shared_ptr<RateIndependentFlowRule>>(m, "RateIndenpendentFlowRule")
       .def("f",
            [](RateIndependentFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> double
            {

--- a/src/visco_flow.cxx
+++ b/src/visco_flow.cxx
@@ -8,16 +8,9 @@
 namespace neml {
 
 ViscoPlasticFlowRule::ViscoPlasticFlowRule(ParameterSet & params) :
-    NEMLObject(params)
+    HistoryNEMLObject(params)
 {
 
-}
-
-size_t ViscoPlasticFlowRule::nhist() const
-{
-  History h;
-  populate_hist(h);
-  return h.size();
 }
 
 // Default implementation of flow rule wrt time

--- a/src/visco_flow.cxx
+++ b/src/visco_flow.cxx
@@ -142,15 +142,16 @@ size_t SuperimposedViscoPlasticFlowRule::nmodels() const
   return rules_.size();
 }
 
-size_t SuperimposedViscoPlasticFlowRule::nhist() const
-{
-  return offsets_[nmodels()];
-}
-
-void SuperimposedViscoPlasticFlowRule::init_hist(double * const h) const
+void SuperimposedViscoPlasticFlowRule::populate_hist(History & hist) const
 {
   for (size_t i = 0; i < nmodels(); i++)
-    rules_[i]->init_hist(model_history_(h, i));
+    rules_[i]->populate_hist(hist);
+}
+
+void SuperimposedViscoPlasticFlowRule::init_hist(History & hist) const
+{
+  for (size_t i = 0; i < nmodels(); i++)
+    rules_[i]->init_hist(hist);
 }
 
 void SuperimposedViscoPlasticFlowRule::y(const double* const s, 
@@ -894,12 +895,12 @@ std::unique_ptr<NEMLObject> LinearViscousFlow::initialize(ParameterSet & params)
   return neml::make_unique<LinearViscousFlow>(params); 
 }
 
-size_t LinearViscousFlow::nhist() const
+void LinearViscousFlow::init_hist(History & h) const
 {
-  return 0;
+  return;
 }
 
-void LinearViscousFlow::init_hist(double * const h) const
+void LinearViscousFlow::populate_hist(History & h) const
 {
   return;
 }

--- a/src/visco_flow.cxx
+++ b/src/visco_flow.cxx
@@ -115,6 +115,9 @@ SuperimposedViscoPlasticFlowRule::SuperimposedViscoPlasticFlowRule(ParameterSet 
   for (size_t i = 1; i <= rules_.size(); i++) {
     offsets_[i] = offsets_[i-1] + rules_[i-1]->nhist();
   }
+
+  for (size_t i = 0; i < nmodels(); i++)
+    rules_[i]->set_variable_prefix("model"+std::to_string(i)+"_");
 }
 
 std::string SuperimposedViscoPlasticFlowRule::type()
@@ -705,6 +708,9 @@ void PerzynaFlowRule::populate_hist(History & hist) const
   if (surface_->nhist() != hardening_->nhist()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
+  
+  // We want to make sure the variable prefix remains the same
+  hardening_->set_variable_prefix(get_variable_prefix());
 
   hardening_->populate_hist(hist);
 }
@@ -1112,6 +1118,10 @@ void ChabocheFlowRule::populate_hist(History & hist) const
   if (surface_->nhist() != hardening_->ninter()) {
     throw NEMLError("Hardening model and flow surface are not compatible");
   }
+  
+  // Make sure the variable prefix stays the same
+  hardening_->set_variable_prefix(get_variable_prefix());
+
   hardening_->populate_hist(hist);
 }
 
@@ -1329,18 +1339,18 @@ void YaguchiGr91FlowRule::populate_hist(History & hist) const
   // 6-11 X2
   // 12   Q
   // 13   sa
-  hist.add<Symmetric>("X1");
-  hist.add<Symmetric>("X2");
-  hist.add<double>("Q");
-  hist.add<double>("sa");
+  hist.add<Symmetric>(prefix("X1"));
+  hist.add<Symmetric>(prefix("X2"));
+  hist.add<double>(prefix("Q"));
+  hist.add<double>(prefix("sa"));
 }
 
 void YaguchiGr91FlowRule::init_hist(History & hist) const
 {
-  hist.get<Symmetric>("X1") = Symmetric::zero();
-  hist.get<Symmetric>("X2") = Symmetric::zero();
-  hist.get<double>("Q") = 0.0;
-  hist.get<double>("sa") = 0.0;
+  hist.get<Symmetric>(prefix("X1")) = Symmetric::zero();
+  hist.get<Symmetric>(prefix("X2")) = Symmetric::zero();
+  hist.get<double>(prefix("Q")) = 0.0;
+  hist.get<double>(prefix("sa")) = 0.0;
 }
 
 // Rate rule

--- a/src/visco_flow_wrap.cxx
+++ b/src/visco_flow_wrap.cxx
@@ -11,6 +11,7 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 namespace neml {
 PYBIND11_MODULE(visco_flow, m) {
   py::module::import("neml.objects");
+  py::module::import("neml.history");
 
   m.doc() = "Viscoplastic flow models.";
 

--- a/src/visco_flow_wrap.cxx
+++ b/src/visco_flow_wrap.cxx
@@ -11,7 +11,6 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 namespace neml {
 PYBIND11_MODULE(visco_flow, m) {
   py::module::import("neml.objects");
-  py::module::import("neml.history");
 
   m.doc() = "Viscoplastic flow models.";
 

--- a/src/visco_flow_wrap.cxx
+++ b/src/visco_flow_wrap.cxx
@@ -14,16 +14,7 @@ PYBIND11_MODULE(visco_flow, m) {
 
   m.doc() = "Viscoplastic flow models.";
 
-  py::class_<ViscoPlasticFlowRule, NEMLObject, std::shared_ptr<ViscoPlasticFlowRule>>(m, "ViscoPlasticFlowRule")
-      .def_property_readonly("nhist", &ViscoPlasticFlowRule::nhist, "Number of history variables.")
-      .def("init_hist",
-           [](ViscoPlasticFlowRule & m) -> py::array_t<double>
-           {
-            auto h = alloc_vec<double>(m.nhist());
-            m.init_hist(arr2ptr<double>(h));
-            return h;
-           }, "Initialize history variables.")
-
+  py::class_<ViscoPlasticFlowRule, HistoryNEMLObject, std::shared_ptr<ViscoPlasticFlowRule>>(m, "ViscoPlasticFlowRule")
       .def("y",
            [](ViscoPlasticFlowRule & m, py::array_t<double, py::array::c_style> s, py::array_t<double, py::array::c_style> alpha, double T) -> double
            {

--- a/src/walker.cxx
+++ b/src/walker.cxx
@@ -35,13 +35,6 @@ std::unique_ptr<NEMLObject> WalkerKremplSwitchRule::initialize(ParameterSet & pa
 }
 
 
-size_t WalkerKremplSwitchRule::nhist() const
-{
-  History h;
-  populate_hist(h);
-  return h.size();
-}
-
 void WalkerKremplSwitchRule::populate_hist(History & hist) const
 {
   return flow_->populate_hist(hist);

--- a/src/walker.cxx
+++ b/src/walker.cxx
@@ -37,12 +37,19 @@ std::unique_ptr<NEMLObject> WalkerKremplSwitchRule::initialize(ParameterSet & pa
 
 size_t WalkerKremplSwitchRule::nhist() const
 {
-  return flow_->nhist();
+  History h;
+  populate_hist(h);
+  return h.size();
 }
 
-void WalkerKremplSwitchRule::init_hist(double * const h)
+void WalkerKremplSwitchRule::populate_hist(History & hist) const
 {
-  return flow_->init_hist(h);
+  return flow_->populate_hist(hist);
+}
+
+void WalkerKremplSwitchRule::init_hist(History & hist) const
+{
+  return flow_->init_hist(hist);
 }
 
 void WalkerKremplSwitchRule::s(const double * const s, const double * const alpha,
@@ -1529,20 +1536,6 @@ State WrappedViscoPlasticFlowRule::make_state_(const double * const s, const dou
   return State(Symmetric(s), gather_hist_(alpha), T);
 }
 
-size_t WrappedViscoPlasticFlowRule::nhist() const
-{
-  return blank_hist_().size();
-}
-
-void WrappedViscoPlasticFlowRule::init_hist(double * const h) const
-{
-  // Pointless memory error
-  std::fill(h, h+nhist(), 0.0);
-  // Actual stuff
-  History hv = gather_hist_(h);
-  initialize_hist(hv);
-}
-
 // Rate rule
 void WrappedViscoPlasticFlowRule::y(const double* const s, const double* const alpha, double T,
               double & yv) const
@@ -1744,7 +1737,7 @@ void TestFlowRule::populate_hist(History & h) const
   h.add<double>("iso");
 }
 
-void TestFlowRule::initialize_hist(History & h) const
+void TestFlowRule::init_hist(History & h) const
 {
   h.get<double>("alpha") = 0.0;
   h.get<double>("iso") = s0_;
@@ -1891,7 +1884,7 @@ void WalkerFlowRule::populate_hist(History & h) const
   }
 }
 
-void WalkerFlowRule::initialize_hist(History & h) const
+void WalkerFlowRule::init_hist(History & h) const
 {
   h.get<double>("alpha") = 0;
   h.get<double>(R_->name()) = R_->initial_value();

--- a/src/walker_wrap.cxx
+++ b/src/walker_wrap.cxx
@@ -12,6 +12,7 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 namespace neml {
 PYBIND11_MODULE(walker, m) {
   py::module::import("neml.objects");
+  py::module::import("neml.history");
   py::module::import("neml.general_flow");
   py::module::import("neml.visco_flow");
 

--- a/src/walker_wrap.cxx
+++ b/src/walker_wrap.cxx
@@ -276,21 +276,6 @@ PYBIND11_MODULE(walker, m) {
   py::class_<WrappedViscoPlasticFlowRule, ViscoPlasticFlowRule,
       std::shared_ptr<WrappedViscoPlasticFlowRule>>(m,
                                                     "WrappedViscoPlasticFlowRule")
-    .def("populate_hist",
-         [](WrappedViscoPlasticFlowRule & m) -> History
-         {
-          History h;
-          m.populate_hist(h);
-          return h;
-         }, "Return a blank history")
-    .def("initialize_hist", 
-         [](WrappedViscoPlasticFlowRule & m) -> History
-         {
-          History h;
-          m.populate_hist(h);
-          m.initialize_hist(h);
-          return h;
-         }, "Initialize the history, including setting the initial conditions.")
     .def("y_wrap",
          [](WrappedViscoPlasticFlowRule & m, State & state) -> double
          {

--- a/src/walker_wrap.cxx
+++ b/src/walker_wrap.cxx
@@ -12,7 +12,6 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 namespace neml {
 PYBIND11_MODULE(walker, m) {
   py::module::import("neml.objects");
-  py::module::import("neml.history");
   py::module::import("neml.general_flow");
   py::module::import("neml.visco_flow");
 

--- a/src/walker_wrap.cxx
+++ b/src/walker_wrap.cxx
@@ -26,22 +26,9 @@ PYBIND11_MODULE(walker, m) {
                                                               "flow", "lambda",
                                                               "eps_ref"});
         }))
-      .def("kappa",
-           [](WalkerKremplSwitchRule & m, py::array_t<double,
-              py::array::c_style> eps, double T) -> double
-           {
-             double res;
-             m.kappa(arr2ptr<double>(eps), T, res);
-             return res;
-           }, "Rate sliding function")
-      .def("dkappa",
-           [](WalkerKremplSwitchRule & m, py::array_t<double,
-              py::array::c_style> eps, double T) -> py::array_t<double>
-           {
-            auto f = alloc_vec<double>(6);
-            m.dkappa(arr2ptr<double>(eps), T, arr2ptr<double>(f));
-            return f;
-           }, "Derivative of the kappa function wrt strain rate.")
+      .def("kappa", &WalkerKremplSwitchRule::kappa, "Rate scaling function")
+      .def("dkappa", &WalkerKremplSwitchRule::dkappa, 
+           "Derivative of the kappa function wrt strain rate.")
       ;
 
   py::class_<SofteningModel, NEMLObject, std::shared_ptr<SofteningModel>>(m,

--- a/test/nicediff.py
+++ b/test/nicediff.py
@@ -27,10 +27,10 @@ def diff_skew_history(fn, h0):
 
   return differentiate_new(dfn, vec)
 
-def diff_symmetric_symmetric(fn, s0):
+def diff_symmetric_symmetric(fn, s0, eps = 1e-6):
   dfn = lambda s: fn(tensors.Symmetric(usym(s))).data
 
-  return tensors.SymSymR4(differentiate_new(dfn, s0.data))
+  return tensors.SymSymR4(differentiate_new(dfn, s0.data, eps = eps))
 
 def diff_symmetric_skew(fn, w0):
   dfn = lambda w: fn(tensors.Skew(uskew(w))).data

--- a/test/test_crystaldamage.py
+++ b/test/test_crystaldamage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from neml import history, interpolate
+from neml import interpolate
 from neml.math import tensors, rotations, matrix, projections
 from neml.cp import crystallography, sliprules, crystaldamage, slipharden
 
@@ -94,8 +94,8 @@ class TestPlanarDamageModel(unittest.TestCase, CommonCrystalDamageModel):
         self.nfunc, self.L)
 
     self.huse = history.History()
-    self.hmodel.populate_history(self.huse)
-    self.model.populate_history(self.huse)
+    self.hmodel.populate_hist(self.huse)
+    self.model.populate_hist(self.huse)
 
     for i in range(12):
       self.huse.set_scalar("strength"+str(i), 2.0)
@@ -162,8 +162,8 @@ class TestNilDamageModel(unittest.TestCase, CommonCrystalDamageModel):
     self.model = crystaldamage.NilDamageModel()
 
     self.huse = history.History()
-    self.hmodel.populate_history(self.huse)
-    self.model.populate_history(self.huse)
+    self.hmodel.populate_hist(self.huse)
+    self.model.populate_hist(self.huse)
 
     for i in range(12):
       self.huse.set_scalar("strength"+str(i), 25.0)
@@ -177,10 +177,10 @@ class TestNilDamageModel(unittest.TestCase, CommonCrystalDamageModel):
 
   def test_hist(self):
     test = history.History()
-    self.model.populate_history(test)
+    self.model.populate_hist(test)
     self.assertEqual(test.size, 1)
     self.assertEqual(test.items, ["whatever"])
-    self.model.init_history(test)
+    self.model.init_hist(test)
     self.assertAlmostEqual(test.get_scalar("whatever"), 0.0)
 
   def test_projection(self):

--- a/test/test_damage.py
+++ b/test/test_damage.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('..')
 
-from neml import interpolate, solvers, models, elasticity, ri_flow, hardening, surfaces, visco_flow, general_flow, creep, damage, larsonmiller
+from neml import interpolate, solvers, models, elasticity, ri_flow, hardening, surfaces, visco_flow, general_flow, creep, damage, larsonmiller, history
 from common import *
 
 import unittest
@@ -76,7 +76,10 @@ class CommonScalarDamageModel(object):
     self.assertEqual(self.model.ndamage, 1)
 
   def test_init_damage(self):
-    self.assertTrue(np.allclose(self.model.init_damage(), np.zeros((1,))))
+    h = history.History()
+    self.model.populate_damage(h)
+    self.model.init_damage(h)
+    self.assertTrue(np.allclose(h, np.zeros((1,))))
 
   def test_ddamage_ddamage(self):
     dd_model = self.dmodel.ddamage_dd(self.d_np1, self.d_n, self.e_np1, self.e_n,
@@ -158,13 +161,6 @@ class CommonScalarDamageModel(object):
 class CommonDamagedModel(object):
   def test_nstore(self):
     self.assertEqual(self.model.nstore, self.bmodel.nstore + self.model.ndamage)
-
-  def test_store(self):
-    base = self.bmodel.init_store()
-    damg = self.model.init_damage()
-    comp = list(damg) + list(base)
-    fromm = self.model.init_store()
-    self.assertTrue(np.allclose(fromm, comp))
   
   def test_tangent_proportional_strain(self):
     t_n = 0.0

--- a/test/test_elastic_switch.py
+++ b/test/test_elastic_switch.py
@@ -39,7 +39,7 @@ class TestSimpleMaterials(unittest.TestCase):
     self.are_equal(self.elastic2, model.elastic)
 
   def test_ri_plasticity(self):
-    surface = surfaces.IsoJ2()
+    surface = surfaces.IsoKinJ2()
     sy = 100.0
     K = 1000.0
     H = 500.0

--- a/test/test_general_flow.py
+++ b/test/test_general_flow.py
@@ -103,7 +103,7 @@ class CommonGeneralFlow(object):
 class CommonTVPFlow(object):
   def test_history(self):
     self.assertEqual(len(self.h_n), self.model.nhist)
-    self.assertTrue(np.allclose(self.h_n, self.model.init_hist()))
+    self.assertTrue(np.allclose(self.h_n, self.model.initial_history()))
 
   def test_srate(self):
     t_np1 = self.gen_t()

--- a/test/test_hardening.py
+++ b/test/test_hardening.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('..')
 
-from neml import hardening, interpolate, history
+from neml import hardening, interpolate
 import unittest
 
 from common import *

--- a/test/test_hardening.py
+++ b/test/test_hardening.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('..')
 
-from neml import hardening, interpolate
+from neml import hardening, interpolate, history
 import unittest
 
 from common import *
@@ -15,7 +15,7 @@ class CommonHardening(object):
   """
   def test_history(self):
     self.assertEqual(self.model.nhist, len(self.hist0))
-    self.assertTrue(np.allclose(self.model.init_hist(), self.hist0))
+    self.assertTrue(np.allclose(self.model.initial_history(), self.hist0))
 
   def test_gradient(self):
     dfn = lambda x: self.model.q(x, self.T)
@@ -175,7 +175,7 @@ class CommonNonAssociative(object):
   def test_history(self):
     self.assertEqual(self.model.nhist, len(self.hist0))
     self.assertEqual(self.model.ninter, self.conform)
-    self.assertTrue(np.allclose(self.model.init_hist(), self.hist0))
+    self.assertTrue(np.allclose(self.model.initial_history(), self.hist0))
 
   def gen_stress(self):
     s = np.array([-150,200,-50,80,-20,30])

--- a/test/test_hucocks.py
+++ b/test/test_hucocks.py
@@ -593,8 +593,8 @@ class TestHuCocksHardening(unittest.TestCase, CommonSlipHardening):
       Paranoid check on the history state, given this is a kinda complicated model
     """
     H1 = history.History()
-    self.model.populate_history(H1)
-    self.model.init_history(H1)
+    self.model.populate_hist(H1)
+    self.model.init_hist(H1)
 
     self.assertEqual(len(np.array(H1)), 12+3+3)
     

--- a/test/test_kinematics.py
+++ b/test/test_kinematics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from neml import history, interpolate, elasticity
+from neml import interpolate, elasticity
 from neml.math import tensors, rotations
 from neml.cp import crystallography, slipharden, sliprules, inelasticity, kinematics, crystaldamage
 

--- a/test/test_kinematics.py
+++ b/test/test_kinematics.py
@@ -204,12 +204,12 @@ class TestStandardKinematics(unittest.TestCase, CommonKinematics):
 
   def test_setup_history(self):
     H1 = history.History()
-    self.model.populate_history(H1)
-    self.model.init_history(H1)
+    self.model.populate_hist(H1)
+    self.model.init_hist(H1)
 
     H2 = history.History()
-    self.imodel.populate_history(H2)
-    self.imodel.init_history(H2)
+    self.imodel.populate_hist(H2)
+    self.imodel.init_hist(H2)
 
     self.assertTrue(np.allclose(np.array(H1), np.array(H2)))
 

--- a/test/test_ri_flow.py
+++ b/test/test_ri_flow.py
@@ -18,7 +18,7 @@ class CommonFlowRule(object):
 
   def test_history(self):
     self.assertEqual(self.model.nhist, len(self.hist0))
-    self.assertTrue(np.allclose(self.model.init_hist(), self.hist0))
+    self.assertTrue(np.allclose(self.model.initial_history(), self.hist0))
 
   def test_df_ds(self):
     stress = self.gen_stress()

--- a/test/test_slipharden.py
+++ b/test/test_slipharden.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from neml import history, interpolate
+from neml import interpolate
 from neml.math import tensors, rotations, matrix
 from neml.cp import crystallography, slipharden, sliprules
 
@@ -581,8 +581,8 @@ class TestVoceHardening(unittest.TestCase, CommonPlasticSlipHardening,
 
   def test_initialize_hist(self):
     H = history.History()
-    self.model.populate_history(H)
-    self.model.init_history(H)
+    self.model.populate_hist(H)
+    self.model.init_hist(H)
     self.assertTrue(np.isclose(H.get_scalar('strength'), 0.0))
 
   def test_static_strength(self):
@@ -644,8 +644,8 @@ class TestNyeVoceHardening(unittest.TestCase, CommonPlasticSlipHardening,
     
   def test_initialize_hist(self):
     H = history.History()
-    self.model.populate_history(H)
-    self.model.init_history(H)
+    self.model.populate_hist(H)
+    self.model.init_hist(H)
     self.assertTrue(np.isclose(H.get_scalar('strength'), 0.0))
 
   def test_static_strength(self):
@@ -701,8 +701,8 @@ class TestVoceHardeningMoveVar(unittest.TestCase, CommonPlasticSlipHardening,
 
   def test_initialize_hist(self):
     H = history.History()
-    self.model.populate_history(H)
-    self.model.init_history(H)
+    self.model.populate_hist(H)
+    self.model.init_hist(H)
     self.assertTrue(np.isclose(H.get_scalar(self.vname), 0.0))
 
   def test_static_strength(self):
@@ -770,8 +770,8 @@ class TestMultiVoceHardening(unittest.TestCase,
 
   def test_initialize_hist(self):
     H = history.History()
-    self.model.populate_history(H)
-    self.model.init_history(H)
+    self.model.populate_hist(H)
+    self.model.init_hist(H)
     self.assertTrue(np.isclose(H.get_scalar('strength0'), 0.0))
     self.assertTrue(np.isclose(H.get_scalar('strength1'), 0.0))
 
@@ -831,8 +831,8 @@ class TestLinearSlipHardening(unittest.TestCase, CommonPlasticSlipHardening,
     
   def test_initialize_hist(self):
     H = history.History()
-    self.model.populate_history(H)
-    self.model.init_history(H)
+    self.model.populate_hist(H)
+    self.model.init_hist(H)
     self.assertTrue(np.isclose(H.get_scalar('strength'), 0.0))
 
   def test_static_strength(self):

--- a/test/test_sliprules.py
+++ b/test/test_sliprules.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from neml import history, interpolate
+from neml import interpolate
 from neml.math import tensors, rotations, matrix
 from neml.cp import crystallography, slipharden, sliprules
 
@@ -43,14 +43,14 @@ class CommonSlipRule(object):
 class CommonSlipMultiStrengthSlipRule(object):
   def test_setup_history(self):
     model_hist = history.History()
-    self.model.populate_history(model_hist)
-    self.model.init_history(model_hist)
+    self.model.populate_hist(model_hist)
+    self.model.init_hist(model_hist)
     
     manual_hist = history.History()
     for strength in self.strengths:
       Hs = history.History()
-      strength.populate_history(Hs)
-      strength.init_history(Hs)
+      strength.populate_hist(Hs)
+      strength.init_hist(Hs)
       manual_hist.add_union(Hs)
 
     self.assertTrue(np.allclose(np.array(model_hist),
@@ -194,8 +194,8 @@ class TestKinematicPowerLawSlipComplicated(unittest.TestCase, CommonSlipRule):
 
     self.model = sliprules.KinematicPowerLawSlipRule(self.backstrength, self.isostrength, self.flowresistance, self.g0, self.n)
 
-    self.model.populate_history(self.H)
-    self.model.init_history(self.H)
+    self.model.populate_hist(self.H)
+    self.model.init_hist(self.H)
 
     self.strength_values = np.linspace(0,10,36) + 5.0
     self.H.copy_data(self.strength_values)
@@ -205,12 +205,12 @@ class TestKinematicPowerLawSlipComplicated(unittest.TestCase, CommonSlipRule):
 class CommonSlipStrengthSlipRule(CommonSlipMultiStrengthSlipRule):
   def test_init_hist(self):
     H1 = history.History()
-    self.model.populate_history(H1)
-    self.model.init_history(H1)
+    self.model.populate_hist(H1)
+    self.model.init_hist(H1)
 
     H2 = history.History()
-    self.strengthmodel.populate_history(H2)
-    self.strengthmodel.init_history(H2)
+    self.strengthmodel.populate_hist(H2)
+    self.strengthmodel.init_hist(H2)
 
     self.assertTrue(np.allclose(np.array(H1),
       np.array(H2)))

--- a/test/test_visco_flow.py
+++ b/test/test_visco_flow.py
@@ -54,7 +54,7 @@ class CommonFlowRule(object):
 
   def test_history(self):
     self.assertEqual(self.model.nhist, len(self.hist0))
-    self.assertTrue(np.allclose(self.model.init_hist(), self.hist0))
+    self.assertTrue(np.allclose(self.model.initial_history(), self.hist0))
 
   def test_dy_ds(self):
     stress = self.gen_stress()

--- a/test/test_walker.py
+++ b/test/test_walker.py
@@ -938,7 +938,8 @@ class TestTestFlowRule(unittest.TestCase, CommonWrappedFlow, CommonFlowRule):
       [300.0,50.0,25.0],
       [50.0,150.0,-20.0],
       [25.0,-20.0,-100.0]])
-    self.h = self.model.populate_hist()
+    self.h = history.History()
+    self.model.populate_hist(self.h)
     self.h.set_scalar("alpha", 0.1)
     self.h.set_scalar("iso", 200.0)
     self.T = 300.0
@@ -957,12 +958,12 @@ class TestTestFlowRule(unittest.TestCase, CommonWrappedFlow, CommonFlowRule):
     self.assertEqual(self.model.nhist, 2)
 
   def test_setup_hist(self):
-    hobj = self.model.populate_hist()
+    hobj = self.model.initial_history()
     self.assertEqual(hobj.size, 2)
     self.assertTrue(hobj.items, ["alpha", "iso"])
 
   def test_initialize_hist(self):
-    h = self.model.initialize_hist()
+    h = self.model.initial_history()
     self.assertAlmostEqual(h.get_scalar("alpha"), 0.0)
     self.assertAlmostEqual(h.get_scalar("iso"), self.s0)
 
@@ -979,7 +980,8 @@ class TestTestFlowRule(unittest.TestCase, CommonWrappedFlow, CommonFlowRule):
     self.assertEqual(should, actual)
 
   def test_h(self):
-    should = self.model.populate_hist()
+    should = history.History()
+    self.model.populate_hist(should)
 
     should.set_scalar("alpha", 1.0)
     should.set_scalar("iso", self.K)
@@ -1110,8 +1112,9 @@ class TestWalkerFlowRule(unittest.TestCase, CommonWrappedFlow, CommonFlowRule):
       [12.0, 18.0,50.0]]).dev()
 
     self.X = self.X1 + self.X2
-
-    self.h = self.model.populate_hist()
+    
+    self.h = history.History()
+    self.model.populate_hist(self.h)
     self.h.set_scalar("alpha", self.a)
     self.h.set_scalar("R", self.R)
     self.h.set_scalar("D", self.D)
@@ -1141,12 +1144,13 @@ class TestWalkerFlowRule(unittest.TestCase, CommonWrappedFlow, CommonFlowRule):
     self.assertEqual(self.model.nhist, self.nhist)
 
   def test_setup_hist(self):
-    hobj = self.model.populate_hist()
+    hobj = history.History()
+    self.model.populate_hist(hobj)
     self.assertEqual(hobj.size, self.nhist)
     self.assertTrue(hobj.items, ["alpha", "R", "D", "X0", "X1"])
 
   def test_initialize_hist(self):
-    h = self.model.initialize_hist()
+    h = self.model.initial_history()
     self.assertAlmostEqual(h.get_scalar("alpha"), 0.0)
     self.assertAlmostEqual(h.get_scalar("R"), 0.0)
     self.assertAlmostEqual(h.get_scalar("D"), self.D_0)
@@ -1179,7 +1183,8 @@ class TestWalkerFlowRule(unittest.TestCase, CommonWrappedFlow, CommonFlowRule):
 
   def test_h(self):
     mval = self.model.h_wrap(self.state)
-    sval = self.model.populate_hist()
+    sval = history.History()
+    self.model.populate_hist(sval)
     
     # All this for alpha...
     xi = (self.D - self.D_0) / self.D_xi
@@ -1220,7 +1225,8 @@ class TestWalkerFlowRule(unittest.TestCase, CommonWrappedFlow, CommonFlowRule):
 
   def test_h_time(self):
     mval = self.model.h_time_wrap(self.state)
-    sval = self.model.populate_hist()
+    sval = history.History()
+    self.model.populate_hist(sval)
     
     # All this for alpha...
     xi = (self.D - self.D_0) / self.D_xi

--- a/util/abaqus/report.cxx
+++ b/util/abaqus/report.cxx
@@ -17,7 +17,7 @@ int main(int argc, char ** argv) {
 
   double * ihist = new double[n];
   
-  model->init_hist(ihist);
+  model->init_store(ihist);
 
   std::cout << std::endl;
   

--- a/util/cxx_interface/cxxsimple.cxx
+++ b/util/cxx_interface/cxxsimple.cxx
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
   double * h_n = new double [model->nstore()];
   double * h_np1 = new double [model->nstore()];
 
-  model->init_hist(h_n);
+  model->init_store(h_n);
 
   double e_n[6], e_np1[6], s_n[6], s_np1[6], A_np1[36];
   std::fill(e_n, e_n+6, 0.0);

--- a/util/string_interface/cxxstring.cxx
+++ b/util/string_interface/cxxstring.cxx
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
   double * h_n = new double [model->nstore()];
   double * h_np1 = new double [model->nstore()];
 
-  model->init_hist(h_n);
+  model->init_store(h_n);
 
   double e_n[6], e_np1[6], s_n[6], s_np1[6], A_np1[36];
   std::fill(e_n, e_n+6, 0.0);


### PR DESCRIPTION
To eventually be able to template on the scalar Real type a logical first step is to move everything over to using the History and Tensor objects, instead of raw `double *` data.  Even accomplishing this will have several steps:

- [x] Setup objects to name history using `History` but then convert to rawptr
- [x] Refactor to provide `HasHistory` type mixin
- [x] Eliminate the difference between `store` and `history`
- [x] Move top level objects over to tensor interface and then convert back to rawptr for lower level
- [x] Move down the chain, converting objects over to tensor objects as you go
- [ ] Code cleanup and consolidation