### PR TITLE
Add composite flow rule

### DIFF
--- a/doc/sphinx/vp_flow.rst
+++ b/doc/sphinx/vp_flow.rst
@@ -33,6 +33,7 @@ Implementations
 ---------------
 .. toctree::
    
+   vp_flow/superimposed
    vp_flow/perzyna
    vp_flow/chaboche
    vp_flow/yaguchi

--- a/doc/sphinx/vp_flow/superimposed.rst
+++ b/doc/sphinx/vp_flow/superimposed.rst
@@ -1,0 +1,38 @@
+Superimposed viscoplastic flow rule
+===================================
+
+Overview
+--------
+
+This model sums the contribution of multiple individual viscoplastic hardening
+rules according to the relations:
+
+.. math::
+
+   \dot{\gamma} = \sum_{i=1}^{n_{models}} \dot{\gamma}_i
+
+   \mathbf{g}_{...} = \frac{1}{\dot{\gamma}} \sum_{i=1}^{n_{models}} \dot{\gamma}_i
+      \mathbf{g}_{...,i}
+
+   \mathbf{h}_{...} = \bigoplus_{i=1}^{n_{models}} \mathbf{h}_{...,i}
+
+where :math:`...` here is all of :math:`\gamma`, :math:`t`, and :math:`T` and
+:math:`\oplus` represents concatenation.  The internal variables is then
+the set of all variables maintained by each individual flow rule (and these
+variables cannot overlap).
+
+Parameters
+----------
+
+.. csv-table::
+   :header: "Parameter", "Object type", "Description", "Default"
+   :widths: 12, 30, 50, 8
+
+   ``flow_rules``, :code:`std::vector<`:cpp:class:`neml::ViscoplasticFlowRule`:code:`>`, List of individual flow rules, No
+
+Class description
+-----------------
+
+.. doxygenclass:: neml::SuperimposedViscoPlasticFlowRule
+   :members:
+   :undoc-members:

--- a/include/visco_flow.h
+++ b/include/visco_flow.h
@@ -98,6 +98,109 @@ class NEML_EXPORT ViscoPlasticFlowRule: public NEMLObject {
   virtual void override_guess(double * const guess);
 };
 
+/// Superimpose multiple flow rules into a composite model
+class NEML_EXPORT SuperimposedViscoPlasticFlowRule : public ViscoPlasticFlowRule
+{
+ public:
+  SuperimposedViscoPlasticFlowRule(ParameterSet & params);
+
+  /// String type for the object system
+  static std::string type();
+  /// Default parameters
+  static std::unique_ptr<NEMLObject> initialize(ParameterSet & params);
+  /// Initialize from parameters
+  static ParameterSet parameters();
+
+  /// Number of individual models being summed
+  size_t nmodels() const;
+
+  /// Number of history variables
+  virtual size_t nhist() const;
+  /// Initialize history at time zero
+  virtual void init_hist(double * const h) const;
+
+  /// Scalar flow rate
+  virtual void y(const double* const s, const double* const alpha, double T,
+                double & yv) const;
+  /// Derivative of scalar flow wrt stress
+  virtual void dy_ds(const double* const s, const double* const alpha, double T,
+                double * const dyv) const;
+  /// Derivative of scalar flow wrt history
+  virtual void dy_da(const double* const s, const double* const alpha, double T,
+                double * const dyv) const;
+
+  /// Contribution towards the flow proportional to the scalar inelastic
+  /// strain rate
+  virtual void g(const double * const s, const double * const alpha, double T,
+                double * const gv) const;
+  /// Derivative of g wrt stress
+  virtual void dg_ds(const double * const s, const double * const alpha, double T,
+                double * const dgv) const;
+  /// Derivative of g wrt history
+  virtual void dg_da(const double * const s, const double * const alpha, double T,
+               double * const dgv) const;
+
+  /// Contribution towards the flow proportional directly to time
+  virtual void g_time(const double * const s, const double * const alpha, double T,
+                double * const gv) const;
+  /// Derivative of g_time wrt stress
+  virtual void dg_ds_time(const double * const s, const double * const alpha, double T,
+                double * const dgv) const;
+  /// Derivative of g_time wrt history
+  virtual void dg_da_time(const double * const s, const double * const alpha, double T,
+               double * const dgv) const;
+
+  /// Contribution towards the flow proportional to the temperature rate
+  virtual void g_temp(const double * const s, const double * const alpha, double T,
+                double * const gv) const;
+  /// Derivative of g_temp wrt stress
+  virtual void dg_ds_temp(const double * const s, const double * const alpha, double T,
+                double * const dgv) const;
+  /// Derivative of g_temp wrt history
+  virtual void dg_da_temp(const double * const s, const double * const alpha, double T,
+               double * const dgv) const;
+
+  /// Hardening rate proportional to the scalar inelastic strain rate
+  virtual void h(const double * const s, const double * const alpha, double T,
+                double * const hv) const;
+  /// Derivative of h wrt stress
+  virtual void dh_ds(const double * const s, const double * const alpha, double T,
+                double * const dhv) const;
+  /// Derivative of h wrt history
+  virtual void dh_da(const double * const s, const double * const alpha, double T,
+                double * const dhv) const;
+
+  /// Hardening rate proportional directly to time
+  virtual void h_time(const double * const s, const double * const alpha, double T,
+                double * const hv) const;
+  /// Derivative of h_time wrt stress
+  virtual void dh_ds_time(const double * const s, const double * const alpha, double T,
+                double * const dhv) const;
+  /// Derivative of h_time wrt history
+  virtual void dh_da_time(const double * const s, const double * const alpha, double T,
+                double * const dhv) const;
+
+  /// Hardening rate proportional to the temperature rate
+  virtual void h_temp(const double * const s, const double * const alpha, double T,
+                double * const hv) const;
+  /// Derivative of h_temp wrt. stress
+  virtual void dh_ds_temp(const double * const s, const double * const alpha, double T,
+                double * const dhv) const;
+  /// Derivative of h_temp wrt history
+  virtual void dh_da_temp(const double * const s, const double * const alpha, double T,
+                double * const dhv) const;
+
+ protected:
+  double * model_history_(double * const h, size_t i) const;
+  const double * model_history_(const double * const h, size_t i) const;
+
+ protected:
+  std::vector<std::shared_ptr<ViscoPlasticFlowRule>> rules_;
+  std::vector<size_t> offsets_;
+};
+
+static Register<SuperimposedViscoPlasticFlowRule> regSuperimposedViscoPlasticFlowRule;
+
 /// The "g" function in the Perzyna model -- often a power law
 class NEML_EXPORT GFlow: public NEMLObject {
  public:

--- a/src/visco_flow_wrap.cxx
+++ b/src/visco_flow_wrap.cxx
@@ -180,6 +180,13 @@ PYBIND11_MODULE(visco_flow, m) {
 
       ;
 
+  py::class_<SuperimposedViscoPlasticFlowRule, ViscoPlasticFlowRule, std::shared_ptr<SuperimposedViscoPlasticFlowRule>>(m, "SuperimposedViscoPlasticFlowRule")
+    .def(py::init([](py::args args, py::kwargs kwargs)
+      {
+        return create_object_python<SuperimposedViscoPlasticFlowRule>(args, kwargs, {"flow_rules"});
+      }))
+      ;
+
   py::class_<GFlow, NEMLObject, std::shared_ptr<GFlow>>(m, "GFlow")
       .def("g", &GFlow::g, "g function in Perzyna model")
       .def("dg", &GFlow::dg, "Derivative of g wrt f")

--- a/test/test_visco_flow.py
+++ b/test/test_visco_flow.py
@@ -84,9 +84,6 @@ class CommonFlowRule(object):
     num = differentiate(dfn, stress)
     exact = self.model.dg_ds(stress, hist, self.T)
     
-    print(num)
-    print(exact)
-
     self.assertTrue(np.allclose(num, exact, rtol = 1.0e-3))
 
   def test_dg_da(self):


### PR DESCRIPTION
Add a viscoplastic flow rule that sums the contributions of multiple individual flow rules.

Scalar flow rates are summed, flow directions are weighted by the flow rates and summed, and the sets of internal variables are combined together.