### PR TITLE
Potential compiler fix for weird limits error

### DIFF
--- a/src/damage.cxx
+++ b/src/damage.cxx
@@ -2,6 +2,7 @@
 #include "elasticity.h"
 
 #include <cmath>
+#include <stdexcept>
 #include <limits>
 
 namespace neml {


### PR DESCRIPTION
Adds `stdexecpt` which some stack overflow randomness suggests is required...