### PR TITLE
Add tensors to the interface

### DIFF
--- a/include/neml_interface.h
+++ b/include/neml_interface.h
@@ -3,6 +3,7 @@
 
 #include "nemlerror.h"
 #include "models.h"
+#include "math/tensors.h"
 
 namespace neml {
 std::unique_ptr<NEMLModel> parse_xml_unique(std::string fname, std::string mname);


### PR DESCRIPTION
Turns out deer uses `Vector` and `Orientation` from the NEML API and we didn't include those in the public interface.  Linkers are getting too clever for their own good and not including the symbol.