### PR TITLE
Switch to nose2

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,8 +11,8 @@ jobs:
                   CIBW_BEFORE_BUILD: "cmake -DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=OFF . && cmake --build . && rm CMakeCache.txt && rm -rf CMakeFiles && pip install -r requirements.txt"
                   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
                   CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-                  CIBW_TEST_REQUIRES: nose 
-                  CIBW_TEST_COMMAND: nosetests {project}/test
+                  CIBW_TEST_REQUIRES: nose2
+                  CIBW_TEST_COMMAND: nose2 --output-buffer {project}/test
                   CIBW_REPAIR_WHEEL_COMMAND_LINUX: "LD_LIBRARY_PATH=$(pwd)/lib:$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} {wheel}"
                   CIBW_REPAIR_WHEEL_COMMAND_MACOS: "DYLD_LIBRARY_PATH=$(pwd)/lib:$DYLD_LIBRARY_PATH delocate-listdeps {wheel} && DYLD_LIBRARY_PATH=$(pwd)/lib:$DYLD_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
                   CIBW_BUILD_VERBOSITY: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
               with:
                     submodules: recursive
             - run: sudo apt update
-            - run: sudo apt install build-essential cmake libblas-dev liblapack-dev python3-dev python3-networkx python3-numpy python3-scipy python3-matplotlib python3-nose
+            - run: sudo apt install build-essential cmake libblas-dev liblapack-dev python3-dev python3-networkx python3-numpy python3-scipy python3-matplotlib python3-nose2
             - run: cmake -D CMAKE_BUILD_TYPE=${{ matrix.btype }} -D WRAP_PYTHON=ON .
             - run: make -j 2
-            - run: nosetests3 -v 
+            - run: nose2 --output-buffer
       test-base-linux:
             runs-on: ubuntu-latest
             strategy:
@@ -40,10 +40,10 @@ jobs:
                     submodules: recursive
             - run: brew update
             - run: brew install cmake openblas superlu python 1>/dev/null || true
-            - run: pip3 install --user networkx numpy scipy matplotlib nose
+            - run: pip3 install --user networkx numpy scipy matplotlib nose2
             - run: cmake -D CMAKE_BUILD_TYPE=${{ matrix.btype }} -D WRAP_PYTHON=ON -D PYTHON_EXECUTABLE=$(python3-config --prefix)/bin/python3.9 -D PYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython3.9.dylib -D PYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python3.9 -D USE_OPENMP=OFF .
             - run: make -j 2
-            - run: ~/Library/Python/3.9/bin/nosetests -v
+            - run: ~/Library/Python/3.9/bin/nose2 --output-buffer
       test-base-mac:
             runs-on: macos-latest
             strategy:
@@ -76,10 +76,10 @@ jobs:
                msystem: MINGW64
                update: true
                install: git mingw-w64-x86_64-toolchain base-devel mingw-w64-x86_64-openblas mingw-w64-x86_64-cmake mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-numpy mingw-w64-x86_64-python-scipy mingw-w64-x86_64-python-networkx mingw-w64-x86_64-python-matplotlib
-           - run: pip install nose
+           - run: pip install nose2
            - run: cmake . -G"MSYS Makefiles" -D"WRAP_PYTHON=ON" -D"CMAKE_BUILD_TYPE=${{ matrix.btype }}"
            - run: make -j 2
-           - run: nosetests -v
+           - run: nose2 --output-buffer
       test-base-windows:
            runs-on: windows-latest
            strategy:

--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -9,8 +9,8 @@ jobs:
                   CIBW_BEFORE_BUILD: "cmake -DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=OFF . && cmake --build . && rm CMakeCache.txt && rm -rf CMakeFiles && pip install -r requirements.txt"
                   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
                   CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-                  CIBW_TEST_REQUIRES: nose 
-                  CIBW_TEST_COMMAND: nosetests {project}/test
+                  CIBW_TEST_REQUIRES: nose2
+                  CIBW_TEST_COMMAND: nose2 --output-buffer {project}/test
                   CIBW_REPAIR_WHEEL_COMMAND_LINUX: "LD_LIBRARY_PATH=$(pwd)/lib:$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} {wheel}"
                   CIBW_REPAIR_WHEEL_COMMAND_MACOS: "DYLD_LIBRARY_PATH=$(pwd)/lib:$DYLD_LIBRARY_PATH delocate-listdeps {wheel} && DYLD_LIBRARY_PATH=$(pwd)/lib:$DYLD_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
                   CIBW_BUILD_VERBOSITY: 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 scipy
 matplotlib
 networkx
-nose
+nose2

--- a/setup.py
+++ b/setup.py
@@ -111,8 +111,8 @@ setup (
     # Get the python files
     packages=find_packages(),
     # Locate tests
-    test_suite='nose.collector',
-    tests_require=['nose'],
+    test_suite='nose2.collector.collector',
+    tests_require=['nose2'],
     # Python dependencies
     install_requires=[
       'numpy',


### PR DESCRIPTION
nose is apparently beyond end of life and python3.9 support is dropping off.  This PR switches the automated testing to use nose2.